### PR TITLE
Issue #1 - Enhance cv_facts module doc

### DIFF
--- a/library/cv_facts.py
+++ b/library/cv_facts.py
@@ -62,6 +62,45 @@ options:
     default: null
 """
 
+EXAMPLES="""
+# Collect Facts from CVP server
+# Register output into a variable
+- name: Test and validation for cv_facts module.
+  hosts: cvp
+  connection: local
+  gather_facts: no
+  tasks:
+    - name: "Gather CVP facts {{inventory_hostname}}"
+      cv_facts:
+        host: '{{ansible_host}}'
+        username: '{{cvp_username}}'
+        password: '{{cvp_password}}'
+        protocol: https
+      register: cv_facts
+    
+    - name: "Print out facts from CVP"
+      debug:
+        msg: "{{cv_facts}}"
+
+# Collect Facts from CVP server
+# Use pre-defined module output
+- name: Test and validation for cv_facts module.
+  hosts: cvp
+  connection: local
+  gather_facts: no
+  tasks:
+    - name: "Gather CVP facts {{inventory_hostname}}"
+      cv_facts:
+        host: '{{ansible_host}}'
+        username: '{{cvp_username}}'
+        password: '{{cvp_password}}'
+        protocol: https
+    
+    - name: "Print out facts from CVP"
+      debug:
+        msg: "{{ansible_facts}}"
+"""
+
 from ansible.module_utils.basic import AnsibleModule
 from cvprac.cvp_client import CvpClient
 from cvprac.cvp_client_errors import CvpLoginError, CvpApiError


### PR DESCRIPTION
Implement EXAMPLE block in cv_facts.

Now `ansible-doc cv_facts` provide module documentation and examples
about how to use it in a playbook.

```shell
(venv2.7-ansible2.8) tests|issue#01⚡ ⇒ ansible-doc cv_facts

> CV_FACTS    (ansible-cvp/library/cv_facts.py)

        Returns the list of devices, configlets, containers and images
[...]

EXAMPLES:

# Collect Facts from CVP server
# Register output into a variable
- name: Test and validation for cv_facts module.
  hosts: cvp
```