### PR TITLE
Issue #11 - cv_container to support intended definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,7 @@
 
 **cv_configlet**
 
- - `add`, `delete`, and `show` configlets.
-
-  Configlets can be created, deleted then added to containers or devices. - also in cv_devices as required to move devices between containers
-  Any Tasks that are generated as a result will be returned.
-  Need to add the option to check (CVP verify) the configuration contained in the Configlet
+  Module to manage containers on CVP based on an intend method. After extracting facts from CVP with `cv_facts`, module create and delete containers based on the topology defined within ansible.
 
 > A complete playbook to create / show / delete configlet is available under [tests folder](tests/playbook.configlet.demo.yaml) 
 
@@ -104,8 +100,13 @@ This example outlines how to use Ansible to create a device container on Arista 
   connection: local
   gather_facts: no
   vars:
-    - container_name: automated_container
-    - container_parent: Tenant
+    containers:
+      - name: Fabric
+        parent_container: Tenant
+      - name: Spines
+        parent_container: Fabric
+      - name: Leaves
+        parent_container: Fabric
   tasks:
     # collect CVP facts
     - name: "Gather CVP facts {{inventory_hostname}}"
@@ -120,33 +121,14 @@ This example outlines how to use Ansible to create a device container on Arista 
       debug:
         msg: "{{cv_facts}}"
     
-    # Create container under root container
+    # Create containers topology
     - name: Create a container on CVP.
       cv_container:
         host: '{{ansible_host}}'
         username: '{{cvp_username}}'
         password: '{{cvp_password}}'
-        protocol: https
-        container: "{{container_name}}"
-        parent: "{{container_parent}}"
-        action: add
-    
-    # Look for container deleted previously.
-    # If result contains, then we assume there is en error
-    - name: Show a container on CVP.
-      cv_container:
-        host: '{{ansible_host}}'
-        username: '{{cvp_username}}'
-        password: '{{cvp_password}}'
-        protocol: https
-        container: "{{container_name}}"
-        parent: "{{container_parent}}"
-        action: show
-      register: cvp_result
-
-    - name: Display cv_container show result
-      debug:
-        msg: "{{cvp_result}}"
+        topology: '{{containers}}'
+        cvp_facts: '{{cvp_facts.ansible_facts}}'
 ```
 
 

--- a/tests/playbook.container.demo.yaml
+++ b/tests/playbook.container.demo.yaml
@@ -1,66 +1,66 @@
 ---
-- name: Test cv_container
+- name: Build Topology.
   hosts: cvp
   connection: local
   gather_facts: no
   vars:
-    - container_name: automated_container
-    - container_parent: Tenant
+    verbose: False
+    containers:
+      - name: Fabric
+        parent_container: Tenant
+      - name: Spines
+        parent_container: Fabric
+      - name: Leaves
+        parent_container: Fabric
+      - name: f2
+        parent_container: Tenant
+      - name: s1
+        parent_container: f2
+      - name: s2
+        parent_container: f2
+      - name: l2
+        parent_container: s2
   tasks:
-    # Create container under root container
-    - name: Create a container on CVP.
-      cv_container:
+    - name: "Gather CVP facts {{inventory_hostname}}"
+      cv_facts:
         host: '{{ansible_host}}'
         username: '{{cvp_username}}'
         password: '{{cvp_password}}'
         protocol: https
-        container: "{{container_name}}"
-        parent: "{{container_parent}}"
-        action: add
-    
-    # Look for container deleted previously.
-    # If result contains, then we assume there is en error
-    - name: Show a container on CVP.
+      register: cvp_facts
+    - name: "Build Container topology on {{inventory_hostname}}"
       cv_container:
         host: '{{ansible_host}}'
         username: '{{cvp_username}}'
         password: '{{cvp_password}}'
-        protocol: https
-        container: "{{container_name}}"
-        parent: "{{container_parent}}"
-        action: show
-      register: cvp_result
-      failed_when: '"Not Found" in cvp_result.data.container'
+        topology: '{{containers}}'
+        cvp_facts: '{{cvp_facts.ansible_facts}}'
 
-    - name: Display cv_container show result
-      debug:
-        msg: "{{cvp_result}}"
-    
-    # Delete container created at previous stage.
-    - name: Delete a container on CVP.
-      cv_container:
+- name: Test container deletion
+  hosts: cvp
+  connection: local
+  gather_facts: no
+  vars:
+    verbose: False
+    containers:
+      - name: Fabric
+        parent_container: Tenant
+      - name: Spines
+        parent_container: Fabric
+      - name: Leaves
+        parent_container: Fabric
+  tasks:
+    - name: "Gather CVP facts {{inventory_hostname}}"
+      cv_facts:
         host: '{{ansible_host}}'
         username: '{{cvp_username}}'
         password: '{{cvp_password}}'
         protocol: https
-        container: "{{container_name}}"
-        parent: "{{container_parent}}"
-        action: delete
-
-    # Look for container deleted previously.
-    # If result does not contain, then we assume there is en error
-    - name: Show a container on CVP.
+      register: cvp_facts
+    - name: "Build Container topology on {{inventory_hostname}}"
       cv_container:
         host: '{{ansible_host}}'
         username: '{{cvp_username}}'
         password: '{{cvp_password}}'
-        protocol: https
-        container: "{{container_name}}"
-        parent: "{{container_parent}}"
-        action: show
-      register: cvp_result
-      failed_when: '"Not Found" not in cvp_result.data.container'
-    
-    - name: Display cv_container show result
-      debug:
-        msg: "{{cvp_result}}"
+        topology: '{{containers}}'
+        cvp_facts: '{{cvp_facts.ansible_facts}}'


### PR DESCRIPTION
Refactor cv_container to be intend based and support a containers topology provided by user.

Module compare topology to `cv_facts` content, create missing containers and remove containers not in topology and with no children nor devices.

Current data model can be extended later to support other `cv_*` modules

Short play example:
-------------------
```yaml
- name: Test cv_container
  hosts: cvp
  connection: local
  gather_facts: no
  vars:
    verbose: False
    containers:
      - name: Fabric
        parent_container: Tenant
      - name: Spines
        parent_container: Fabric
      - name: Leaves
        parent_container: Fabric
  tasks:
    - name: "Gather CVP facts {{inventory_hostname}}"
      cv_facts:
        host: '{{ansible_host}}'
        username: '{{cvp_username}}'
        password: '{{cvp_password}}'
        protocol: https
      register: cvp_facts
    - name: "Build Container topology on {{inventory_hostname}}"
      cv_container:
        host: '{{ansible_host}}'
        username: '{{cvp_username}}'
        password: '{{cvp_password}}'
        topology: '{{containers}}'
        cvp_facts: '{{cvp_facts.ansible_facts}}'
```