### PR TITLE
Fix #83: container information not consistent in cv_facts

### DIFF
--- a/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
@@ -182,9 +182,6 @@ def cv_facts(module):
         # Add applied Configlets
         container['configlets'] = []
         applied_configlets = module.client.api.get_configlets_by_container_id(container['key'])['configletList']
-        # FIXME: Issue #83 debug
-        # if container['name'] == 'MLAG01':
-        #     module.fail_json(msg=str(module.client.api.get_configlets_by_container_id(container['key'])))
         for configlet in applied_configlets:
             container['configlets'].append(configlet['name'])
         # Add applied Images

--- a/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
@@ -182,7 +182,10 @@ def cv_facts(module):
         # Add applied Configlets
         container['configlets'] = []
         applied_configlets = module.client.api.get_configlets_by_container_id(container['key'])['configletList']
-        for device in applied_devices:
+        # FIXME: Issue #83 debug
+        # if container['name'] == 'MLAG01':
+        #     module.fail_json(msg=str(module.client.api.get_configlets_by_container_id(container['key'])))
+        for configlet in applied_configlets:
             container['configlets'].append(configlet['name'])
         # Add applied Images
         container['imageBundle'] = ""


### PR DESCRIPTION
Fix an issue where cv_facts use wrong variable to fill in list of
attached configlets to a container.