### PR TITLE
Implement subset for cv_fact (#89)

### DIFF
--- a/ansible_collections/arista/cvp/README.md
+++ b/ansible_collections/arista/cvp/README.md
@@ -26,7 +26,7 @@ Support for this `arista.cvp` collection is provided by the community directly i
 
 ## Contributing
 
-Contributing pull requests are gladly welcomed for this repository. If you are planning a big change, please start a discussion first to make sure we’ll be able to merge it.
+Contributing pull requests are gladly welcomed for this repository. If you are planning a big change, please start a discussion first to make sure we'll be able to merge it.
 
 You can also open an [issue](https://github.com/aristanetworks/ansible-cvp/issues) to report any problem or to submit enhancement.
 

--- a/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
@@ -182,9 +182,6 @@ def cv_facts(module):
         # Add applied Configlets
         container['configlets'] = []
         applied_configlets = module.client.api.get_configlets_by_container_id(container['key'])['configletList']
-        # FIXME: Issue #83 debug
-        # if container['name'] == 'MLAG01':
-        #     module.fail_json(msg=str(module.client.api.get_configlets_by_container_id(container['key'])))
         for configlet in applied_configlets:
             container['configlets'].append(configlet['name'])
         # Add applied Images

--- a/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
@@ -41,15 +41,36 @@ author: EMEA AS Team (@aristanetworks)
 short_description: Collect facts from CloudVision Portal.
 description:
   - Returns the list of devices, configlets, containers and images
+options:
+  gather_subset:
+    description:
+      - When supplied, this argument will restrict the facts collected
+      - to a given subset.  Possible values for this argument include
+      - all, hardware, config, and interfaces.  Can specify a list of
+      - values to include a larger subset.  Values can also be used
+      - with an initial C(M(!)) to specify that a specific subset should
+      - not be collected.
+    required: false
+    default: ['default']
+    type: list
+    choices:
+      - default
+      - config
 '''
 
 EXAMPLES = r'''
 ---
-    # Collect CVP Facts as init process
+# Collect CVP Facts as init process without devices configuration
 - name: "Gather CVP facts from {{inventory_hostname}}"
   arista.cvp.cv_facts:
   register: cvp_facts
 
+# Collect CVP facts with devices configuration
+- name: "Gather CVP facts from {{inventory_hostname}}"
+  arista.cvp.cv_facts:
+    gather_subset:
+      config
+  register: cvp_facts
 '''
 
 
@@ -106,8 +127,8 @@ def cv_facts(module):
 
     # Work through Devices list adding device specific information
     for device in facts['devices']:
-        # Add designed config for device
-        if device['streamingStatus'] == "active":
+        # Add designed config for streaming devices (#61) only and if gather_subset is set to config (#89)
+        if 'config' in module.params['gather_subset'] and device['streamingStatus'] == "active":
             device['config'] = module.client.api.get_device_configuration(device['key'])
         # Add parent container name
         container = module.client.api.get_container_by_id(device['parentContainerKey'])
@@ -228,7 +249,12 @@ def cv_facts(module):
 def main():
     """ main entry point for module execution
     """
-    argument_spec = dict()
+    argument_spec = dict(
+        gather_subset=dict(type='list',
+                           elements='str',
+                           required=False,
+                           choices=['default', 'config'],
+                           default='default'))
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
 

--- a/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
@@ -182,7 +182,10 @@ def cv_facts(module):
         # Add applied Configlets
         container['configlets'] = []
         applied_configlets = module.client.api.get_configlets_by_container_id(container['key'])['configletList']
-        for device in applied_devices:
+        # FIXME: Issue #83 debug
+        # if container['name'] == 'MLAG01':
+        #     module.fail_json(msg=str(module.client.api.get_configlets_by_container_id(container['key'])))
+        for configlet in applied_configlets:
             container['configlets'].append(configlet['name'])
         # Add applied Images
         container['imageBundle'] = ""

--- a/ansible_collections/arista/cvp/tests/issue-89.yml
+++ b/ansible_collections/arista/cvp/tests/issue-89.yml
@@ -1,0 +1,50 @@
+---
+- name: Build Testing topology using Dev CVP servers
+  hosts: cvp
+  connection: local
+  gather_facts: no
+  vars:
+    - quiet: True
+  ### Configuration tasks
+  tasks:
+    - name: '#01 - Collect initial facts with default config from {{inventory_hostname}}'
+      cv_facts:
+      register: FACTS
+
+    - name: "#03 - Check if config key does not exists in devices"
+      assert:
+        that:
+          - "'config' not in item"
+        fail_msg: 'Config has been found in facts'
+        success_msg: "Configuration is absent from facts"
+        quiet: '{{quiet}}'
+      with_items:
+        - '{{FACTS.ansible_facts.devices}}'
+      # ignore_errors: yes
+
+    # - name: '#04 - Save FACTS to issue89.log'
+    #   copy: 
+    #     content: '{{ FACTS }}' 
+    #     dest: 'issue89.default.log'
+
+    - name: '#05 - Collect initial facts with gather_subset config from {{inventory_hostname}}'
+      cv_facts:
+        gather_subset:
+          config
+      register: FACTS
+
+    - name: "#07 - Check if config key does not exists in devices"
+      assert:
+        that:
+          - "'config' in item"
+        success_msg: "Config has been found in facts"
+        fail_msg: "Configuration is absent from facts"
+        quiet: '{{quiet}}'
+      with_items:
+        - ' {{FACTS.ansible_facts.devices}} '
+    #   ignore_errors: yes
+
+    # - name: '#08 - Save FACTS to issue89.config.log'
+    #   copy: 
+    #     content: '{{ FACTS }}' 
+    #     dest: 'issue89.config.log'


### PR DESCRIPTION
Implement subset option in cv-fact to enable eos device configuration
extraction.

Configuration:
--------------

```yaml

    - name: 'Collect initial facts with default config from {{inventory_hostname}}'
      cv_facts:
      register: FACTS

    - name: 'Collect initial facts with gather_subset config from {{inventory_hostname}}'
      cv_facts:
        gather_subset:
          config
      register: FACTS
```

Validation playbook:
--------------------
`ansible_collections/arista/cvp/tests/issue-89.yml`