### PR TITLE
Implement state=absent for cv_configlet

### DIFF
--- a/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
@@ -85,6 +85,14 @@ options:
     required: false
     default: ['none']
     type: list
+  state:
+    description: 
+        - If absent, configlets will be removed from CVP if they are not binded
+        - to either a container or a device.
+        - If present, configlets will be created or updated.
+    required: false
+    default: 'present'
+    type: string
 '''
 
 EXAMPLES = r'''
@@ -189,13 +197,16 @@ def configlet_action(module):
             if re.search(r"\ball\b", str(module.params['configlet_filter'])) or (
                any(element in configlet['name'] for element in module.params['configlet_filter'])):
                 if configlet['name'] in module.params['configlets']:
-                    ansible_configlet = module.params['configlets'][configlet['name']]
-                    configlet_compare = compare(configlet['config'], ansible_configlet)
-                    # compare function returns a floating point number
-                    if configlet_compare[0] == 100.0:
-                        keep_configlet.append(configlet)
-                    else:
-                        update_configlet.append({'data': configlet, 'config': ansible_configlet})
+                    if module.params['state'] == 'present':
+                        ansible_configlet = module.params['configlets'][configlet['name']]
+                        configlet_compare = compare(configlet['config'], ansible_configlet)
+                        # compare function returns a floating point number
+                        if configlet_compare[0] == 100.0:
+                            keep_configlet.append(configlet)
+                        else:
+                            update_configlet.append({'data': configlet, 'config': ansible_configlet})
+                    elif module.params['state'] == 'absent':
+                        delete_configlet.append(configlet)
                 else:
                     delete_configlet.append(configlet)
     # Look for new configlets, if a configlet is not CVP assume it is to be created
@@ -301,12 +312,15 @@ def main():
     argument_spec = dict(
         configlets=dict(type='dict', required=True),
         cvp_facts=dict(type='dict', required=True),
-        configlet_filter=dict(type='list', default='none'))
+        configlet_filter=dict(type='list', default='none'),
+        state=dict(type='str',
+                   choices=['present', 'absent'],
+                   default='present',
+                   required=False))
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
-    # if not HAS_FUZZYWUZZY:
-    #     module.fail_json(msg='fuzzywuzzy required for this module')
+
     if not HAS_DIFFLIB:
         module.fail_json(msg='difflib required for this module')
 

--- a/ansible_collections/arista/cvp/tests/issue-27.yml
+++ b/ansible_collections/arista/cvp/tests/issue-27.yml
@@ -1,0 +1,65 @@
+---
+- name: 'Test Issue #27 - state option'
+  hosts: cvp
+  connection: local
+  gather_facts: no
+  collections:
+    - arista.cvp
+  vars:
+    configlet_list:
+      ISSUE27_01: 'alias a{{ 999 | random }} show version'
+  tasks:
+    - name: '#01 - Collecting facts from CVP {{inventory_hostname}}.'
+      cv_facts:
+      register: FACTS
+
+    - name: '#02 - Create configlets on CVP {{inventory_hostname}}.'
+      cv_configlet:
+        cvp_facts: "{{FACTS.ansible_facts}}"
+        configlets: "{{configlet_list}}"
+        configlet_filter: ["ISSUE27"]
+      register: CONFIGLET
+
+    - name: '#03 - CVP configlets status on {{inventory_hostname}}'
+      debug:
+        var: CONFIGLET
+
+    - name: '#04 - Collecting facts from CVP {{inventory_hostname}}.'
+      cv_facts:
+      register: FACTS
+
+    - name: "#05 - Check if ISSUE27_01 configlet exists"
+      assert:
+        that:
+          - "FACTS.ansible_facts['configlets'] | selectattr(search_key,'equalto',search_val) | list | count > 0"
+        fail_msg: "ISSUE27_01 has not been found in facts"
+        success_msg: "ISSUE27_01 has been found as expected"
+      vars:
+        search_key: name
+        search_val: ISSUE27_01
+
+    - name: '#06 - Delete configlets on CVP {{inventory_hostname}}.'
+      cv_configlet:
+        cvp_facts: "{{FACTS.ansible_facts}}"
+        configlets: "{{configlet_list}}"
+        configlet_filter: ["ISSUE27"]
+        state: absent
+      register: CONFIGLET
+
+    - name: '#07 - CVP configlets status on {{inventory_hostname}}'
+      debug:
+        var: CONFIGLET
+
+    - name: '#08 - Collecting facts from CVP {{inventory_hostname}}.'
+      cv_facts:
+      register: FACTS
+
+    - name: "#09 - Check if ISSUE27_01 configlet has been deleted"
+      assert:
+        that:
+          - "FACTS.ansible_facts['configlets'] | selectattr(search_key,'equalto',search_val) | list | count < 1"
+        fail_msg: "ISSUE27_01 has been found in facts"
+        success_msg: "ISSUE27_01 has not been found as expected"
+      vars:
+        search_key: name
+        search_val: ISSUE27_01


### PR DESCRIPTION
Implement state=absent for cv_configlet. If configured, then configlets
not attached to devices nor containers are removed from CVP.

__Configuration__

```yaml
    - name: '#06 - Delete configlets on CVP {{inventory_hostname}}.'
      cv_configlet:
        cvp_facts: "{{FACTS.ansible_facts}}"
        configlets: "{{configlet_list}}"
        configlet_filter: ["ISSUE27"]
        state: absent

```

__Output example:__

```
ok: [cvp_2018] => {
    "CONFIGLET": {
        "changed": true,
        "data": {
            "deleted": [
                {
                    "ISSUE27_01": "success"
                }
            ],
            "new": [],
            "tasks": [],
            "updated": []
        },
        "failed": false
    }
}

```

__Validation Playbook__

`ansible_collections/arista/cvp/tests/issue-27.yml`