### PR TITLE
Improve cv_facts as per #95

### DIFF
--- a/ansible_collections/arista/cvp/README.md
+++ b/ansible_collections/arista/cvp/README.md
@@ -26,7 +26,7 @@ Support for this `arista.cvp` collection is provided by the community directly i
 
 ## Contributing
 
-Contributing pull requests are gladly welcomed for this repository. If you are planning a big change, please start a discussion first to make sure we’ll be able to merge it.
+Contributing pull requests are gladly welcomed for this repository. If you are planning a big change, please start a discussion first to make sure we'll be able to merge it.
 
 You can also open an [issue](https://github.com/aristanetworks/ansible-cvp/issues) to report any problem or to submit enhancement.
 

--- a/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
@@ -36,7 +36,7 @@ from ansible_collections.arista.cvp.plugins.module_utils.cv_client_errors import
 
 DOCUMENTATION = r'''
 ---
-module: cv_facts_v2
+module: cv_facts
 version_added: "2.9"
 author: EMEA AS Team (@aristanetworks)
 short_description: Collect facts from CloudVision Portal.
@@ -80,13 +80,13 @@ EXAMPLES = r'''
 ---
   tasks:
     - name: '#01 - Collect devices facts from {{inventory_hostname}}'
-      cv_facts_v2:
+      cv_facts:
         facts:
           devices
       register: FACTS_DEVICES
 
     - name: '#02 - Collect devices facts (with config) from {{inventory_hostname}}'
-      cv_facts_v2:
+      cv_facts:
         gather_subset:
           config
         facts:
@@ -94,22 +94,21 @@ EXAMPLES = r'''
       register: FACTS_DEVICES_CONFIG
 
     - name: '#03 - Collect confilgets facts from {{inventory_hostname}}'
-      cv_facts_v2:
+      cv_facts:
         facts:
           configlets
       register: FACTS_CONFIGLETS
 
     - name: '#04 - Collect containers facts from {{inventory_hostname}}'
-      cv_facts_v2:
+      cv_facts:
         facts:
           containers
       register: FACTS_CONTAINERS
 
     - name: '#10 - Collect ALL facts from {{inventory_hostname}}'
-      cv_facts_v2:
+      cv_facts:
       register: FACTS
 '''
-
 
 
 def connect(module, debug=False):
@@ -386,7 +385,6 @@ def facts_builder(module, debug=False):
             logging.debug('** Collecting facts facts ...')
         facts = facts_tasks(module=module, facts=facts, debug=debug)
 
-
     # End of Facts module
     if debug:
         logging.debug('** All facts done')
@@ -394,7 +392,7 @@ def facts_builder(module, debug=False):
 
 
 def main():
-    """ 
+    """
     main entry point for module execution.
     """
     debug_module = True
@@ -419,8 +417,7 @@ def main():
                             'configlets',
                             'containers',
                             'devices',
-                            'tasks',
-                            'images'],
+                            'tasks'],
                    default='all'))
 
     module = AnsibleModule(argument_spec=argument_spec,

--- a/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
@@ -395,7 +395,7 @@ def main():
     """
     main entry point for module execution.
     """
-    debug_module = True
+    debug_module = False
     if debug_module:
         logging.basicConfig(format='%(asctime)s %(message)s',
                             filename='cv_fact_v2.log', level=logging.DEBUG)

--- a/ansible_collections/arista/cvp/plugins/modules/cv_facts_v1.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_facts_v1.py
@@ -1,0 +1,278 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+#
+# FIXME: required to pass ansible-test
+# GNU General Public License v3.0+
+#
+# Copyright 2019 Arista Networks AS-EMEA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.0',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+import logging
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection, ConnectionError
+from ansible_collections.arista.cvp.plugins.module_utils.cv_client import CvpClient
+from ansible_collections.arista.cvp.plugins.module_utils.cv_client_errors import CvpLoginError, CvpApiError
+
+DOCUMENTATION = r'''
+---
+module: cv_facts
+version_added: "2.9"
+author: EMEA AS Team (@aristanetworks)
+short_description: Collect facts from CloudVision Portal.
+description:
+  - Returns the list of devices, configlets, containers and images
+'''
+
+EXAMPLES = r'''
+---
+    # Collect CVP Facts as init process
+- name: "Gather CVP facts from {{inventory_hostname}}"
+  arista.cvp.cv_facts:
+  register: cvp_facts
+
+'''
+
+
+def connect(module):
+    ''' Connects to CVP device using user provided credentials from playbook.
+    :param module: Ansible module with parameters and client connection.
+    :return: CvpClient object with connection instantiated.
+    '''
+    client = CvpClient()
+    connection = Connection(module._socket_path)
+    host = connection.get_option("host")
+    port = connection.get_option("port")
+    user = connection.get_option("remote_user")
+    pswd = connection.get_option("password")
+    try:
+        client.connect([host],
+                       user,
+                       pswd,
+                       protocol="https",
+                       port=port,
+                       )
+    except CvpLoginError as e:
+        module.fail_json(msg=str(e))
+    return client
+
+
+def cv_facts(module):
+    ''' Connects to CVP device using user provided credentials from module.
+    :param module: Ansible module with parameters and client connection.
+    :return: CvpClient object with connection instantiated.
+    '''
+    facts = {}
+    # Get version data for CVP
+    facts['cvp_info'] = module.client.api.get_cvp_info()
+
+    # Build required data for devices in CVP - Device Data, Config, Associated Container,
+    # Associated Images, and Associated Configlets
+    deviceField = {'hostname': 'name', 'fqdn': 'fqdn', 'complianceCode': 'complianceCode',
+                   'complianceIndication': 'complianceIndication', 'version': 'version',
+                   'ipAddress': 'ipAddress', 'systemMacAddress': 'key',
+                   'parentContainerKey': 'parentContainerKey',
+                   'streamingStatus': 'streamingStatus'}
+    facts['devices'] = []
+
+    # Get Inventory Data for All Devices
+    inventory = module.client.api.get_inventory()
+    # Reduce device data to required fields
+    logging.debug('-> L100 - Reading inventory')
+    for device in inventory:
+        deviceFacts = {}
+        for field in device.keys():
+            if field in deviceField:
+                deviceFacts[deviceField[field]] = device[field]
+        facts['devices'].append(deviceFacts)
+
+    # Work through Devices list adding device specific information
+    logging.debug('-> L109 - Getting specific device information')
+    for device in facts['devices']:
+        logging.debug('--> L111 - DEVICE %s', device['fqdn'])
+        # Add designed config for device
+        if device['streamingStatus'] == "active":
+            logging.debug('   --> L114 - call get_device_configuration')
+            device['config'] = module.client.api.get_device_configuration(device['key'])
+        # Add parent container name
+        logging.debug('   --> L117 - call get_container_by_id')
+        container = module.client.api.get_container_by_id(device['parentContainerKey'])
+        device['parentContainerName'] = container['name']
+        # Add Device Specific Configlets
+        logging.debug('   --> L121 - call get_configlets_by_device_id')
+        configlets = module.client.api.get_configlets_by_device_id(device['key'])
+        device['deviceSpecificConfiglets'] = []
+        for configlet in configlets:
+            if int(configlet['containerCount']) == 0:
+                device['deviceSpecificConfiglets'].append(configlet['name'])
+        # Add ImageBundle Info
+        device['imageBundle'] = ""
+        logging.debug('   --> L129 - call get_net_element_info_by_device_id')
+        deviceInfo = module.client.api.get_net_element_info_by_device_id(device['key'])
+        if "imageBundleMapper" in deviceInfo:
+            # There should only be one ImageBudle but its id is not decernable
+            # If the Image is applied directly to the device its type will be 'netelement'
+            if len(deviceInfo['imageBundleMapper'].values()) > 0:
+                if deviceInfo['imageBundleMapper'].values()[0]['type'] == 'netelement':
+                    device['imageBundle'] = deviceInfo['bundleName']
+        logging.debug('--> L137 - End of DEVICE %s', device['fqdn'])
+    # Build required data for configlets in CVP - Configlet Name, Config, Associated Containers,
+    # Associated Devices, and Configlet Type
+    configletField = {'name': 'name', 'config': 'config', 'type': 'type', 'key': 'key'}
+    facts['configlets'] = []
+
+    # Get List of all configlets
+    logging.debug('-> L144 - Collecting Configlet')
+    configlets = module.client.api.get_configlets()['data']
+    # Reduce configlet data to required fields
+    for configlet in configlets:
+        configletFacts = {}
+        for field in configlet.keys():
+            if field in configletField:
+                configletFacts[configletField[field]] = configlet[field]
+        facts['configlets'].append(configletFacts)
+
+    # Work through Configlet list adding Configlet specific information
+    for configlet in facts['configlets']:
+        logging.debug('--> L156 - CONFIGLET %s', configlet['name'])
+        # Add applied Devices
+        configlet['devices'] = []
+        logging.debug('   --> L159 - call get_devices_by_configlet')
+        applied_devices = module.client.api.get_devices_by_configlet(configlet['name'])
+        for device in applied_devices['data']:
+            configlet['devices'].append(device['hostName'])
+        # Add applied Containers
+        configlet['containers'] = []
+        logging.debug('   --> L165 - call get_containers_by_configlet')
+        applied_containers = module.client.api.get_containers_by_configlet(configlet['name'])
+        for container in applied_containers['data']:
+            configlet['containers'].append(container['containerName'])
+        logging.debug('--> L156 - END OF CONFIGLET %s', configlet['name'])
+
+
+    # Build required data for containers in CVP - Container Name, parent container, Associated Configlets
+    # Associated Devices, and Child Containers
+    containerField = {'name': 'name', 'parentName': 'parentName', 'childContainerId': 'childContainerKey',
+                      'key': 'key'}
+    facts['containers'] = []
+
+    # Get List of all Containers
+    logging.debug('-> Collecting containers')
+    logging.debug('--> L180 - call get_containers')
+    containers = module.client.api.get_containers()['data']
+    # Reduce container data to required fields
+    for container in containers:
+        containerFacts = {}
+        for field in container.keys():
+            if field in containerField:
+                containerFacts[containerField[field]] = container[field]
+        facts['containers'].append(containerFacts)
+
+    # Work through Container list adding Container specific information
+    for container in facts['containers']:
+        logging.debug('--> L192 - CONTAINER %s', container['name'])
+        # Add applied Devices
+        container['devices'] = []
+        logging.debug(' --> L180 - call get_devices_by_container_id')
+        applied_devices = module.client.api.get_devices_by_container_id(container['key'])
+        for device in applied_devices:
+            container['devices'].append(device['fqdn'])
+        # Add applied Configlets
+        container['configlets'] = []
+        logging.debug(' --> L180 - call get_configlets_by_container_id')
+        applied_configlets = module.client.api.get_configlets_by_container_id(container['key'])['configletList']
+        for device in applied_devices:
+            container['configlets'].append(configlet['name'])
+        # Add applied Images
+        container['imageBundle'] = ""
+        logging.debug(' --> L180 - call get_image_bundle_by_container_id')
+        applied_images = module.client.api.get_image_bundle_by_container_id(container['key'])['imageBundleList']
+        if len(applied_images) > 0:
+            container['imageBundle'] = applied_images[0]['name']
+        logging.debug('--> L211 - END OF CONTAINER %s', container['name'])
+
+    # Build required data for images in CVP - Image Name, certified, Image Components
+    imageField = {'name': 'name', 'isCertifiedImageBundle': 'certifified', 'imageIds': 'imageNames', 'key': 'key'}
+    facts['imageBundles'] = []
+
+    # Get List of all Image Bundles
+    logging.debug('-> Collecting imageBundle')
+    logging.debug('--> L219 - call get_image_bundles')
+    imageBundles = module.client.api.get_image_bundles()['data']
+    # Reduce image data to required fields
+    for imageBundle in imageBundles:
+        imageBundleFacts = {}
+        for field in imageBundle.keys():
+            if field in imageField:
+                imageBundleFacts[imageField[field]] = imageBundle[field]
+        facts['imageBundles'].append(imageBundleFacts)
+
+    # Build required data for tasks in CVP - work order Id, current task status, name
+    # description
+    tasksField = {'name': 'name', 'workOrderId': 'taskNo', 'workOrderState': 'status',
+                  'currentTaskName': 'currentAction', 'description': 'description',
+                  'workOrderUserDefinedStatus': 'displayedStutus', 'note': 'note',
+                  'taskStatus': 'actionStatus'}
+    facts['tasks'] = []
+
+    # Get List of all Tasks
+    logging.debug('-> Collecting tasks')
+    logging.debug('--> L239 - call get_tasks')
+    tasks = module.client.api.get_tasks()['data']
+    # Reduce task data to required fields
+    for task in tasks:
+        taskFacts = {}
+        for field in task.keys():
+            if field in tasksField:
+                taskFacts[tasksField[field]] = task[field]
+        facts['tasks'].append(taskFacts)
+    logging.debug('-> End of process')
+    return facts
+
+
+def main():
+    """ main entry point for module execution
+    """
+
+    logging.basicConfig(format='%(asctime)s %(message)s', filename='cv_fact.log', level=logging.DEBUG)
+
+    argument_spec = dict(
+        gather_subset=dict(type='list',
+                           elements='str',
+                           required=False,
+                           choices=['default', 'config'],
+                           default='default'))
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
+
+    result = dict(changed=False, ansible_facts={})
+
+    module.client = connect(module)
+
+    result['ansible_facts'] = cv_facts(module)
+    result['changed'] = False
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible_collections/arista/cvp/plugins/modules/cv_facts_v1.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_facts_v1.py
@@ -35,21 +35,35 @@ from ansible_collections.arista.cvp.plugins.module_utils.cv_client_errors import
 
 DOCUMENTATION = r'''
 ---
-module: cv_facts
+module: cv_facts_v1
 version_added: "2.9"
 author: EMEA AS Team (@aristanetworks)
 short_description: Collect facts from CloudVision Portal.
 description:
   - Returns the list of devices, configlets, containers and images
+options:
+  gather_subset:
+    description:
+      - When supplied, this argument will restrict the facts collected
+      - to a given subset.  Possible values for this argument include
+      - all, hardware, config, and interfaces.  Can specify a list of
+      - values to include a larger subset.  Values can also be used
+      - with an initial C(M(!)) to specify that a specific subset should
+      - not be collected.
+    required: false
+    default: ['default']
+    type: list
+    choices:
+      - default
+      - config
 '''
 
 EXAMPLES = r'''
 ---
     # Collect CVP Facts as init process
 - name: "Gather CVP facts from {{inventory_hostname}}"
-  arista.cvp.cv_facts:
+  arista.cvp.cv_facts_v1:
   register: cvp_facts
-
 '''
 
 
@@ -167,7 +181,6 @@ def cv_facts(module):
         for container in applied_containers['data']:
             configlet['containers'].append(container['containerName'])
         logging.debug('--> L156 - END OF CONFIGLET %s', configlet['name'])
-
 
     # Build required data for containers in CVP - Container Name, parent container, Associated Configlets
     # Associated Devices, and Child Containers

--- a/ansible_collections/arista/cvp/tests/issue-95.yml
+++ b/ansible_collections/arista/cvp/tests/issue-95.yml
@@ -59,5 +59,5 @@
 
     - name: '#11 - Save FACTS to cv_facts_v2.output.log'
       copy: 
-        content: '{{ FACTS_TASKS }}' 
+        content: '{{ FACTS }}' 
         dest: 'cv_facts_v2.json'

--- a/ansible_collections/arista/cvp/tests/issue-95.yml
+++ b/ansible_collections/arista/cvp/tests/issue-95.yml
@@ -1,0 +1,47 @@
+---
+- name: Build Testing topology using Dev CVP servers
+  hosts: cvp
+  connection: local
+  gather_facts: no
+  ### Configuration tasks
+  tasks:
+    - name: '#01 - Collect devices facts from {{inventory_hostname}}'
+      cv_facts_v2:
+        facts:
+          devices
+      register: FACTS_DEVICES
+
+    - name: '#02 - Collect devices facts (with config) from {{inventory_hostname}}'
+      cv_facts_v2:
+        gather_subset:
+          config
+        facts:
+          devices
+      register: FACTS_DEVICES_CONFIG
+
+    - name: '#03 - Collect confilgets facts from {{inventory_hostname}}'
+      cv_facts_v2:
+        facts:
+          configlets
+      register: FACTS_CONFIGLETS
+
+    - name: '#04 - Collect containers facts from {{inventory_hostname}}'
+      cv_facts_v2:
+        facts:
+          containers
+      register: FACTS_CONTAINERS
+
+    - name: '#05 - Collect tasks facts from {{inventory_hostname}}'
+      cv_facts_v2:
+        facts:
+          containers
+      register: FACTS_TASKS
+
+    - name: '#10 - Collect ALL facts from {{inventory_hostname}}'
+      cv_facts_v2:
+      register: FACTS
+
+    - name: '#11 - Save FACTS to cv_facts_v2.output.log'
+      copy: 
+        content: '{{ FACTS }}' 
+        dest: 'cv_facts_v2.log'

--- a/ansible_collections/arista/cvp/tests/issue-95.yml
+++ b/ansible_collections/arista/cvp/tests/issue-95.yml
@@ -3,16 +3,16 @@
   hosts: cvp
   connection: local
   gather_facts: no
-  ### Configuration tasks
   tasks:
+### Start cv_facts_v2 testing ##################################################
     - name: '#01 - Collect devices facts from {{inventory_hostname}}'
-      cv_facts_v2:
+      cv_facts:
         facts:
           devices
       register: FACTS_DEVICES
 
     - name: '#02 - Collect devices facts (with config) from {{inventory_hostname}}'
-      cv_facts_v2:
+      cv_facts:
         gather_subset:
           config
         facts:
@@ -20,28 +20,44 @@
       register: FACTS_DEVICES_CONFIG
 
     - name: '#03 - Collect confilgets facts from {{inventory_hostname}}'
-      cv_facts_v2:
+      cv_facts:
         facts:
           configlets
       register: FACTS_CONFIGLETS
 
     - name: '#04 - Collect containers facts from {{inventory_hostname}}'
-      cv_facts_v2:
+      cv_facts:
         facts:
           containers
       register: FACTS_CONTAINERS
 
-    - name: '#05 - Collect tasks facts from {{inventory_hostname}}'
-      cv_facts_v2:
+    - name: '#05 - Collect pending tasks facts from {{inventory_hostname}}'
+      cv_facts:
+        gather_subset:
+          tasks_pending
         facts:
-          containers
+          tasks
+      register: FACTS_TASKS_PENDING
+
+    - name: '#06 - Collect failed tasks facts from {{inventory_hostname}}'
+      cv_facts:
+        gather_subset:
+          tasks_failed
+        facts:
+          tasks
+      register: FACTS_TASKS_FAILED
+
+    - name: '#05 - Collect default tasks facts from {{inventory_hostname}}'
+      cv_facts:
+        facts:
+          tasks
       register: FACTS_TASKS
 
     - name: '#10 - Collect ALL facts from {{inventory_hostname}}'
-      cv_facts_v2:
+      cv_facts:
       register: FACTS
 
     - name: '#11 - Save FACTS to cv_facts_v2.output.log'
       copy: 
-        content: '{{ FACTS }}' 
-        dest: 'cv_facts_v2.log'
+        content: '{{ FACTS_TASKS }}' 
+        dest: 'cv_facts_v2.json'

--- a/docs/cv_facts.md
+++ b/docs/cv_facts.md
@@ -13,6 +13,8 @@ This module collects facts from CloudVision platform and return a dictionary for
 
 Module comes with 2 different options to allow user to select what information to retrieve from CVP:
 
+__Facts limitation:__
+
 - __`facts`__: A list of facts to retrieve from CVP. it can be one or more entries from the list:
     - `devices`
     - `containers`
@@ -20,11 +22,15 @@ Module comes with 2 different options to allow user to select what information t
     - `tasks`. 
 > If not specified, module will extract all this elements from CloudVision
 
+__Facts subset__
+
 - __`gather_subset`__: Allow user to extract an optional element from CloudVision.
     - `config`: Add device configuration in device facts. If not set, configuration is skipped. (applicable if `devices` is part of __facts__)
     - `tasks_pending`: Collect only facts from pending tasks on CloudVision. (applicable if `tasks` is part of __facts__)
     - `tasks_failed`: Collect only failed tasks information. (applicable if `tasks` is part of __facts__)
     - `tasks_all`: Collect all tasks information from CVP. (applicable if `tasks` is part of __facts__)
+
+Module supports inactive devices and 3rd part devices: When `gather_subset: config` is defined, only devices with flag `"streamingStatus": "active"` have their configuration collected into the facts.
 
 ## Usage
 

--- a/docs/cv_facts.md
+++ b/docs/cv_facts.md
@@ -11,6 +11,21 @@ This module collects facts from CloudVision platform and return a dictionary for
 - list of configlets
 - list of tasks
 
+Module comes with 2 different options to allow user to select what information to retrieve from CVP:
+
+- __`facts`__: A list of facts to retrieve from CVP. it can be one or more entries from the list:
+    - `devices`
+    - `containers`
+    - `configlets`
+    - `tasks`. 
+> If not specified, module will extract all this elements from CloudVision
+
+- __`gather_subset`__: Allow user to extract an optional element from CloudVision.
+    - `config`: Add device configuration in device facts. If not set, configuration is skipped. (applicable if `devices` is part of __facts__)
+    - `tasks_pending`: Collect only facts from pending tasks on CloudVision. (applicable if `tasks` is part of __facts__)
+    - `tasks_failed`: Collect only failed tasks information. (applicable if `tasks` is part of __facts__)
+    - `tasks_all`: Collect all tasks information from CVP. (applicable if `tasks` is part of __facts__)
+
 ## Usage
 
 __Authentication__
@@ -33,12 +48,43 @@ ansible_httpapi_port=443
 
 __Inputs__
 
-Below is a basic playbook to collect facts:
+Below is a basic playbook to collect all facts:
 
 ```yaml
   tasks:
     - name: "Gather CVP facts {{inventory_hostname}}"
       cv_facts:
+
+    - name: "Print out facts from CVP"
+      debug:
+        msg: "{{ansible_facts}}"
+```
+
+To only get a subset of facts with configlets:
+
+```yaml
+  tasks:
+    - name: "Gather CVP facts {{inventory_hostname}}"
+      cv_facts:
+        facts:
+          configlets
+
+    - name: "Print out facts from CVP"
+      debug:
+        msg: "{{ansible_facts}}"
+```
+
+Extracting device configuration in facts:
+
+```yaml
+  tasks:
+    - name: "Gather CVP facts {{inventory_hostname}}"
+      cv_facts:
+        facts:
+          devices
+        gather_subset:
+          condiguration
+
     - name: "Print out facts from CVP"
       debug:
         msg: "{{ansible_facts}}"
@@ -46,7 +92,7 @@ Below is a basic playbook to collect facts:
 
 __Result__
 
-Below is an example of expected output
+Below is an example of output with default parameters
 
 ```json
 {
@@ -57,78 +103,182 @@ Below is an example of expected output
         }, 
         "configlets": [
             {
-                "config": "alias v10 show version\n", 
-                "containers": [], 
+                "name": "ANSIBLE_TESTING_CONTAINER",
+                "isDefault": "no",
+                "config": "alias a57 show version",
+                "reconciled": false,
+                "netElementCount": 3,
+                "editable": true,
+                "dateTimeInLongFormat": 1574944821353,
+                "isDraft": false,
+                "note": "## Managed by Ansible ##",
+                "visible": true,
+                "containerCount": 2,
+                "user": "cvpadmin",
+                "key": "configlet_3503_4572477104617871",
+                "sslConfig": false,
                 "devices": [
-                    "veos01"
-                ], 
-                "key": "configlet_1065_1398913896328423", 
-                "name": "RECONCILE_172.23.0.2", 
-                "type": "Static"
-            } 
+                    "veos01",
+                    "veos02",
+                    "veos03"
+                ],
+                "type": "Static",
+                "containers": [
+                    "Fabric",
+                    "Leaves"
+                ],
+                "isAutoBuilder": ""
+            }
         ],
         "containers": [
             {
-                "childContainerKey": null, 
-                "configlets": [], 
-                "devices": [], 
-                "imageBundle": "", 
-                "key": "root", 
-                "name": "Tenant", 
-                "parentName": null
-            }, 
-            {
-                "childContainerKey": null, 
-                "configlets": [], 
-                "devices": [], 
-                "imageBundle": "", 
-                "key": "container_1306_1487093442541759", 
-                "name": "Fabric", 
-                "parentName": "Tenant"
-            },
+                "childContainerId": null,
+                "imageBundle": "",
+                "name": "MLAG01",
+                "factoryId": 1,
+                "CreatedOn": 1574944849950,
+                "parentName": "Leaves",
+                "userId": null,
+                "configlets": [],
+                "key": "container_9007_5100829604178666",
+                "CreatedBy": "cvpadmin",
+                "devices": [
+                    "veos01",
+                    "veos02"
+                ],
+                "Key": "container_9007_5100829604178666",
+                "parentId": "container_9005_5100826828532751",
+                "Mode": "expand",
+                "type": null,
+                "id": 21,
+                "Name": "MLAG01"
+            }
         ],
         "devices": [
             {
-                "complianceCode": "0000", 
-                "complianceIndication": "", 
-                "config": "! Command: show running-config\n", 
+                "memTotal": 0,
+                "imageBundle": "",
+                "serialNumber": "728870FA16465700865C770C620DF4DE",
+                "internalVersion": "4.23.0F",
+                "dcaKey": null,
                 "deviceSpecificConfiglets": [
-                    "SYS_TelemetryBuilderV2_172.23.0.3_1", 
-                    "veos02-basic-configuration", 
-                    "SYS_TelemetryBuilderV2", 
-                    "RECONCILE_172.23.0.3"
-                ], 
-                "fqdn": "veos02", 
-                "imageBundle": "", 
-                "ipAddress": "172.23.0.3", 
-                "key": "50:5d:9e:7a:dc:0a", 
-                "name": "veos02", 
-                "parentContainerKey": "container_1310_1487099262859288", 
-                "parentContainerName": "MLAG01", 
-                "version": "4.23.0F"
+                    "SYS_TelemetryBuilderV2_172.23.0.2_1",
+                    "veos01-basic-configuration",
+                    "ANSIBLE_TESTING_VEOS"
+                ],
+                "systemMacAddress": "50:25:22:56:12:61",
+                "tempAction": null,
+                "deviceStatus": "Registered",
+                "taskIdList": [],
+                "internalBuildId": "bf140e5e-dc9b-4586-9c8e-9615c43ed837",
+                "mlagEnabled": false,
+                "modelName": "vEOS",
+                "hostname": "veos01",
+                "complianceCode": "0000",
+                "version": "4.23.0F",
+                "type": "netelement",
+                "isDANZEnabled": false,
+                "parentContainerId": "container_9007_5100829604178666",
+                "status": "Registered",
+                "danzEnabled": false,
+                "unAuthorized": false,
+                "parentContainerKey": "container_9007_5100829604178666",
+                "deviceInfo": "Registered",
+                "ztpMode": false,
+                "bootupTimestamp": 1569848744.301779,
+                "lastSyncUp": 0,
+                "key": "50:25:22:56:12:61",
+                "parentContainerName": "MLAG01",
+                "containerName": "MLAG01",
+                "domainName": "",
+                "internalBuild": "bf140e5e-dc9b-4586-9c8e-9615c43ed837",
+                "ipAddress": "172.23.0.2",
+                "sslConfigAvailable": false,
+                "fqdn": "veos01",
+                "bootupTimeStamp": 1569848744.301779,
+                "isMLAGEnabled": false,
+                "streamingStatus": "active",
+                "memFree": 0,
+                "architecture": "",
+                "complianceIndication": "",
+                "sslEnabledByCVP": false,
+                "hardwareRevision": ""
             }
         ],
-        "imageBundles": [
-            {
-                "certifified": "true", 
-                "imageNames": [
-                    "EOS-4.20.11M.swi", 
-                    "TerminAttr-1.5.4-1.swix"
-                ], 
-                "key": "imagebundle_1571150950845802635", 
-                "name": "EOS-4.20.11M"
-            }
-        ], 
         "tasks": [
             {
-                "actionStatus": "COMPLETED", 
-                "currentAction": "Task Status Update", 
-                "description": "Configlet Assign from Container Move: veos03", 
-                "displayedStutus": "Completed", 
-                "name": "", 
-                "note": "Executed by Ansible", 
-                "status": "COMPLETED", 
-                "taskNo": "121"
+                "currentTaskType": "User Task",
+                "newParentContainerName": "MLAG01",
+                "executedOnInLongFormat": 0,
+                "ccId": "",
+                "dualSupervisor": false,
+                "taskStatus": "ACTIVE",
+                "note": "",
+                "completedOnInLongFormat": 1574946580964,
+                "description": "Configlet Assign: veos01",
+                "createdOnInLongFormat": 1574946575919,
+                "workOrderId": "445",
+                "netElementId": "50:25:22:56:12:61",
+                "createdBy": "cvpadmin",
+                "executedBy": "",
+                "workOrderUserDefinedStatus": "Pending",
+                "data": {
+                    "ERROR_IN_CAPTURING_RUNNING_CONFIG": "",
+                    "NETELEMENT_ID": "50:25:22:56:12:61",
+                    "imageBundleId": "",
+                    "imageToBePushedToDevice": "",
+                    "ZERO_TOUCH_REPLACEMENT": "",
+                    "ERROR_IN_CAPTURING_DESIGN_CONFIG": "",
+                    "designedConfigOutputIndex": "",
+                    "image": "",
+                    "runningConfig": "",
+                    "configSnapshots": [],
+                    "imageId": [],
+                    "ignoreConfigletList": [],
+                    "IS_AUTO_GENERATED_IN_CVP": false,
+                    "commandUsedInMgmtIpVal": "",
+                    "user": "",
+                    "sessionUsedInMgmtIpVal": "",
+                    "IS_ADD_OR_MOVE_FLOW": false,
+                    "ccExecutingNode": "",
+                    "preRollbackImage": "",
+                    "WORKFLOW_ACTION": "Configlet Push",
+                    "newparentContainerId": "container_9007_5100829604178666",
+                    "APP_SESSION_ID": "",
+                    "INCORRECT_CONFIG_IN_CAPTURING_DESIGN_CONFIG": "",
+                    "noOfRe-Tries": 0,
+                    "imageIdList": [],
+                    "ccId": "",
+                    "presentImageInDevice": "",
+                    "configletList": [],
+                    "INCORRECT_CONFIG_IN_CAPTURING_DESIGN_CONFIG_OUTPUT_INDEX": "",
+                    "VIEW": "CONFIG",
+                    "isRollbackFromSnapshotFlow": false,
+                    "targetIpAddress": "",
+                    "isRollbackTask": false,
+                    "IS_CONFIG_PUSH_NEEDED": "yes",
+                    "isDCAEnabled": false,
+                    "currentparentContainerId": "container_9007_5100829604178666",
+                    "configExistInCVP": false,
+                    "config": [],
+                    "designedConfig": "",
+                    "extensionsRequireReboot": []
+                },
+                "workOrderDetails": {
+                    "workOrderDetailsId": "",
+                    "serialNumber": "728870FA16465700865C770C620DF4DE",
+                    "workOrderId": "",
+                    "netElementHostName": "veos01",
+                    "netElementId": "50:25:22:56:12:61",
+                    "ipAddress": "172.23.0.2"
+                },
+                "workOrderState": "ACTIVE",
+                "taskStatusBeforeCancel": "",
+                "currentTaskName": "Submit",
+                "name": "",
+                "templateId": "ztp",
+                "workFlowDetailsId": "",
+                "newParentContainerId": "container_9007_5100829604178666"
             }
         ]
     }


### PR DESCRIPTION
__Features:__

- Enable collection of subset of facts
- Use full JSON content from CVP (#30)
- Collect only `pending` tasks by default (can be changed by user)
- Device configuration is now optional as per issue #31 
- Refactor code for better readability

__Examples:__

```yaml
- name: '#01 - Collect devices facts from {{inventory_hostname}}'
    cv_facts:
    facts:
        devices
    register: FACTS_DEVICES

- name: '#02 - Collect devices facts (with config) from {{inventory_hostname}}'
    cv_facts:
    gather_subset:
        config
    facts:
        devices
    register: FACTS_DEVICES_CONFIG

- name: '#04 - Collect containers facts from {{inventory_hostname}}'
    cv_facts:
    facts:
        containers
    register: FACTS_CONTAINERS

- name: '#05 - Collect pending tasks facts from {{inventory_hostname}}'
    cv_facts:
    gather_subset:
        tasks_pending
    facts:
        tasks
    register: FACTS_TASKS_PENDING

- name: '#06 - Collect ALL facts from {{inventory_hostname}}'
    cv_facts:
    register: FACTS
```


__Test results:__

CVP using lab requirements and running 3 devices / 6 containers / 45 configlets

```
#10 - Collect ALL facts from cvp_2018 ---------------------------- 53.43s
#03 - Collect confilgets facts from cvp_2018 --------------------- 39.19s
#04 - Collect containers facts from cvp_2018 --------------------- 10.46s
#02 - Collect devices facts (with config) from cvp_2018 ----------- 7.06s
#01 - Collect devices facts from cvp_2018 ------------------------- 5.69s
#05 - Collect pending tasks facts from cvp_2018 ------------------- 4.81s
#05 - Collect default tasks facts from cvp_2018 ------------------- 3.87s
#06 - Collect failed tasks facts from cvp_2018 -------------------- 3.80s
#11 - Save FACTS to cv_facts_v2.output.log ------------------------ 1.84s
```

Previous module still available under __`cv_facts_v1`__