### PR TITLE
Implement state=absent in cv_facts

### DIFF
--- a/ansible_collections/arista/cvp/README.md
+++ b/ansible_collections/arista/cvp/README.md
@@ -26,7 +26,7 @@ Support for this `arista.cvp` collection is provided by the community directly i
 
 ## Contributing
 
-Contributing pull requests are gladly welcomed for this repository. If you are planning a big change, please start a discussion first to make sure we’ll be able to merge it.
+Contributing pull requests are gladly welcomed for this repository. If you are planning a big change, please start a discussion first to make sure we'll be able to merge it.
 
 You can also open an [issue](https://github.com/aristanetworks/ansible-cvp/issues) to report any problem or to submit enhancement.
 

--- a/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
@@ -86,13 +86,14 @@ options:
     default: ['none']
     type: list
   state:
-    description: 
+    description:
         - If absent, configlets will be removed from CVP if they are not binded
         - to either a container or a device.
         - If present, configlets will be created or updated.
     required: false
     default: 'present'
-    type: string
+    choices: ['present', 'absent']
+    type: str
 '''
 
 EXAMPLES = r'''

--- a/ansible_collections/arista/cvp/plugins/modules/cv_device.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_device.py
@@ -66,6 +66,14 @@ options:
     required: false
     default: ['none']
     type: list
+  state:
+    description:
+        - If absent, devices will be removed from CVP and moved back to undefined.
+        - If present, devices will be configured or updated.
+    required: false
+    default: 'present'
+    choices: ['present', 'absent']
+    type: str
 '''
 
 EXAMPLES = r'''
@@ -450,13 +458,112 @@ def device_action(module):
     return [changed, data]
 
 
+def match_filter(device_filter='all', device_name=''):
+    """
+    Compare device name to device_filter
+
+    Parameters
+    ----------
+    device_filter : str, optional
+        Filter to test device name, by default 'all'
+    device_name : str,
+        Name of the device.
+
+    Returns
+    -------
+    bool
+        True if match filter, False otherwise.
+    """
+    if re.search(r"\ball\b", str(device_filter)) or (
+       any(element in device_name for element in device_filter)):
+        return True
+    return False
+
+
+def get_tasks(taskid_list, module):
+    """
+    Get tasks information from a list of tasks.
+
+    Parameters
+    ----------
+    taskid_list : list
+        List of task IDs to get.
+    module : AnsibleModule
+        Ansible module.
+
+    Returns
+    -------
+    list
+        List of tasks from CVP.
+    """
+    tasks = module.client.api.get_tasks_by_status('Pending')
+    task_list = list()
+    for task in tasks:
+        if task['workOrderId'] in taskid_list:
+            task_list.append(task)
+    return task_list
+
+
+def devices_reset(module):
+    """
+    Method to reset devices.
+
+    Reset all devices listed in module.params['devices'].
+
+    Parameters
+    ----------
+    module : AnsibleModule
+        Ansible Module.
+
+    Returns
+    -------
+    dict
+        Dict result with tasks and information.
+    """
+    # If any configlet changed updated 'changed' flag
+    changed = False
+    # Compare configlets against cvp_facts-configlets
+    reset_device = []  # devices to factory reset
+    reset = []
+    newTasks = []  # Task Ids that have been identified during device actions
+    taskList = []  # Tasks that have a pending status after function runs
+
+    for cvp_device in module.params['cvp_facts']['devices']:
+        # Include only devices that match filter elements, "all" will
+        # include all devices.
+        if match_filter(device_filter=module.params['device_filter'], device_name=cvp_device['name']):
+            try:
+                device_action = module.client.api.reset_device("Ansible", cvp_device)
+            except Exception as error:
+                errorMessage = str(error)
+                message = "Device %s cannot be reset - %s" % (cvp_device['name'], errorMessage)
+                reset.append({cvp_device['name']: message})
+            else:
+                if "errorMessage" in str(device_action):
+                    message = "Device %s cannot be Reset - %s" % (cvp_device['name'], device_action['errorMessage'])
+                    reset.append({cvp_device['name']: message})
+                else:
+                    changed = True
+                    if 'taskIds' in device_action.keys():
+                        for taskId in device_action['taskIds']:
+                            newTasks.append(taskId)
+                        reset.append({cvp_device['name']: 'Reset-%s' % device_action['tasksIds']})
+                    else:
+                        reset.append({cvp_device['name']: 'Reset-No_Tasks'})
+    taskList = get_tasks(taskid_list=newTasks, module=module)
+
+    data = {'reset': reset, 'tasks': taskList}
+    return data
+
+
 def main():
     """ main entry point for module execution
     """
     argument_spec = dict(
         devices=dict(type='dict', required=True),
         cvp_facts=dict(type='dict', required=True),
-        device_filter=dict(type='list', default='none'))
+        device_filter=dict(type='list', default='none'),
+        state=dict(type='str', choices=['present', 'absent'], default='present', required=False))
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
@@ -465,8 +572,14 @@ def main():
     # Connect to CVP instance
     module.client = connect(module)
 
-    # Pass module params to configlet_action to act on configlet
-    result['changed'], result['data'] = device_action(module)
+    if module.params['state'] == 'present':
+        # Configure devices on CVP
+        # Pass module params to configlet_action to act on configlet
+        result['changed'], result['data'] = device_action(module)
+    elif module.params['state'] == 'absent':
+        # Reset devices when user configured state=absent
+        result['changed'], result['data'] = devices_reset(module)
+
     module.exit_json(**result)
 
 

--- a/ansible_collections/arista/cvp/plugins/modules/cv_device.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_device.py
@@ -566,7 +566,7 @@ def main():
         state=dict(type='str',
                    choices=['present', 'absent'],
                    default='present',
-                   required=True))
+                   required=False))
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
@@ -574,6 +574,9 @@ def main():
     messages = dict(issues=False)
     # Connect to CVP instance
     module.client = connect(module)
+
+    # if 'state' not in module.params:
+    #     module.params['state']=present
 
     if module.params['state'] == 'present':
         # Configure devices on CVP

--- a/ansible_collections/arista/cvp/plugins/modules/cv_device.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_device.py
@@ -563,7 +563,10 @@ def main():
         devices=dict(type='dict', required=True),
         cvp_facts=dict(type='dict', required=True),
         device_filter=dict(type='list', default='none'),
-        state=dict(type='str', choices=['present', 'absent'], default='present', required=False))
+        state=dict(type='str',
+                   choices=['present', 'absent'],
+                   default='present',
+                   required=True))
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)

--- a/ansible_collections/arista/cvp/plugins/modules/cv_device.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_device.py
@@ -544,10 +544,10 @@ def devices_reset(module):
                     reset.append({cvp_device['name']: message})
                 else:
                     changed = True
-                    if 'taskIds' in device_action.keys():
-                        for taskId in device_action['taskIds']:
+                    if 'taskIds' in str(device_action):
+                        for taskId in device_action['data']['taskIds']:
                             newTasks.append(taskId)
-                        reset.append({cvp_device['name']: 'Reset-%s' % device_action['tasksIds']})
+                            reset.append({cvp_device['name']: 'Reset-%s' % taskId})
                     else:
                         reset.append({cvp_device['name']: 'Reset-No_Tasks'})
     taskList = get_tasks(taskid_list=newTasks, module=module)
@@ -578,7 +578,8 @@ def main():
         result['changed'], result['data'] = device_action(module)
     elif module.params['state'] == 'absent':
         # Reset devices when user configured state=absent
-        result['changed'], result['data'] = devices_reset(module)
+        result['changed'] = True
+        result['data'] = devices_reset(module)
 
     module.exit_json(**result)
 

--- a/ansible_collections/arista/cvp/tests/inventory.ini
+++ b/ansible_collections/arista/cvp/tests/inventory.ini
@@ -7,7 +7,7 @@ cvp_2018  ansible_host=10.90.224.122  cvp_port=443 ansible_httpapi_host=10.90.22
 cvp_2019   ansible_host=10.90.224.122  cvp_port=444 ansible_httpapi_host=10.90.224.122 ansible_httpapi_port=444
 
 [lab]
-cvp_demo    ansible_host=10.83.28.164   cvp_port=443
+cvp_demo    ansible_host=10.83.28.164 ansible_httpapi_host=10.83.28.164 cvp_port=443 ansible_httpapi_port=443
 
 [cv2019]
 cvp_2018
@@ -22,15 +22,13 @@ ansible_python_interpreter=$(which python)
 ansible_connection=httpapi
 ansible_httpapi_use_ssl=True
 ansible_httpapi_validate_certs=False
-ansible_user=cvpadmin
-ansible_password=ansible
 ansible_network_os=eos
 cvp_port=443
 
 [lab:vars]
-cvp_username='ansible'
-cvp_password='ansible'
+ansible_user='ansible'
+ansible_password='ansible'
 
 [development:vars]
-cvp_username='cvpadmin'
-cvp_password='ansible'
+ansible_user=cvpadmin
+ansible_password=ansible

--- a/ansible_collections/arista/cvp/tests/issue-58.yml
+++ b/ansible_collections/arista/cvp/tests/issue-58.yml
@@ -1,0 +1,36 @@
+---
+- name: Build Testing topology using Dev CVP servers
+  hosts: cvp
+  connection: local
+  gather_facts: no
+  vars:
+    CVP_CONTAINERS:
+      DC1_LEAF1:
+        parent_container: DC1_L3LEAFS
+      DC1_FABRIC:
+        parent_container: Tenant
+      DC1_L3LEAFS:
+        parent_container: DC1_FABRIC
+      DC1_LEAF2:
+        parent_container: DC1_L3LEAFS
+      DC1_SPINES:
+        parent_container: DC1_FABRIC
+  tasks:
+    - name: 'Collecting facts from CVP {{inventory_hostname}}.'
+      arista.cvp.cv_facts:
+      register: CVP_FACTS
+    - name: "Creating Container topology on {{inventory_hostname}}"
+      arista.cvp.cv_container:
+        topology: '{{CVP_CONTAINERS}}'
+        cvp_facts: '{{CVP_FACTS.ansible_facts}}'
+        mode: merge
+        save_topology: true
+    - name: 'Refreshing facts from CVP {{inventory_hostname}}.'
+      arista.cvp.cv_facts:
+      register: CVP_FACTS
+    - name: "Deleting Container topology on {{inventory_hostname}}"
+      arista.cvp.cv_container:
+        topology: '{{CVP_CONTAINERS}}'
+        cvp_facts: '{{CVP_FACTS.ansible_facts}}'
+        mode: delete
+        save_topology: true

--- a/ansible_collections/arista/cvp/tests/issue-99.yml
+++ b/ansible_collections/arista/cvp/tests/issue-99.yml
@@ -1,0 +1,56 @@
+---
+- name: Build Testing topology using Dev CVP servers
+  hosts: cvp
+  connection: local
+  gather_facts: no
+  vars:
+    DEVEL_CONTAINERS:
+      staging:
+        parent_container: Tenant
+    DEVEL_DEVICES:
+      veos01:
+        name: veos01
+        configlets:
+          - DEV_VEOS01
+        imageBundle: []
+        parentContainerName: staging
+  tasks:
+    - name: 'Collect facts from {{inventory_hostname}}'
+      tags: [always]
+      cv_facts:
+      register: facts
+    - name: 'Create initial topology on {{inventory_hostname}}'
+      tags: [build]
+      cv_container:
+        topology: '{{DEVEL_CONTAINERS}}'
+        cvp_facts: '{{facts.ansible_facts}}'
+        save_topology: true
+    - name: 'Configure devices on {{inventory_hostname}}'
+      tags: [build]
+      cv_device:
+        devices: '{{DEVEL_DEVICES}}'
+        cvp_facts: '{{facts.ansible_facts}}'
+        device_filter: ['veos01']
+        state: present
+      register: devices_result
+    - name: 'Run tasks'
+      tags: [build]
+      cv_task:
+        tasks: '{{devices_result.data.tasks}}'
+        # Wait 5 minutes for device to reboot
+        wait: 300
+
+    - name: 'Reset devices on {{inventory_hostname}}'
+      tags: [reset]
+      cv_device:
+        devices: '{{DEVEL_DEVICES}}'
+        cvp_facts: '{{facts.ansible_facts}}'
+        device_filter: ['veos01']
+        state: absent
+      register: devices_result
+    - name: 'Run tasks'
+      tags: [reset]
+      cv_task:
+        tasks: '{{devices_result.data.tasks}}'
+        # Wait 7 minutes for device to reboot
+        wait: 420

--- a/docs/cv_device.md
+++ b/docs/cv_device.md
@@ -139,3 +139,5 @@ Whit this example, `veos01` device will be reset with initial configuration (ZTP
         # Wait 7 minutes for device to reboot
         wait: 420
 ```
+
+> In this scenario, tasks are returned by CVP only if we run reset. If you run playbook with no task execution and then rerun same playbook to execute task, CVP won't return it.

--- a/docs/cv_device.md
+++ b/docs/cv_device.md
@@ -13,7 +13,9 @@ Module comes with a set of options:
 - `devices`: List of devices to manage.
 - `cvp_facts`: Current facts collecting on CVP by a previous task
 - `devices_filter`: Filter to apply intended mode on a set of configlet. If not used, then module only uses ADD mode. device_filter list devices that can be modified or deleted based on configlets entries.
-- `state`: `absent` or `present`. Provide an option to delete devices from topology and reset devices to undefined container. Default value is `present` and it is an optional field.
+- `state`: . Provide an option to delete devices from topology and reset devices to undefined container. Default value is `present` and it is an optional field.
+    - `absent`: Reset devices.
+    - `present`: Configure devices.
 
 ## Usage
 
@@ -61,6 +63,7 @@ Below is a basic playbook to collect facts:
         devices: "{{devices_inventory}}"
         cvp_facts: '{{cvp_facts.ansible_facts}}'
         device_filter: ['veos']
+        state: present
       register: cvp_device
 ```
 


### PR DESCRIPTION
Implement option to reset devices as per issue #99 

__Playbook example__

```yaml
- name: Build Switch configuration
  hosts: DC1_FABRIC
  connection: local
  gather_facts: no
  vars:
      CVP_DEVICES:
        DC1-SPINE1:
          name: DC1-SPINE1
          parentContainerName: DC1_SPINES
          configlets:
              - AVD_DC1-SPINE1
          imageBundle: []
  tasks:
    - name: Get facts
      cv_facts
      register: FACTS
    - name: reset devices
      cv-device:
        devices: "{{CVP_DEVICES}}"
        cvp_facts: '{{FACTS.ansible_facts}}'
        device_filter: ['DC1']
        state: absent
```

__Results__

- Devices moves back to undefined.
- Clean configuration.
- Restart ZTP process to onboard device.