### PR TITLE
Issue #108 - Fix code to get coherent result in cv_container

### DIFF
--- a/ansible_collections/arista/cvp/plugins/modules/cv_container.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_container.py
@@ -777,8 +777,9 @@ def attached_configlet_to_container(module, intended, facts):
             if 'taskIds' in configlet_action['data']:
                 for task in configlet_action['data']['taskIds']:
                     task_ids.append(task)
-            attached_configlet.append(configlet_list)
-            attached['configlet_attached'] = attached['configlet_attached'] + 1
+            if len(configlet_list) > 0:
+                attached_configlet.append(configlet_list)
+                attached['configlet_attached'] = attached['configlet_attached'] + 1
     # Build ansible output messages.
     attached['list'] = attached_configlet
     attached['taskIds'] = task_ids


### PR DESCRIPTION
Add additional test to ensure output is not updating if CV returns a
list with no entry.