### PR TITLE
Allow custom root container in cv_container

### DIFF
--- a/ansible_collections/arista/cvp/plugins/modules/cv_container.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_container.py
@@ -113,6 +113,24 @@ EXAMPLES = r'''
         cvp_facts: '{{cvp_facts.ansible_facts}}'
 '''
 
+def get_root_container(containers_fact):
+    """
+    Extract name of the root conainer provided by cv_facts.
+
+    Parameters
+    ----------
+    containers_fact : list
+        List of containers to read from cv_facts
+
+    Returns
+    -------
+    string
+        Name of the root container, if not found, return Tenant as default value
+    """
+    for container in containers_fact:
+        if container['key'] == 'root':
+            return container['name']
+    return 'Tenant'
 
 def tree_to_list(json_data, myList):
     """
@@ -271,7 +289,8 @@ def tree_build_from_list(containers):
     tree = Tree()  # Create the base node
     previously_created = list()
     # Create root node to mimic CVP behavior
-    tree.create_node("Tenant", "Tenant")
+    root_container = get_root_container(containers_fact=containers)
+    tree.create_node(root_container, root_container)
     # Iterate for first level of containers directly attached under root.
     for cvp_container in containers:
         if cvp_container['parentName'] is None:

--- a/ansible_collections/arista/cvp/plugins/modules/cv_container.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_container.py
@@ -113,10 +113,11 @@ EXAMPLES = r'''
         cvp_facts: '{{cvp_facts.ansible_facts}}'
 '''
 
+
 def create_builtin_containers(facts, debug=False):
     """
     Update builtin containers with root container name
-    
+
     Parameters
     ----------
     facts : dict
@@ -126,6 +127,7 @@ def create_builtin_containers(facts, debug=False):
     """
     root = get_root_container(containers_fact=facts['containers'], debug=debug)
     builtin_containers.append(root)
+
 
 def get_root_container(containers_fact, debug=True):
     """
@@ -150,6 +152,7 @@ def get_root_container(containers_fact, debug=True):
             logging.debug('  -> CloudVision ROOT container has name %s', container['Name'])
             return container['Name']
     return 'Tenant'
+
 
 def tree_to_list(json_data, myList, debug=False):
     """
@@ -489,7 +492,7 @@ def create_new_containers(module, intended, facts, debug=False):
     # Get root container of topology
     topology_root = get_root_container(containers_fact=facts['containers'])
     # Build ordered list of containers to create: from Tenant to leaves.
-    container_intended_tree = tree_build_from_dict(containers=intended, root=topology_root,debug=debug)
+    container_intended_tree = tree_build_from_dict(containers=intended, root=topology_root, debug=debug)
     container_intended_ordered_list = tree_to_list(json_data=container_intended_tree, myList=list())
     # Parse ordered list of container and chek if they are configured on CVP.
     # If not, then call container creation process.


### PR DESCRIPTION
Module assumes root container is always named Tenant as it is the default value. But some design have this value changed.

When root container is not Tenant then, module starts an infinite loop as it is looking for a non-existing key.

Instead of assuming root is Tenant, module should identify the root container and use it as base for the tree representation