### PR TITLE
cv_configlet : implement diff and set changed to true when appro…

### DIFF
--- a/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
@@ -124,7 +124,7 @@ EXAMPLES = r'''
 '''
 
 
-def compare(fromText, toText, lines=10):
+def compare(fromText, toText, fromName='', toName='', lines=10):
     """ Compare text string in 'fromText' with 'toText' and produce
         diffRatio - a score as a float in the range [0, 1] 2.0*M / T
           T is the total number of elements in both sequences,
@@ -139,7 +139,7 @@ def compare(fromText, toText, lines=10):
     """
     fromlines = fromText.splitlines(1)
     tolines = toText.splitlines(1)
-    diff = list(difflib.unified_diff(fromlines, tolines, n=lines))
+    diff = list(difflib.unified_diff(fromlines, tolines,  fromName, toName, n=lines))
     textComp = difflib.SequenceMatcher(None, fromText, toText)
     diffRatio = round(textComp.quick_ratio() * 100, 2)
     return [diffRatio, diff]
@@ -188,6 +188,7 @@ def configlet_action(module):
     new_configlet = []  # configlets to add to CVP
     new = []
     taskList = []  # Tasks that have a pending status after function runs
+    diff = ""
 
     for configlet in module.params['cvp_facts']['configlets']:
         # Only deal with Static configlets not Configletbuilders or
@@ -200,12 +201,12 @@ def configlet_action(module):
                 if configlet['name'] in module.params['configlets']:
                     if module.params['state'] == 'present':
                         ansible_configlet = module.params['configlets'][configlet['name']]
-                        configlet_compare = compare(configlet['config'], ansible_configlet)
+                        configlet_compare = compare(configlet['config'], ansible_configlet, 'CVP', 'Ansible')
                         # compare function returns a floating point number
                         if configlet_compare[0] == 100.0:
                             keep_configlet.append(configlet)
                         else:
-                            update_configlet.append({'data': configlet, 'config': ansible_configlet})
+                            update_configlet.append({'data': configlet, 'config': ansible_configlet,'diff':''.join(configlet_compare[1])})
                     elif module.params['state'] == 'absent':
                         delete_configlet.append(configlet)
                 else:
@@ -258,6 +259,7 @@ def configlet_action(module):
                         module.client.api.add_note_to_configlet(configlet['data']['key'], "## Managed by Ansible ##")
                         changed = True
                         updated.append({configlet['data']['name']: "success"})
+                        diff += configlet['data']['name'] + ":\n" + configlet['diff'] + "\n\n"
 
         # Add any new configlets as required
         if len(new_configlet) > 0:
@@ -303,11 +305,12 @@ def configlet_action(module):
         for configlet in update_configlet:
             updated.append({configlet['data']['name']: "checked"})
             changed = True
+            diff += configlet['data']['name'] + ":\n" + configlet['diff'] + "\n\n"
         for configlet in delete_configlet:
             deleted.append({configlet['name']: "checked"})
             changed = True
         data = {'new': new, 'updated': updated, 'deleted': deleted, 'tasks': taskList}
-    return [changed, data]
+    return [changed, data, diff]
 
 
 def main():
@@ -334,7 +337,9 @@ def main():
     module.client = connect(module)
 
     # Pass module params to configlet_action to act on configlet
-    result['changed'], result['data'] = configlet_action(module)
+    result['changed'], result['data'], diff = configlet_action(module)
+    if len(diff) > 0:
+        result['diff'] = {'prepared': diff}
     module.exit_json(**result)
 
 

--- a/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
@@ -139,7 +139,7 @@ def compare(fromText, toText, fromName='', toName='', lines=10):
     """
     fromlines = fromText.splitlines(1)
     tolines = toText.splitlines(1)
-    diff = list(difflib.unified_diff(fromlines, tolines,  fromName, toName, n=lines))
+    diff = list(difflib.unified_diff(fromlines, tolines, fromName, toName, n=lines))
     textComp = difflib.SequenceMatcher(None, fromText, toText)
     diffRatio = round(textComp.quick_ratio() * 100, 2)
     return [diffRatio, diff]
@@ -206,7 +206,7 @@ def configlet_action(module):
                         if configlet_compare[0] == 100.0:
                             keep_configlet.append(configlet)
                         else:
-                            update_configlet.append({'data': configlet, 'config': ansible_configlet,'diff':''.join(configlet_compare[1])})
+                            update_configlet.append({'data': configlet, 'config': ansible_configlet, 'diff': ''.join(configlet_compare[1])})
                     elif module.params['state'] == 'absent':
                         delete_configlet.append(configlet)
                 else:

--- a/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
@@ -299,10 +299,13 @@ def configlet_action(module):
     else:
         for configlet in new_configlet:
             new.append({configlet['name']: "checked"})
+            changed = True
         for configlet in update_configlet:
             updated.append({configlet['data']['name']: "checked"})
+            changed = True
         for configlet in delete_configlet:
             deleted.append({configlet['name']: "checked"})
+            changed = True
         data = {'new': new, 'updated': updated, 'deleted': deleted, 'tasks': taskList}
     return [changed, data]
 


### PR DESCRIPTION
Fixes #120

This PR does not change what input `cv_configlet` expects.

It does change what `cv_configlet` outputs : if one or more configlets have been modified, the modules outputs an additional key, `diff`, that will be interpreted and displayed by Ansible. This diff is of type `prepared` (see [here](https://www.networktocode.com/blog/post/generating-diff-with-ansible/))
This text outputs is actually a concatenation of all configlets' diffs, as we can update more than one in a single `cv_configlet` execution.

Note that my patch leverage the existing call to `compare()`, i.e. the diff was generated but not used verbatim.

Additionally, the PR changes the behavior of `cv_configlet` : when in check mode (dry run), the module now returns `changed` as `true` if any configlet _would have been_ added, deleted or modified. If I recall correctly (this change was sitting in a branch of mine), the diff is not displayed by Ansible when the task has `changed` set to `false` (i.e. green in `ansible-playbook`). 
But even without the diff, it seems to me that this behavior is preferred, as I stated in #120 .