### PR TITLE
cv_device: fix a KeyError in check mode when provisioning a new device

### DIFF
--- a/ansible_collections/arista/cvp/plugins/modules/cv_device.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_device.py
@@ -445,7 +445,7 @@ def device_action(module):
     else:
         # Only display action results as Ansible check_mode is active
         for device in new_device:
-            new.append({device[0]['name']: "checked"})
+            new.append({device['ansible_device']['name']: "checked"})
         for device in update_device:
             updated.append({device['name']: "checked",
                             'configlets': device['configlets'],


### PR DESCRIPTION
When using `cv_device` in check mode (`--check`) to provision a new device, there was a `KeyError` : 
```
  File "/tmp/ansible_arista.cvp.cv_device_payload_z_xeoqd5/ansible_arista.cvp.cv_device_payload.zip/ansible_collections/arista/cvp/plugins/modules/cv_device.py", line 592, in <module>
  File "/tmp/ansible_arista.cvp.cv_device_payload_z_xeoqd5/ansible_arista.cvp.cv_device_payload.zip/ansible_collections/arista/cvp/plugins/modules/cv_device.py", line 582, in main
  File "/tmp/ansible_arista.cvp.cv_device_payload_z_xeoqd5/ansible_arista.cvp.cv_device_payload.zip/ansible_collections/arista/cvp/plugins/modules/cv_device.py", line 448, in device_action
KeyError: 0
```
