### PR TITLE
Implement role to configure ZTP on CloudVision

### DIFF
--- a/ansible_collections/arista/cvp/roles/ztp_configuration/.travis.yml
+++ b/ansible_collections/arista/cvp/roles/ztp_configuration/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/ansible_collections/arista/cvp/roles/ztp_configuration/README.md
+++ b/ansible_collections/arista/cvp/roles/ztp_configuration/README.md
@@ -1,0 +1,107 @@
+ztp-setup
+=========
+
+Ansible role to provision and configure Zero Touch Provisioning on a CloudVision server. Role will do the following:
+- Activate DHCPd service on CloudVision.
+- Create `/etc/dhcp/dhcpd.conf` file with relevant information.
+- Reload `dhcpd` service to apply changes.
+
+Requirements
+------------
+
+None
+
+Role Variables
+--------------
+
+```yaml
+ztp:
+  default:            <Section with default value for hosts configuration>
+    registration:     <*default URL to get Script to register to CV or initial configuration>
+    gateway:          <Gateway to use by default if not set per device>
+    nameservers:      <List of default NS to use on a per host basis>
+  general:            <Section to define subnets parameters>
+    subnets:
+      - network:      <*Subnet where DHCP will listen for request>
+        netmask:      <*Netmask of given subnet>
+        gateway:      <Gateway to configure for given subnet>
+        nameservers:  <List of name-servers to configure for given subnet>
+        start:        <First IP available in the pool>
+        end:          <Last IP available in the pool>
+        lease_time:   <Maximum lease time before device loose IP. Renewal is max/2>
+  clients:            <List of clients on a mac-address basis>
+    - name:           <*Hostname to provide when device do a DHCP request>
+      mac:            <*Mac address of the host>
+      ip4:            <*IP Address of the host>
+      registration:   <Registration URL to use for the host. If not set, default value will be applied>
+      gateway:        <Gateway to use for the host. If not set, default value will be applied>
+      nameservers:    <List of NS to use for the host. If not set, default value will be applied>
+```
+
+Variables with `*` are mandatory, others are optional and might be skipped if not needed in your setup.
+
+Dependencies
+------------
+
+No dependency required for this role.
+
+Example Playbook
+----------------
+
+Below is a basic playbook running `arista.cvp.ztp_configuration` role
+
+```yaml
+---
+- name: Configure ZTP service on CloudVision
+  hosts: ztp_server
+  gather_facts: no
+  vars:
+    ztp:
+      default:
+        registration: 'http://10.255.0.1/ztp/bootstrap'
+        gateway: 10.255.0.3
+        nameservers: 
+          - '10.255.0.3'
+      general:
+        subnets:
+          - network: 10.255.0.0
+            netmask: 255.255.255.0
+            gateway: 10.255.0.3
+            nameservers: 
+              - '10.255.0.3'
+            start: 10.255.0.200
+            end: 10.255.0.250
+            lease_time: 300
+      clients:
+        - name: DC1-SPINE1
+          mac: 0c:1d:c0:1d:62:01
+          ip4: 10.255.0.11
+        - name: DC1-SPINE2
+          mac: 0c:1d:c0:1d:62:02
+          ip4: 10.255.0.12
+        - name: DC1-LEAF1A
+          mac: 0c:1d:c0:1d:62:11
+          ip4: 10.255.0.13
+  tasks:
+  - name: 'Execute ZTP configuration role'
+    import_role:
+      name: arista.cvp.ztp-setup
+```
+
+Inventory is configured like below:
+
+```yaml
+---
+all:
+  children:
+    CVP:
+      hosts:
+        cv_ztp:
+          ansible_host: 1.1.1.1
+          ansible_user: root
+          ansible_password: password
+```
+
+## License
+
+Project is published under [Apache 2.0 License](../../../../../LICENSE)

--- a/ansible_collections/arista/cvp/roles/ztp_configuration/defaults/main.yml
+++ b/ansible_collections/arista/cvp/roles/ztp_configuration/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for ztp-setup

--- a/ansible_collections/arista/cvp/roles/ztp_configuration/handlers/main.yml
+++ b/ansible_collections/arista/cvp/roles/ztp_configuration/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for ztp-setup

--- a/ansible_collections/arista/cvp/roles/ztp_configuration/meta/main.yml
+++ b/ansible_collections/arista/cvp/roles/ztp_configuration/meta/main.yml
@@ -1,0 +1,53 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.9
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  

--- a/ansible_collections/arista/cvp/roles/ztp_configuration/tasks/main.yml
+++ b/ansible_collections/arista/cvp/roles/ztp_configuration/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+# tasks file for ztp-setup
+- name: 'Generate DHCPd configuration file'
+  template:
+    src: 'dhcpd.conf.j2'
+    dest: /etc/dhcp/dhcpd.conf
+    backup: yes
+
+- name: Check & activate DHCP service on {{inventory_hostname}}
+  shell:
+    cmd: chkconfig dhcpd on
+
+# - name: Check & activate DHCP service on {{inventory_hostname}}
+#   service:
+#     name: dhcpd
+#     enabled: yes
+
+- name: Restart DHCP service on {{inventory_hostname}}
+  shell:
+    cmd: service dhcpd restart
+
+# - name: Restart DHCP service on {{inventory_hostname}}
+#   service:
+#     name: dhcpd
+#     state: restarted

--- a/ansible_collections/arista/cvp/roles/ztp_configuration/templates/dhcpd.conf.j2
+++ b/ansible_collections/arista/cvp/roles/ztp_configuration/templates/dhcpd.conf.j2
@@ -1,0 +1,39 @@
+# Subnet of ZTP interface
+{% for subnet in ztp.general.subnets %}
+subnet {{subnet.network}} netmask {{subnet.netmask}} {
+    range {{subnet.start}} {{subnet.end}};
+{% if subnet.gateway is defined %}
+    option routers {{subnet.gateway}};
+{% endif %}
+{% if subnet.nameservers is defined and subnet.nameservers is iterable %}
+    option domain-name-servers {% for ns in subnet.nameservers %}{{ns}}{% if not loop.last %}, {%endif%}{%endfor%};
+{% endif %}
+{% if subnet.registration is defined %}
+    option bootfile-name "{{subnet.registration}}";
+{% endif %}
+{% if subnet.lease_time is defined %}
+    max-lease-time {{subnet.lease_time}};
+{% endif %}
+}
+{% endfor %}
+
+# Per host definition
+{% for client in ztp.clients %}
+host {{client.name}} {
+    option host-name "{{client.name}}";
+    hardware ethernet {{client.mac}};
+    fixed-address {{client.ip4}};
+    option bootfile-name "{{ztp.default.registration}}";
+{% if client.gateway is defined %}
+    option routers {{client.gateway}};
+{% elif ztp.default.gateway is defined %}
+    option routers {{ztp.default.gateway}};
+{% endif %}
+{% if client.nameservers is defined and subnet.nameservers is iterable %}
+    option domain-name-servers {% for ns in client.nameservers %}{{ns}}{% if not loop.last %}, {%endif%}{%endfor%};
+{% elif ztp.default.nameservers is defined and ztp.default.nameservers is iterable%}
+    option domain-name-servers {% for ns in ztp.default.nameservers %}{{ns}}{% if not loop.last %}, {%endif%}{%endfor%};
+{% endif %}
+}
+
+{% endfor %}

--- a/ansible_collections/arista/cvp/roles/ztp_configuration/tests/inventory
+++ b/ansible_collections/arista/cvp/roles/ztp_configuration/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/ansible_collections/arista/cvp/roles/ztp_configuration/tests/test.yml
+++ b/ansible_collections/arista/cvp/roles/ztp_configuration/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - ztp-setup

--- a/ansible_collections/arista/cvp/roles/ztp_configuration/vars/main.yml
+++ b/ansible_collections/arista/cvp/roles/ztp_configuration/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for ztp-setup


### PR DESCRIPTION
Add a simple role to configure ZTP server on a CloudVision server:

- Define global IP address Pool
	- Default Gateway
	- Default DNS servers
	- Registration URL
- Define mac based entry with Hostname / IPv4 address binding

Role should implement a basic data model that can be leverage from any project.

Not in scope at T0:
- Per IP registration script
- Vendor Class protection to serve only Arista
- Configuration in a DHCP relay environment