### PR TITLE
Issues/147 facts execution time

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/cv_api2018.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/cv_api2018.py
@@ -614,6 +614,13 @@ class CvpApi(object):
                 configlet['config'] = full_cfglt_data['config']
         return configlets
 
+    def get_configlets_and_mappers(self):
+        '''
+        Return a list of all defined configlets and associated mappers
+        '''
+        self.log.debug('getConfigletsAndAssociatedMappers')
+        return self.clnt.get('/configlet/getConfigletsAndAssociatedMappers.do')
+
     def get_devices_by_configlet(self, configlet_name, start=0, end=0):
         ''' Returns a list of devices to which the named configlet is applied.
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/cv_api2019.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/cv_api2019.py
@@ -616,6 +616,13 @@ class CvpApi(object):
                 configlet['config'] = full_cfglt_data['config']
         return configlets
 
+    def get_configlets_and_mappers(self):
+        '''
+        Return a list of all defined configlets and associated mappers
+        '''
+        self.log.debug('getConfigletsAndAssociatedMappers')
+        return self.clnt.get('/configlet/getConfigletsAndAssociatedMappers.do')
+
     def get_devices_by_configlet(self, configlet_name, start=0, end=0):
         ''' Returns a list of devices to which the named configlet is applied.
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/logger.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/logger.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# coding: utf-8 -*-
+#
+# FIXME: required to pass ansible-test
+# GNU General Public License v3.0+
+#
+# Copyright 2019 Arista Networks AS-EMEA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import logging
+from logging.handlers import RotatingFileHandler
+import os
+
+# Get Logging level from Environment variable / Default INFO
+
+# Define standard logging verbosity
+LEVELS = {'debug': logging.DEBUG,
+          'info': logging.INFO,
+          'warning': logging.WARNING,
+          'error': logging.ERROR,
+          'critical': logging.CRITICAL}
+
+# Set loglevel for arista.cvp modules
+LOGGING_LEVEL = os.getenv('ANSIBLE_CVP_LOG_LEVEL', 'info')
+LOGLEVEL = LEVELS.get(LOGGING_LEVEL, logging.NOTSET)
+
+# Set loglevel for urllib3
+LOGGING_LEVEL_URLLIB3 = os.getenv('ANSIBLE_CVP_LOG_APICALL', 'warning')
+LOGLEVEL_URLLIB3 = LEVELS.get(LOGGING_LEVEL_URLLIB3, logging.WARNING)
+
+# Get filename to write logs / default /temp/arista.cvp.debug.log
+LOGGING_FILENAME = os.getenv(
+    'ANSIBLE_CVP_LOG_FILE', '/tmp/arista.cvp.debug.log')
+
+# set a format which is simpler for console use
+formatter = logging.Formatter(
+    '%(asctime)s - %(name)-12s: %(levelname)-s - func: %(funcName)-12s (L:%(lineno)-3d) - %(message)s')
+
+# set up ROOT handler to use logging with file rotation.
+handler = logging.handlers.RotatingFileHandler(
+    LOGGING_FILENAME, maxBytes=1000000, backupCount=5)
+handler.setFormatter(formatter)
+handler.setLevel(LOGLEVEL)
+# Unset default logging level for root handler
+logging.getLogger('').setLevel(logging.NOTSET)
+logging.getLogger('').addHandler(handler)
+
+# Configure URLLIB3 logging (default Warning to avoid too much verbosity)
+logging.getLogger("urllib3").setLevel(LOGLEVEL_URLLIB3)

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools_inventory.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools_inventory.py
@@ -1,0 +1,49 @@
+import logging
+import ansible_collections.arista.cvp.plugins.module_utils.logger
+
+MODULE_LOGGER = logging.getLogger('arista.cvp.tools_inventory')
+
+def find_hostname_by_mac(inventory, mac_address):
+    """
+    Function to get device hostname based on System Mac Address.
+
+    Parameters
+    ----------
+    inventory : list
+        Inventory list extracted from CVP.
+    mac_address : string
+        Mac address to search
+
+    Returns
+    -------
+    string
+        Device hostname. Default None if not found
+    """
+    for device in inventory:
+        if 'systemMacAddress' in device:
+            if device['systemMacAddress'] == mac_address:
+                return device['name']
+    return None
+
+
+def find_containerName_by_containerId(containers_list, container_id):
+    """
+    Function to get containername based on container ID.
+
+    Parameters
+    ----------
+    containers_list : list
+        Containers list extracted from CVP.
+    container_id : string
+        ID of the container to search
+
+    Returns
+    -------
+    string
+        Container name. Default None if not found
+    """
+    for container in containers_list:
+        if 'Key' in container:
+            if container['Key'] == container_id:
+                return container['Name']
+    return None

--- a/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
@@ -32,7 +32,15 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection, ConnectionError
 from ansible_collections.arista.cvp.plugins.module_utils.cv_client import CvpClient
 from ansible_collections.arista.cvp.plugins.module_utils.cv_client_errors import CvpLoginError, CvpApiError
+<<<<<<< HEAD
 
+=======
+from ansible_collections.arista.cvp.plugins.module_utils.tools_inventory import (
+    find_hostname_by_mac,
+    find_containerName_by_containerId
+    )
+import ansible_collections.arista.cvp.plugins.module_utils.logger
+>>>>>>> 7ccdac6... Update cv_facts to speed up process (#147)
 
 DOCUMENTATION = r'''
 ---
@@ -197,9 +205,9 @@ def facts_devices(module, facts, debug=False):
     return facts
 
 
-def facts_configlets(module, facts, debug=False):
+def facts_configlets_v1(module, facts):
     """
-    Collect facts of all configlets.
+    DEPRECATED - Collect facts of all configlets.
 
     Parameters
     ----------
@@ -217,6 +225,7 @@ def facts_configlets(module, facts, debug=False):
     """
 
     facts['configlets'] = []
+    MODULE_LOGGER.info('Collecting facts v1')
     configlets = module.client.api.get_configlets()['data']
     # Reduce configlet data to required fields
     for configlet in configlets:
@@ -224,19 +233,95 @@ def facts_configlets(module, facts, debug=False):
             logging.debug('  -> Working on %s', configlet['name'])
         # Get list of devices attached to configlet.
         configlet['devices'] = []
+        MODULE_LOGGER.debug('  -> collecting list of attached devices to configlet: %s', str(configlet))
         applied_devices = module.client.api.get_devices_by_configlet(configlet['name'])
         for device in applied_devices['data']:
             configlet['devices'].append(device['hostName'])
 
         # Get list of containers attached to configlet.
         configlet['containers'] = []
-        applied_containers = module.client.api.get_containers_by_configlet(configlet['name'])
+        MODULE_LOGGER.debug(
+            '  -> collecting list of attached containers to configlet: %s', str(configlet))
+        applied_containers = module.client.api.get_containers_by_configlet(
+            configlet['name'])
         for container in applied_containers['data']:
             configlet['containers'].append(container['containerName'])
 
         # Add configlet to facts list
         facts['configlets'].append(configlet)
+    MODULE_LOGGER.info('All configlet facts collected')
 
+    return facts
+
+
+def facts_configlets(module, facts):
+    """
+    WORK IN PROGRESS - Collect facts of all configlets.
+
+    Parameters
+    ----------
+    module : AnsibleModule
+        Ansible module with parameters and instances
+    facts : dict
+        Fact dictionary where configlets information will be inserted.
+    debug : bool, optional
+        Activate debug logging, by default False
+
+    Returns
+    -------
+    dict
+        facts with configlets content added.
+    """
+    facts['configlets'] = []
+    MODULE_LOGGER.info('Collecting facts v2')
+    configlets_and_mappers = module.client.api.get_configlets_and_mappers()[
+        'data']
+    # Load data to match ID with human readable name
+    inventory = list()
+    containers = list()
+    if 'devices' in facts:
+        MODULE_LOGGER.info('Devices part of facts, using cached version')
+        inventory = facts['devices']
+    else:
+        MODULE_LOGGER.warning(
+            'Devices not part of facts, collecting CV version')
+        inventory = module.client.api.get_inventory()
+    if 'containers' in facts:
+        MODULE_LOGGER.info('Containers part of facts, using cached version')
+        containers = facts['containers']
+    else:
+        MODULE_LOGGER.warning(
+            'Containers not part of facts, collecting CV version')
+        containers = module.client.api.get_containers()['data']
+
+    # Create list of configlets
+    if 'configlets' in configlets_and_mappers:
+        for configlet in configlets_and_mappers['configlets']:
+            configlet['devices'] = list()
+            configlet['containers'] = list()
+            # Parse mapper section to locate potential mappings to devices and containers.
+            MODULE_LOGGER.info('building list of mapping with devices and containers for configlet %s', str(configlet['name']))
+            for mapper in configlets_and_mappers['configletMappers']:
+                # If mapper is tied to our configlet
+                if mapper['configletId'] == configlet['key']:
+                    # If mapper is for device
+                    if mapper['type'] == 'netelement':
+                        device_hostname = find_hostname_by_mac(inventory=inventory, mac_address=mapper['objectId'])
+                        if device_hostname is not None:
+                            MODULE_LOGGER.debug('found mapping to device %s', str(device_hostname))
+                            configlet['devices'].append(device_hostname)
+                    # If mapper is for container
+                    if mapper['type'] == 'container':
+                        container_name = find_containerName_by_containerId(containers_list=containers,
+                                                                            container_id=mapper['objectId'])
+                        if container_name is not None:
+                            MODULE_LOGGER.debug(
+                                'found mapping to container %s', str(container_name))
+                            configlet['containers'].append(container_name)
+            facts['configlets'].append(configlet)
+    else:
+        MODULE_LOGGER.error('No configlet found on CVP')
+    MODULE_LOGGER.info('All configlets facts collected')
     return facts
 
 
@@ -368,17 +453,25 @@ def facts_builder(module, debug=False):
             logging.debug('** Collecting devices facts ...')
         facts = facts_devices(module=module, facts=facts, debug=debug)
 
+<<<<<<< HEAD
     # Extract configlet information
     if 'all' in module.params['facts'] or 'configlets' in module.params['facts']:
         if debug:
             logging.debug('** Collecting configlets facts ...')
         facts = facts_configlets(module=module, facts=facts, debug=debug)
 
+=======
+>>>>>>> 7ccdac6... Update cv_facts to speed up process (#147)
     # Extract containers information
     if 'all' in module.params['facts'] or 'containers' in module.params['facts']:
         if debug:
             logging.debug('** Collecting containers facts ...')
         facts = facts_containers(module=module, facts=facts, debug=debug)
+
+    # Extract configlet information
+    if 'all' in module.params['facts'] or 'configlets' in module.params['facts']:
+        MODULE_LOGGER.info('** Collecting configlets facts ...')
+        facts = facts_configlets(module=module, facts=facts)
 
     # Extract tasks information
     if 'all' in module.params['facts'] or 'tasks' in module.params['facts']:


### PR DESCRIPTION
Update cv_facts to speed up process (#147)

Rewrite `def facts_configlets` to use `get_configlets_and_mappers` function
and reduce number of API call.

No change in inputs and outputs.

Test cases:
-----------
- Manual cv_facts tasks
- AVD integration

Execution time enhacement:
--------------------------
- Original implementation: 6 sec
- New version: 0.3 sec

test setup:
-----------
- 8 devices
- 16 configlets
- 10 containers
