### PR TITLE
Issues/147 facts execution time

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/cv_api2018.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/cv_api2018.py
@@ -614,6 +614,13 @@ class CvpApi(object):
                 configlet['config'] = full_cfglt_data['config']
         return configlets
 
+    def get_configlets_and_mappers(self):
+        '''
+        Return a list of all defined configlets and associated mappers
+        '''
+        self.log.debug('getConfigletsAndAssociatedMappers')
+        return self.clnt.get('/configlet/getConfigletsAndAssociatedMappers.do')
+
     def get_devices_by_configlet(self, configlet_name, start=0, end=0):
         ''' Returns a list of devices to which the named configlet is applied.
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/cv_api2019.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/cv_api2019.py
@@ -617,6 +617,13 @@ class CvpApi(object):
                 configlet['config'] = full_cfglt_data['config']
         return configlets
 
+    def get_configlets_and_mappers(self):
+        '''
+        Return a list of all defined configlets and associated mappers
+        '''
+        self.log.debug('getConfigletsAndAssociatedMappers')
+        return self.clnt.get('/configlet/getConfigletsAndAssociatedMappers.do')
+
     def get_devices_by_configlet(self, configlet_name, start=0, end=0):
         ''' Returns a list of devices to which the named configlet is applied.
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/logger.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/logger.py
@@ -49,7 +49,7 @@ LOGGING_FILENAME = os.getenv(
 
 # set a format which is simpler for console use
 formatter = logging.Formatter(
-    '%(name)-12s: %(levelname)-s - func: %(funcName)-12s (L:%(lineno)-3d) - %(message)s')
+    '%(asctime)s - %(name)-12s: %(levelname)-s - func: %(funcName)-12s (L:%(lineno)-3d) - %(message)s')
 
 # set up ROOT handler to use logging with file rotation.
 handler = logging.handlers.RotatingFileHandler(

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools_inventory.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools_inventory.py
@@ -1,0 +1,49 @@
+import logging
+import ansible_collections.arista.cvp.plugins.module_utils.logger
+
+MODULE_LOGGER = logging.getLogger('arista.cvp.tools_inventory')
+
+def find_hostname_by_mac(inventory, mac_address):
+    """
+    Function to get device hostname based on System Mac Address.
+
+    Parameters
+    ----------
+    inventory : list
+        Inventory list extracted from CVP.
+    mac_address : string
+        Mac address to search
+
+    Returns
+    -------
+    string
+        Device hostname. Default None if not found
+    """
+    for device in inventory:
+        if 'systemMacAddress' in device:
+            if device['systemMacAddress'] == mac_address:
+                return device['name']
+    return None
+
+
+def find_containerName_by_containerId(containers_list, container_id):
+    """
+    Function to get containername based on container ID.
+
+    Parameters
+    ----------
+    containers_list : list
+        Containers list extracted from CVP.
+    container_id : string
+        ID of the container to search
+
+    Returns
+    -------
+    string
+        Container name. Default None if not found
+    """
+    for container in containers_list:
+        if 'Key' in container:
+            if container['Key'] == container_id:
+                return container['Name']
+    return None

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools_inventory.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools_inventory.py
@@ -1,7 +1,32 @@
+#!/usr/bin/env python
+# coding: utf-8 -*-
+#
+# FIXME: required to pass ansible-test
+# GNU General Public License v3.0+
+#
+# Copyright 2019 Arista Networks AS-EMEA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 import logging
 import ansible_collections.arista.cvp.plugins.module_utils.logger
 
 MODULE_LOGGER = logging.getLogger('arista.cvp.tools_inventory')
+
 
 def find_hostname_by_mac(inventory, mac_address):
     """

--- a/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
@@ -35,7 +35,7 @@ from ansible_collections.arista.cvp.plugins.module_utils.cv_client_errors import
 from ansible_collections.arista.cvp.plugins.module_utils.tools_inventory import (
     find_hostname_by_mac,
     find_containerName_by_containerId
-    )
+)
 import ansible_collections.arista.cvp.plugins.module_utils.logger
 
 DOCUMENTATION = r'''
@@ -308,7 +308,7 @@ def facts_configlets(module, facts):
                     # If mapper is for container
                     if mapper['type'] == 'container':
                         container_name = find_containerName_by_containerId(containers_list=containers,
-                                                                            container_id=mapper['objectId'])
+                                                                           container_id=mapper['objectId'])
                         if container_name is not None:
                             MODULE_LOGGER.debug(
                                 'found mapping to container %s', str(container_name))


### PR DESCRIPTION
Update cv_facts to speed up process (#147)

Rewrite `def facts_configlets` to use `get_configlets_and_mappers` function
and reduce number of API call.

No change in inputs and outputs.

Test cases:
-----------
- Manual cv_facts tasks
- AVD integration

Execution time enhacement:
--------------------------
- Original implementation: 6 sec
- New version: 0.3 sec

test setup:
-----------
- 8 devices
- 16 configlets
- 10 containers
