### PR TITLE
Features/cv containers delete configlets

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/cv_api2018.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/cv_api2018.py
@@ -19,6 +19,13 @@
 # limitations under the License.
 #
 
+# pylint: disable=redefined-builtin
+# pylint: disable=too-many-public-methods
+# pylint: disable=too-many-lines
+# pylint: disable=invalid-name
+# pylint: disable=C0103
+
+
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
@@ -26,7 +33,6 @@ __metaclass__ = type
 '''
 import os
 # This import is for proper file IO handling support for both Python 2 and 3
-# pylint: disable=redefined-builtin
 from io import open
 
 from ansible_collections.arista.cvp.plugins.module_utils.cv_client_errors import CvpApiError
@@ -63,8 +69,6 @@ class CvpApi(object):
             failed and no session could be established to a CVP node.  Destroy
             the class and re-instantiate.
     '''
-    # pylint: disable=too-many-public-methods
-    # pylint: disable=too-many-lines
 
     def __init__(self, clnt, request_timeout=30):
         ''' Initialize the class.
@@ -145,7 +149,7 @@ class CvpApi(object):
         try:
             element_info = self.clnt.get('/provisioning/getNetElementInfoById.do?netElementId=%s'
                                          % qplus(device_id), timeout=self.request_timeout)
-        except CvpApiError as e:
+        except CvpApiError as e:  # pylint: disable=invalid-name
             # Catch an invalid task_id error and return None
             if 'errorMessage' in str(e):
                 self.log.debug('Device with id %s could not be found' % device_id)
@@ -306,7 +310,7 @@ class CvpApi(object):
                'format=topology&queryParam=&nodeId=root')
         try:
             self.clnt.post(url, data=data, timeout=self.request_timeout)
-        except Exception as e:
+        except Exception as e:  # pylint: disable=invalid-name
             self.log.debug('Device %s : %s' % (device['fqdn'], e))
             raise Exception("update_configlets_on_device:%s" % e)
         configlets = []
@@ -319,7 +323,7 @@ class CvpApi(object):
             tasks = {}
         return tasks
 
-    def update_imageBundle_on_device(self, app_name, device, add_imageBundle, del_imageBundle, create_task=True):
+    def update_imageBundle_on_device(self, app_name, device, add_imageBundle, del_imageBundle, create_task=True):  # pylint: disable=invalid-name
         ''' Remove the image bundle from the specified container.
 
             Args:
@@ -376,7 +380,7 @@ class CvpApi(object):
                    'format=topology&queryParam=&nodeId=root')
             try:
                 self.clnt.post(url, data=data, timeout=self.request_timeout)
-            except Exception as e:
+            except Exception as e:  # pylint: disable=invalid-name
                 # pylint: disable=unreachable
                 raise Exception("update_imageBundle_on_device:%s" % e)
                 self.log.debug('Device %s : %s' % (device['fqdn'], e))
@@ -431,11 +435,11 @@ class CvpApi(object):
                'format=topology&queryParam=&nodeId=root')
         try:
             self.clnt.post(url, data=data, timeout=self.request_timeout)
-        except CvpApiError as e:
+        except CvpApiError as e:  # pylint: disable=invalid-name
             if any(txt in str(e) for txt in ['Data already exists', 'undefined container']):
                 self.log.debug('Device %s already in container Undefined'
                                % device['fqdn'])
-        except Exception as e:
+        except Exception as e:  # pylint: disable=invalid-name
             self.log.debug('Reset Device %s : %s' % (device['fqdn'], e))
             raise Exception("reset_device:%s" % e)
         if create_task:
@@ -443,7 +447,7 @@ class CvpApi(object):
             tasks = self.clnt.post(url, data=[], timeout=self.request_timeout)
             return tasks
 
-    def provision_device(self, app_name, device, container, configlets, imageBundle, create_task=True):
+    def provision_device(self, app_name, device, container, configlets, imageBundle, create_task=True):  # pylint: disable=invalid-name
         '''Move a device from the undefined container to a target container.
             Optionally apply device-specific configlets and an imageBundle.
 
@@ -476,7 +480,7 @@ class CvpApi(object):
         try:
             self.move_device_to_container('%s:provision_device' % app_name, device, container,
                                           create_task=False)
-        except Exception as e:
+        except Exception as e:  # pylint: disable=invalid-name
             self.log.debug('Provision Device - move %s : %s' % (device['fqdn'], e))
             raise Exception("provsion_device-move_to_container:%s" % e)
         # Don't save configlet action if there is an image bundle to add
@@ -489,7 +493,7 @@ class CvpApi(object):
         try:
             created_tasks = self.update_configlets_on_device(app_name, device, configlets, [],
                                                              configlet_task)
-        except Exception as e:
+        except Exception as e:  # pylint: disable=invalid-name
             self.log.debug('Provision Device - configlets %s : %s' % (device['fqdn'], e))
             raise Exception("provsion_device-update_configlets:%s" % e)
         # If configlet action created tasks then don't action imageBundles
@@ -498,7 +502,7 @@ class CvpApi(object):
             try:
                 created_tasks = self.update_imageBundle_on_device(app_name, device, imageBundle, {},
                                                                   create_task)
-            except Exception as e:
+            except Exception as e:  # pylint: disable=invalid-name
                 self.log.debug('Provision Device - imageBundle %s : %s' % (device['fqdn'], e))
                 raise Exception("provsion_device-update_imageBundle:%s" % e)
         return created_tasks

--- a/ansible_collections/arista/cvp/plugins/module_utils/cv_api2018.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/cv_api2018.py
@@ -579,6 +579,84 @@ class CvpApi(object):
         else:
             return data
 
+    # pylint: disable=too-many-locals
+    # pylint: disable=invalid-name
+    def remove_configlets_from_container(self, app_name, container,
+                                         del_configlets, create_task=True):
+        ''' Remove the configlets from the container.
+            Args:
+                app_name (str): The application name to use in info field.
+                container (dict): The container dict
+                del_configlets (list): List of configlet name and key pairs
+                create_task (bool): Determines whether or not to execute a save
+                    and create the tasks (if any)
+            Returns:
+                response (dict): A dict that contains a status and a list of
+                    task ids created (if any).
+                    Ex: {u'data': {u'status': u'success', u'taskIds': [u'35']}}
+        '''
+        self.log.debug(
+            'remove_configlets_from_container: container: %s names: %s' %
+            (container, del_configlets))
+
+        # Get all the configlets assigned to the device.
+        configlets = self.get_configlets_by_container_id(container['key'])
+
+        # Get a list of the names and keys of the configlets.  Do not add
+        # configlets that are on the delete list.
+        keep_names = []
+        keep_keys = []
+        for configlet in configlets['configletList']:
+            key = configlet['key']
+            if next((ent for ent in del_configlets if ent['key'] == key),
+                    None) is None:
+                keep_names.append(configlet['name'])
+                keep_keys.append(key)
+
+        # Remove the names and keys of the configlets to keep and build a
+        # list of the configlets to remove.
+        del_names = []
+        del_keys = []
+        for entry in del_configlets:
+            del_names.append(entry['name'])
+            del_keys.append(entry['key'])
+
+        info = '%s Configlet Remove: from Container %s' % (app_name,
+                                                           container['name'])
+        info_preview = '<b>Configlet Remove:</b> from Container' + container[
+            'name']
+        data = {'data': [{'info': info,
+                          'infoPreview': info_preview,
+                          'note': '',
+                          'action': 'associate',
+                          'nodeType': 'configlet',
+                          'nodeId': '',
+                          'configletList': keep_keys,
+                          'configletNamesList': keep_names,
+                          'ignoreConfigletNamesList': del_names,
+                          'ignoreConfigletList': del_keys,
+                          'configletBuilderList': [],
+                          'configletBuilderNamesList': [],
+                          'ignoreConfigletBuilderList': [],
+                          'ignoreConfigletBuilderNamesList': [],
+                          'toId': container['key'],
+                          'toIdType': 'container',
+                          'fromId': '',
+                          'nodeName': '',
+                          'fromName': '',
+                          'toName': container['name'],
+                          'nodeIpAddress': '',
+                          'nodeTargetIpAddress': '',
+                          'childTasks': [],
+                          'parentTask': ''}]}
+        self.log.debug(
+            'remove_configlets_from_container: saveTopology data:\n%s'
+            % data['data'])
+        self._add_temp_action(data)
+        if create_task:
+            return self._save_topology_v2([])
+        return data
+
     # ~Configlet Related API Calls
 
     def get_configlet_by_name(self, name):

--- a/ansible_collections/arista/cvp/plugins/module_utils/cv_api2019.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/cv_api2019.py
@@ -147,7 +147,7 @@ class CvpApi(object):
         try:
             element_info = self.clnt.get('/provisioning/getNetElementInfoById.do?netElementId=%s'
                                          % qplus(device_id), timeout=self.request_timeout)
-        except CvpApiError as e:
+        except CvpApiError as e:  # pylint: disable=invalid-name
             # Catch an invalid task_id error and return None
             if 'errorMessage' in str(e):
                 self.log.debug('Device with id %s could not be found' % device_id)
@@ -309,7 +309,7 @@ class CvpApi(object):
                'format=topology&queryParam=&nodeId=root')
         try:
             self.clnt.post(url, data=data, timeout=self.request_timeout)
-        except Exception as e:
+        except Exception as e:  # pylint: disable=invalid-name
             self.log.debug('Device %s : %s' % (device['fqdn'], e))
             raise Exception("update_configlets_on_device:%s" % e)
         configlets = []
@@ -322,7 +322,7 @@ class CvpApi(object):
             tasks = {}
         return tasks
 
-    def update_imageBundle_on_device(self, app_name, device, add_imageBundle, del_imageBundle, create_task=True):
+    def update_imageBundle_on_device(self, app_name, device, add_imageBundle, del_imageBundle, create_task=True):  # pylint: disable=invalid-name
         ''' Remove the image bundle from the specified container.
 
             Args:
@@ -379,7 +379,7 @@ class CvpApi(object):
                    'format=topology&queryParam=&nodeId=root')
             try:
                 self.clnt.post(url, data=data, timeout=self.request_timeout)
-            except Exception as e:
+            except Exception as e:  # pylint: disable=invalid-name
                 # pylint: disable=unreachable
                 raise Exception("update_imageBundle_on_device:%s" % e)
                 self.log.debug('Device %s : %s' % (device['fqdn'], e))
@@ -434,11 +434,11 @@ class CvpApi(object):
                'format=topology&queryParam=&nodeId=root')
         try:
             self.clnt.post(url, data=data, timeout=self.request_timeout)
-        except CvpApiError as e:
+        except CvpApiError as e:  # pylint: disable=invalid-name
             if any(txt in str(e) for txt in ['Data already exists', 'undefined container']):
                 self.log.debug('Device %s already in container Undefined'
                                % device['fqdn'])
-        except Exception as e:
+        except Exception as e:  # pylint: disable=invalid-name
             self.log.debug('Reset Device %s : %s' % (device['fqdn'], e))
             raise Exception("reset_device:%s" % e)
         if create_task:
@@ -446,7 +446,7 @@ class CvpApi(object):
             tasks = self.clnt.post(url, data=[], timeout=self.request_timeout)
             return tasks
 
-    def provision_device(self, app_name, device, container, configlets, imageBundle, create_task=True):
+    def provision_device(self, app_name, device, container, configlets, imageBundle, create_task=True):  # pylint: disable=invalid-name
         '''Move a device from the undefined container to a target container.
             Optionally apply device-specific configlets and an imageBundle.
 
@@ -479,7 +479,7 @@ class CvpApi(object):
         try:
             self.move_device_to_container('%s:provision_device' % app_name, device, container,
                                           create_task=False)
-        except Exception as e:
+        except Exception as e:  # pylint: disable=invalid-name
             self.log.debug('Provision Device - move %s : %s' % (device['fqdn'], e))
             raise Exception("provsion_device-move_to_container:%s" % e)
         # Don't save configlet action if there is an image bundle to add
@@ -492,7 +492,7 @@ class CvpApi(object):
         try:
             created_tasks = self.update_configlets_on_device(app_name, device, configlets, [],
                                                              configlet_task)
-        except Exception as e:
+        except Exception as e:  # pylint: disable=invalid-name
             self.log.debug('Provision Device - configlets %s : %s' % (device['fqdn'], e))
             raise Exception("provsion_device-update_configlets:%s" % e)
         # If configlet action created tasks then don't action imageBundles
@@ -501,7 +501,7 @@ class CvpApi(object):
             try:
                 created_tasks = self.update_imageBundle_on_device(app_name, device, imageBundle, {},
                                                                   create_task)
-            except Exception as e:
+            except Exception as e:  # pylint: disable=invalid-name
                 self.log.debug('Provision Device - imageBundle %s : %s' % (device['fqdn'], e))
                 raise Exception("provsion_device-update_imageBundle:%s" % e)
         return created_tasks

--- a/ansible_collections/arista/cvp/plugins/module_utils/cv_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/cv_tools.py
@@ -22,11 +22,11 @@
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
-
 import re
 import logging
 
 LOGGER = logging.getLogger('arista.cvp.cv_tools')
+
 
 def isIterable(testing_object=None):
     """

--- a/ansible_collections/arista/cvp/plugins/module_utils/cv_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/cv_tools.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+# coding: utf-8 -*-
+#
+# FIXME: required to pass ansible-test
+# GNU General Public License v3.0+
+#
+# Copyright 2019 Arista Networks AS-EMEA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import re
+import logging
+
+LOGGER = logging.getLogger('arista.cvp.cv_tools')
+
+def isIterable(testing_object=None):
+    """
+    Test if an object is iterable or not.
+
+    Test if an object is iterable or not. If yes return True, else return False.
+
+    Parameters
+    ----------
+    testing_object : any, optional
+        Object to test if it is iterable or not, by default None
+
+    """
+    try:
+        some_object_iterator = iter(testing_object)
+        return True
+    except TypeError as te:
+        return False
+
+
+def match_filter(input, filter, default_always='all', default_none='none'):
+    """
+    Function to test if an object match userdefined filter.
+
+    Function support list of string and string as filter.
+    A default value is provided when calling function and if this default value for always matching is configured by user, then return True (Always matching)
+    If filter is a list, then we iterate over the input and check if it matches an entry in the filter.
+
+    Parameters
+    ----------
+    input : string
+        Input to test of that match filter or not.
+    filter : list
+        List of string to compare against input.
+    default_always : str, optional
+        Keyword to consider as always matching, by default 'all'
+    default_none : str, optional
+        Keyword to consider as never matching, by default 'none'
+
+    Returns
+    -------
+    [type]
+        [description]
+    """
+
+    # W102 Workaround to avoid list as default value.
+    if filter is None:
+        LOGGER.critical('Filter is not set, configure default value to [\'all\']')
+        filter = ["all"]
+
+    LOGGER.debug(" * is_in_filter - filter is %s", str(filter))
+    LOGGER.debug(" * is_in_filter - input string is %s", str(input))
+
+    if "all" in filter:
+        return True
+    elif any(element in input for element in filter):
+        return True
+    LOGGER.debug(" * is_in_filter - NOT matched")
+    return False

--- a/ansible_collections/arista/cvp/plugins/module_utils/cv_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/cv_tools.py
@@ -47,7 +47,7 @@ def isIterable(testing_object=None):
         return False
 
 
-def match_filter(input, filter, default_always='all', default_none='none'):
+def match_filter(input, filter, default_always='all'):
     """
     Function to test if an object match userdefined filter.
 
@@ -68,8 +68,8 @@ def match_filter(input, filter, default_always='all', default_none='none'):
 
     Returns
     -------
-    [type]
-        [description]
+    bool
+        True if input matchs filter, False in other situation
     """
 
     # W102 Workaround to avoid list as default value.

--- a/ansible_collections/arista/cvp/plugins/modules/cv_container.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_container.py
@@ -904,7 +904,7 @@ def configure_configlet_to_container(module, intended, facts):
             container_name=container_name, facts=facts)
         MODULE_LOGGER.info('get container info: %s for container %s', str(
             container_info_cvp), str(container_name))
-        if 'configlets' in container_info_cvp:
+        if container_info_cvp is not None and 'configlets' in container_info_cvp:
             for configlet in container_info_cvp['configlets']:
                 # If configlet matchs filter, we just remove attachement.
                 match_filter = cv_tools.match_filter(

--- a/ansible_collections/arista/cvp/plugins/modules/cv_container.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_container.py
@@ -908,7 +908,7 @@ def configure_configlet_to_container(module, intended, facts):
             for configlet in container_info_cvp['configlets']:
                 # If configlet matchs filter, we just remove attachement.
                 match_filter = cv_tools.match_filter(
-                    input=configlet, filter=configlet_filter, default_none='all', default_always='none')
+                    input=configlet, filter=configlet_filter, default_always='none')
                 MODULE_LOGGER.info('Filter test has returned: %s - Filter is %s - input is %s', str(match_filter), str(configlet_filter), str(configlet))
                 # If configlet is not in intended and does not match filter, ignore it
                 # If filter is set to ['none'], we consider to NOT touch attachment in any situation.

--- a/ansible_collections/arista/cvp/plugins/modules/cv_container.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_container.py
@@ -34,6 +34,7 @@ import json
 import traceback
 import logging
 import ansible_collections.arista.cvp.plugins.module_utils.logger
+import ansible_collections.arista.cvp.plugins.module_utils.cv_tools as cv_tools
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection, ConnectionError
 from ansible_collections.arista.cvp.plugins.module_utils.cv_client import CvpClient
@@ -79,6 +80,14 @@ options:
       - override
       - delete
     type: str
+  configlet_filter:
+    description: Filter to apply intended set of configlet on containers.
+                 If not used, then module only uses ADD mode. configlet_filter
+                 list configlets that can be modified or deleted based
+                 on configlets entries.
+    required: false
+    default: ['none']
+    type: list
 '''
 
 EXAMPLES = r'''
@@ -790,7 +799,7 @@ def configlet_factinfo(configlet_name, facts):
     return None
 
 
-def attached_configlet_to_container(module, intended, facts):
+def configure_configlet_to_container(module, intended, facts):
     """
     Attached existing configlet to desired containers based on topology.
 
@@ -812,55 +821,130 @@ def attached_configlet_to_container(module, intended, facts):
     attached = dict()
     #  Number of configlets attached to containers.
     attached['configlet_attached'] = 0
+    #  List of configlets detached by this function
+    detached_configlet = list()
+    #  Structure to save list of configlets detached and number of moved
+    detached = dict()
+    #  Number of configlets detached from containers.
+    detached['configlet_detached'] = 0
     #  List of created taskIds to pass to cv_tasks
     task_ids = list()
     # List of configlets to attach to containers
-    configlet_list = list()
+    configlet_list_attach = list()
+    # List of configlets to detach from containers.
+    configlet_list_detach = list()
     # Define wether we want to save topology or not
     # Force to True as per issue115
     save_topology = True
+    # Configlet filter
+    configlet_filter = module.params['configlet_filter']
     # Read complete intended topology to locate devices
     for container_name, container in intended.items():
         MODULE_LOGGER.info('work with container %s', str(container_name))
         # If we have at least one configlet defined, then we can start process
         # Get CVP information for target container.
         container_info_cvp = container_info(container_name=container_name, module=module)
-        # container_info_facts = container_factinfo(container_name=container_name, facts=facts)
         if 'configlets' in container:
             MODULE_LOGGER.debug('container has a list of containers to configure: %s', str(container['configlets']))
             # Extract list of configlet names
             for configlet in container['configlets']:
-                MODULE_LOGGER.debug('collecting information for configlet %s', str(configlet))
-                # Get CVP information for device.
-                configlet_cvpinfo = configlet_factinfo(configlet_name=configlet, facts=facts)
-                # Configlet information is saved for later deployment
-                configlet_list.append(configlet_cvpinfo)
-                MODULE_LOGGER.debug('configlet_list is now: %s', str(configlet_list))
+                MODULE_LOGGER.debug('running configlet %s', str(configlet))
+                # We apply filter to know if we have to attach configlet.
+                # If filter is set to ['none'], we consider add in any situation.
+                if cv_tools.match_filter(input=configlet, filter=configlet_filter) or('none' in configlet_filter):
+                    MODULE_LOGGER.debug('collecting information for configlet %s', str(configlet))
+                    # Get CVP information for device.
+                    configlet_cvpinfo = configlet_factinfo(configlet_name=configlet, facts=facts)
+                    # Configlet information is saved for later deployment
+                    configlet_list_attach.append(configlet_cvpinfo)
+                    MODULE_LOGGER.debug('configlet_list_attach is now: %s', str(configlet_list_attach))
         # Create call to attach list of containers
         # Initiate a move to desired container.
         # Task is created but not executed.
+        # Create debug output structure
         configlets_name = list()
-        for configlet in configlet_list:
+        for configlet in configlet_list_attach:
             configlets_name.append(configlet['name'])
-        MODULE_LOGGER.info('Apply %s to %s', str(configlets_name), str(container_info_cvp['name']))
-        configlet_action = module.client.api.apply_configlets_to_container(app_name="ansible_cv_container",
-                                                                           new_configlets=configlet_list,
-                                                                           container=container_info_cvp,
-                                                                           create_task=save_topology)
-        # Release list of configlet to configure (#165)
-        configlet_list = list()
-        if 'data' in configlet_action and configlet_action['data']['status'] == 'success':
-            if 'taskIds' in configlet_action['data']:
-                for task in configlet_action['data']['taskIds']:
-                    task_ids.append(task)
-            if len(configlet_list) > 0:
-                attached_configlet.append(configlet_list)
-                attached['configlet_attached'] = attached['configlet_attached'] + 1
+        # Configure new configlet to container
+        if len(configlet_list_attach) > 0:
+            MODULE_LOGGER.info('Apply %s to %s', str(configlets_name), str(container_info_cvp['name']))
+            configlet_action = module.client.api.apply_configlets_to_container(app_name="ansible_cv_container",
+                                                                               new_configlets=configlet_list_attach,
+                                                                               container=container_info_cvp,
+                                                                               create_task=save_topology)
+            # Release list of configlet to configure (#165)
+            configlet_list_attach = list()
+            if 'data' in configlet_action and configlet_action['data']['status'] == 'success':
+                if 'taskIds' in configlet_action['data']:
+                    for task in configlet_action['data']['taskIds']:
+                        task_ids.append(task)
+                if len(configlet_list_attach) > 0:
+                    attached_configlet.append(configlet_list_attach)
+                    attached['configlet_attached'] = attached['configlet_attached'] + 1
+
+        # Remove configlets from containers
+        # def remove_configlets_from_container(self, app_name, container,del_configlets, create_task=True):
+        container_info_cvp = container_factinfo(
+            container_name=container_name, facts=facts)
+        MODULE_LOGGER.info('get container info: %s for container %s', str(
+            container_info_cvp), str(container_name))
+        if 'configlets' in container_info_cvp:
+            for configlet in container_info_cvp['configlets']:
+                # If configlet matchs filter, we just remove attachement.
+                match_filter = cv_tools.match_filter(
+                    input=configlet, filter=configlet_filter, default_none='all', default_always='none')
+                MODULE_LOGGER.info('Filter test has returned: %s - Filter is %s - input is %s', str(match_filter), str(configlet_filter), str(configlet))
+                # If configlet is not in intended and does not match filter, ignore it
+                # If filter is set to ['none'], we consider to NOT touch attachment in any situation.
+                if match_filter is False and configlet not in container_factinfo(container_name=container, facts=facts)['configlets']:
+                    MODULE_LOGGER.warning('configlet does not match filter (%s) and is not in intended topology (%s)', str(
+                        configlet_filter), str(container_info_cvp['configlets']))
+                    continue
+                # If configlet is not part of intended list and match filter: we remove
+                container_factsinfo = container_factinfo(
+                    container_name=container_name, facts=facts)
+                # If there is no configlet found in facts, just skipping this section.
+                if 'configlets' not in container_factsinfo:
+                    MODULE_LOGGER.warning('container %s has no configlets attached - skipped', str(container))
+                    continue
+                if match_filter and configlet not in ['configlets']:
+                    MODULE_LOGGER.debug(
+                        'collecting information for configlet %s', str(configlet))
+                    # Get CVP information for device.
+                    configlet_cvpinfo = configlet_factinfo(configlet_name=configlet, facts=facts)
+                    # Configlet information is saved for later deployment
+                    MODULE_LOGGER.warning(
+                        'addind configlet %s to list of detach...', str(configlet))
+                    configlet_list_detach.append(configlet_cvpinfo)
+
+            # Create debug output structure
+            configlets_name = list()
+            for configlet in configlet_list_detach:
+                configlets_name.append(configlet['name'])
+            # Configure new configlet to container
+            if len(configlet_list_detach) > 0:
+                MODULE_LOGGER.info('Removing %s from %s', str(
+                    configlets_name), str(container_info_cvp['name']))
+                configlet_action = module.client.api.remove_configlets_from_container(app_name="ansible_cv_container",
+                                                                                      del_configlets=configlet_list_detach,
+                                                                                      container=container_info_cvp,
+                                                                                      create_task=save_topology)
+                # Release list of configlet to configure (#165)
+                configlet_list_detach = list()
+                if 'data' in configlet_action and configlet_action['data']['status'] == 'success':
+                    if 'taskIds' in configlet_action['data']:
+                        for task in configlet_action['data']['taskIds']:
+                            task_ids.append(task)
+                    if len(configlet_list_detach) > 0:
+                        detached_configlet.append(configlet_list_detach)
+                        detached['configlet_attached'] = detached['configlet_list_detach'] + 1
+
     # Build ansible output messages.
     attached['list'] = attached_configlet
     attached['taskIds'] = task_ids
     result['changed'] = True
     result['attached_configlet'] = attached
+    result['detached_configlet'] = detached
     return result
 
 
@@ -959,8 +1043,9 @@ def main():
     """ main entry point for module execution
     """
     argument_spec = dict(
-        topology=dict(type='dict', required=True),    # Topology to configure on CV side.
-        cvp_facts=dict(type='dict', required=True),   # Facts from cv_facts module.
+        topology=dict(type='dict', required=True),          # Topology to configure on CV side.
+        cvp_facts=dict(type='dict', required=True),         # Facts from cv_facts module.
+        configlet_filter=dict(type='list', default='none'),  # Filter to protect configlets to be detached
         mode=dict(type='str',
                   required=False,
                   default='merge',
@@ -1001,9 +1086,9 @@ def main():
                     result['data']['moved_result'] = move_process['moved_devices']
 
                 # -> Start process to move devices to targetted containers
-                attached_process = attached_configlet_to_container(module=module,
-                                                                   intended=module.params['topology'],
-                                                                   facts=module.params['cvp_facts'])
+                attached_process = configure_configlet_to_container(module=module,
+                                                                    intended=module.params['topology'],
+                                                                    facts=module.params['cvp_facts'])
                 if attached_process is not None:
                     result['data']['changed'] = True
                     # If a list of task exists, we expose it

--- a/ansible_collections/arista/cvp/plugins/modules/cv_container.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_container.py
@@ -801,7 +801,23 @@ def configlet_factinfo(configlet_name, facts):
 
 def configure_configlet_to_container(module, intended, facts):
     """
-    Attached existing configlet to desired containers based on topology.
+    Manage mechanism to attach and detach configlets from container.
+
+    Addition process:
+    -----------------
+    - if configlet from intended match filter: configlet is attached
+    - if configlet from intended does not match filter: configlet is
+    ignored
+    - configlet_filter = ['none'] filtering is ignored and configlet is
+    attached
+
+    Deletion process:
+    -----------------
+    - if configlet is not part of intended and filter is not matched: we do
+    not remove it
+    - if configlet is not part of intended and filter is matched: we
+    detach configlet.
+    - configlet_filter = ['none'], configet is ignored and not detached
 
     Parameters
     ----------
@@ -897,7 +913,7 @@ def configure_configlet_to_container(module, intended, facts):
                 # If configlet is not in intended and does not match filter, ignore it
                 # If filter is set to ['none'], we consider to NOT touch attachment in any situation.
                 if match_filter is False and configlet not in container_factinfo(container_name=container, facts=facts)['configlets']:
-                    MODULE_LOGGER.warning('configlet does not match filter (%s) and is not in intended topology (%s)', str(
+                    MODULE_LOGGER.warning('configlet does not match filter (%s) and is not in intended topology (%s), skipped', str(
                         configlet_filter), str(container_info_cvp['configlets']))
                     continue
                 # If configlet is not part of intended list and match filter: we remove
@@ -905,7 +921,7 @@ def configure_configlet_to_container(module, intended, facts):
                     container_name=container_name, facts=facts)
                 # If there is no configlet found in facts, just skipping this section.
                 if 'configlets' not in container_factsinfo:
-                    MODULE_LOGGER.warning('container %s has no configlets attached - skipped', str(container))
+                    MODULE_LOGGER.info('container %s has no configlets attached - skipped', str(container))
                     continue
                 if match_filter and configlet not in ['configlets']:
                     MODULE_LOGGER.debug(
@@ -1040,7 +1056,8 @@ def get_tasks(taskIds, module):
 
 
 def main():
-    """ main entry point for module execution
+    """
+    Main entry point for module execution.
     """
     argument_spec = dict(
         topology=dict(type='dict', required=True),          # Topology to configure on CV side.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->

## Proposed changes

cv_container now support option to remove configlet(s) from container by
using a new optional keyword. Meantime, this keyword allows user to also
filter configlets to attach to container

Module Behavior:
----------------

- Add new optional input: configlet_filter (list)
- Addition process:
  - if configlet from intended match filter: configlet is attached
  - if configlet from intended does not match filter: configlet is
  ignored
  - configlet_filter = ['none'] filtering is ignored and configlet is
  attached
- Deletion process:
  - if configlet is not part of intended and filter is not matched: we do
  not remove it
  - if configlet is not part of intended and filter is matched: we
  detach configlet.
  - configlet_filter = ['none'], configet is ignored and not detached

Well knows filter value:
------------------------

- `none`: fallback mechanism to merge (no deletion and add everything from intended)
- `all`: match all

Default value: `configlet_filter=['none']


## How to test

- __Attach configlets to containers__

```yaml
CVP_CONTAINERS:
  DC1_FABRIC:
    parent_container: Tenant
  DC1_L3LEAFS:
    parent_container: DC1_FABRIC
    configlets:
      - GLOBAL-ALIASES
      - GLOBAL-ALIASES2
```

With tasks:

```yaml
---
- name: Rebind configlet based on basic AVD
  hosts: cv_server
  connection: local
  gather_facts: false
  collections:
    - arista.avd
    - arista.cvp
  vars:
    container_root: 'DC1_FABRIC'
    configlets_prefix: 'DC1-AVD'
    device_filter: 'DC1'
    execute_tasks: false
  tasks:
    - name: 'Refreshing facts from CVP {{inventory_hostname}}.'
      arista.cvp.cv_facts:
      register: CVP_FACTS

    - name: "Building Containers topology on {{inventory_hostname}}"
      arista.cvp.cv_container:
        topology: '{{CVP_CONTAINERS}}'
        cvp_facts: '{{CVP_FACTS.ansible_facts}}'
        # configlet_filter: ['all'] == 'none'
```


- __Remove Container attachement__

```yaml
CVP_CONTAINERS:
  DC1_FABRIC:
    parent_container: Tenant
  DC1_L3LEAFS:
    parent_container: DC1_FABRIC
```

With tasks:

```yaml
---
- name: Rebind configlet based on basic AVD
  hosts: cv_server
  connection: local
  gather_facts: false
  collections:
    - arista.avd
    - arista.cvp
  vars:
    container_root: 'DC1_FABRIC'
    configlets_prefix: 'DC1-AVD'
    device_filter: 'DC1'
    execute_tasks: false
  tasks:
    - name: 'Refreshing facts from CVP {{inventory_hostname}}.'
      arista.cvp.cv_facts:
      register: CVP_FACTS

    - name: "Building Containers topology on {{inventory_hostname}}"
      arista.cvp.cv_container:
        topology: '{{CVP_CONTAINERS}}'
        cvp_facts: '{{CVP_FACTS.ansible_facts}}'
        configlet_filter: ['all']
```


## Checklist:
- [x] All new and existing tests passed (`make linting` and `make sanity-lint`).