### PR TITLE
Fix issue with cv_container and relative topology

### DIFF
--- a/ansible_collections/arista/cvp/plugins/modules/cv_container.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_container.py
@@ -890,10 +890,6 @@ def locate_relative_root_container(containers_topology):
     string
         Name of the relative root container. None if not found.
     """
-    if type(containers_topology) is list:
-        MODULE_LOGGER.critical('! ERROR - container_topology is a list -- expected a dict')
-    else:
-        MODULE_LOGGER.info('container_topology is a dict as expected')
     MODULE_LOGGER.debug('relative intended topology is: %s', str(containers_topology))
     for container_name, container in containers_topology.items():
         if container['parent_container'] not in containers_topology.keys():

--- a/ansible_collections/arista/cvp/plugins/modules/cv_container.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_container.py
@@ -58,7 +58,7 @@ version_added: "2.9"
 author: EMEA AS Team (@aristanetworks)
 short_description: Manage Provisioning topology.
 description:
-  - CloudVison Portal Configlet configuration requires a dictionary of containers with their parent,
+  - CloudVision Portal Configlet configuration requires a dictionary of containers with their parent,
     to create and delete containers on CVP side.
   - Returns number of created and/or deleted containers
 options:
@@ -161,7 +161,7 @@ def tree_to_list(json_data, myList):
     Example:
     --------
         >>> containers = {"Tenant": {"children": [{"Fabric": {"children": [{"Leaves": {"children": ["MLAG01", "MLAG02"]}}, "Spines"]}}]}}
-        >>> print tree_to_list(containers=containers, myList=lsit())
+        >>> print tree_to_list(containers=containers, myList=list())
         [u'Tenant', u'Fabric', u'Leaves', u'MLAG01', u'MLAG02', u'Spines']
 
     Parameters
@@ -169,7 +169,7 @@ def tree_to_list(json_data, myList):
     json_data : [type]
         [description]
     myList : list
-        Ordered list of element to create on CVP / recusrive function
+        Ordered list of element to create on CVP / recursive function
 
     Returns
     -------
@@ -483,7 +483,7 @@ def create_new_containers(module, intended, facts):
     # Build ordered list of containers to create: from Tenant to leaves.
     container_intended_tree = tree_build_from_dict(containers=intended, root=topology_root)
     container_intended_ordered_list = tree_to_list(json_data=container_intended_tree, myList=list())
-    # Parse ordered list of container and chek if they are configured on CVP.
+    # Parse ordered list of container and check if they are configured on CVP.
     # If not, then call container creation process.
     for container_name in container_intended_ordered_list:
         found = False
@@ -502,7 +502,7 @@ def create_new_containers(module, intended, facts):
             # If a container has been created, increment creation counter
             if response[0]:
                 count_container_creation += 1
-    # Build module message to retur for creation.
+    # Build module message to return for creation.
     if count_container_creation > 0:
         return [True, {'containers_created': "" + str(count_container_creation) + ""}]
     return [False, {'containers_created': "0"}]
@@ -643,7 +643,7 @@ def container_info(container_name, module):
     container_name : string
         Name of the container to look for on CVP side.
     module : AnsibleModule
-        Ansible module to get access to cvp cient.
+        Ansible module to get access to cvp client.
     Returns
     -------
     dict: Dict of container info from CVP or exit with failure if no info for
@@ -667,7 +667,7 @@ def device_info(device_name, module):
     device_name : string
         Name of the container to look for on CVP side.
     module : AnsibleModule
-        Ansible module to get access to cvp cient.
+        Ansible module to get access to cvp client.
     Returns
     -------
     dict: Dict of device info from CVP or exit with failure if no info for
@@ -763,7 +763,7 @@ def container_factinfo(container_name, facts):
     configlet_name : string
         Name of the container to look for on CVP side.
     module : AnsibleModule
-        Ansible module to get access to cvp cient.
+        Ansible module to get access to cvp client.
 
     Returns
     -------
@@ -785,7 +785,7 @@ def configlet_factinfo(configlet_name, facts):
     configlet_name : string
         Name of the container to look for on CVP side.
     module : AnsibleModule
-        Ansible module to get access to cvp cient.
+        Ansible module to get access to cvp client.
 
     Returns
     -------

--- a/docs/cv_configlet.md
+++ b/docs/cv_configlet.md
@@ -1,6 +1,14 @@
 # Manage Configlet content
 
-## Descrpition
+- [Manage Configlet content](#manage-configlet-content)
+  - [Description](#description)
+  - [Options](#options)
+  - [Usage](#usage)
+    - [Authentication](#authentication)
+    - [Inputs example](#inputs-example)
+    - [Result example](#result-example)
+
+## Description
 
 __Module name:__ `arista.cvp.cv_configlet`
 
@@ -14,12 +22,12 @@ Module comes with a set of options:
 - `cvp_facts`: Current facts collecting on CVP by a previous task
 - `configlet_filter`: Filter to apply configlet management. If configured, module will add/update/delete configlets matching entries. If not matching, module will ignore configlet configured on CVP. If option is not set, module will only work in `add` mode
 - `state`: Provide an option to delete configlets from CloudVision. Default value is present and it is an optional field.
-    - `present`: Create / update configlets from CV.
-    - `absent`: remove configlets from CV.
+  - `present`: Create / update configlets from CV.
+  - `absent`: remove configlets from CV.
 
 ## Usage
 
-__Authentication__
+### Authentication
 
 This module uses `HTTPAPI` connection plugin for authentication. These elements shall be declared using this plugin mechanism and are automatically shared with `arista.cvp.cv_*` modules.
 
@@ -37,7 +45,7 @@ ansible_network_os=eos
 ansible_httpapi_port=443
 ```
 
-__Inputs__
+### Inputs example
 
 Below is a basic playbook to collect facts:
 
@@ -59,7 +67,7 @@ Below is a basic playbook to collect facts:
       register: cvp_configlet
 ```
 
-__Result__
+### Result example
 
 Below is an example of expected output
 
@@ -88,5 +96,3 @@ msg:
       -alias a971 show version+alias b61 show version
   failed: false
 ```
-
-

--- a/docs/cv_device.md
+++ b/docs/cv_device.md
@@ -1,6 +1,16 @@
 # Manage device content
 
-## Descrpition
+- [Manage device content](#manage-device-content)
+  - [Description](#description)
+  - [Options](#options)
+  - [Usage](#usage)
+    - [Authentication](#authentication)
+    - [Inputs example](#inputs-example)
+    - [Result example](#result-example)
+  - [Use cases](#use-cases)
+    - [Reset devices to undefined container](#reset-devices-to-undefined-container)
+
+## Description
 
 __Module name:__ `arista.cvp.cv_device`
 
@@ -14,16 +24,16 @@ Module comes with a set of options:
 - `cvp_facts`: Current facts collecting on CVP by a previous task
 - `devices_filter`: Filter to apply intended mode on a set of configlet. If not used, then module only uses ADD mode. device_filter list devices that can be modified or deleted based on configlets entries.
 - `state`: . Provide an option to delete devices from topology and reset devices to undefined container. Default value is `present` and it is an optional field.
-    - `absent`: Reset devices.
-    - `present`: Configure devices.
+  - `absent`: Reset devices.
+  - `present`: Configure devices.
 - `configlet_fitler`: Allow user to select behaviour to apply on configlets attached to a device:
-    - `override`: (default) Configure list provided by user and remove any other configlets attached to device.
-    - `merge`: add configlets listed by user to the device and do not touch existing configlets.
-    - `delete`: Remove list of configlets from device and let other unchanged.
+  - `override`: (default) Configure list provided by user and remove any other configlets attached to device.
+  - `merge`: add configlets listed by user to the device and do not touch existing configlets.
+  - `delete`: Remove list of configlets from device and let other unchanged.
 
 ## Usage
 
-__Authentication__
+### Authentication
 
 This module uses `HTTPAPI` connection plugin for authentication. These elements shall be declared using this plugin mechanism and are automatically shared with `arista.cvp.cv_*` modules.
 
@@ -41,7 +51,7 @@ ansible_network_os=eos
 ansible_httpapi_port=443
 ```
 
-__Inputs__
+### Inputs example
 
 Below is a basic playbook to collect facts:
 
@@ -71,7 +81,7 @@ Below is a basic playbook to collect facts:
       register: cvp_device
 ```
 
-__Result__
+### Result example
 
 Below is an example of expected output
 
@@ -110,7 +120,6 @@ Below is an example of expected output
     }
 }
 ```
-
 
 ## Use cases
 

--- a/docs/cv_facts.md
+++ b/docs/cv_facts.md
@@ -1,6 +1,15 @@
 # Collecting Facts
 
-## Descrpition
+- [Collecting Facts](#collecting-facts)
+  - [Description](#description)
+    - [Facts limitation](#facts-limitation)
+    - [Facts subset](#facts-subset)
+  - [Usage](#usage)
+    - [Authentication](#authentication)
+    - [Inputs example](#inputs-example)
+    - [Result example](#result-example)
+
+## Description
 
 __Module name:__ `arista.cvp.cv_facts`
 
@@ -13,28 +22,29 @@ This module collects facts from CloudVision platform and return a dictionary for
 
 Module comes with 2 different options to allow user to select what information to retrieve from CVP:
 
-__Facts limitation:__
+### Facts limitation
 
 - __`facts`__: A list of facts to retrieve from CVP. it can be one or more entries from the list:
-    - `devices`
-    - `containers`
-    - `configlets`
-    - `tasks`. 
+  - `devices`
+  - `containers`
+  - `configlets`
+  - `tasks`.
+
 > If not specified, module will extract all this elements from CloudVision
 
-__Facts subset__
+### Facts subset
 
 - __`gather_subset`__: Allow user to extract an optional element from CloudVision.
-    - `config`: Add device configuration in device facts. If not set, configuration is skipped. (applicable if `devices` is part of __facts__)
-    - `tasks_pending`: Collect only facts from pending tasks on CloudVision. (applicable if `tasks` is part of __facts__)
-    - `tasks_failed`: Collect only failed tasks information. (applicable if `tasks` is part of __facts__)
-    - `tasks_all`: Collect all tasks information from CVP. (applicable if `tasks` is part of __facts__)
+  - `config`: Add device configuration in device facts. If not set, configuration is skipped. (applicable if `devices` is part of __facts__)
+  - `tasks_pending`: Collect only facts from pending tasks on CloudVision. (applicable if `tasks` is part of __facts__)
+  - `tasks_failed`: Collect only failed tasks information. (applicable if `tasks` is part of __facts__)
+  - `tasks_all`: Collect all tasks information from CVP. (applicable if `tasks` is part of __facts__)
 
 Module supports inactive devices and 3rd part devices: When `gather_subset: config` is defined, only devices with flag `"streamingStatus": "active"` have their configuration collected into the facts.
 
 ## Usage
 
-__Authentication__
+### Authentication
 
 This module uses `HTTPAPI` connection plugin for authentication. These elements shall be declared using this plugin mechanism and are automatically shared with `arista.cvp.cv_*` modules.
 
@@ -52,7 +62,7 @@ ansible_network_os=eos
 ansible_httpapi_port=443
 ```
 
-__Inputs__
+### Inputs example
 
 Below is a basic playbook to collect all facts:
 
@@ -89,14 +99,14 @@ Extracting device configuration in facts:
         facts:
           devices
         gather_subset:
-          condiguration
+          configuration
 
     - name: "Print out facts from CVP"
       debug:
         msg: "{{ansible_facts}}"
 ```
 
-__Result__
+### Result example
 
 Below is an example of output with default parameters
 
@@ -104,9 +114,9 @@ Below is an example of output with default parameters
 {
     "ansible_facts": {
         "cvp_info": {
-            "appVersion": "Foster_Build_03", 
+            "appVersion": "Foster_Build_03",
             "version": "2018.2.5"
-        }, 
+        },
         "configlets": [
             {
                 "name": "ANSIBLE_TESTING_CONTAINER",
@@ -290,5 +300,3 @@ Below is an example of output with default parameters
     }
 }
 ```
-
-

--- a/docs/cv_task.md
+++ b/docs/cv_task.md
@@ -1,6 +1,14 @@
 # Manage pending tasks on CVP
 
-## Descrpition
+- [Manage pending tasks on CVP](#manage-pending-tasks-on-cvp)
+  - [Description](#description)
+  - [Options](#options)
+  - [Usage](#usage)
+    - [Authentication](#authentication)
+    - [Inputs example](#inputs-example)
+    - [Result example](#result-example)
+
+## Description
 
 __Module name:__ `arista.cvp.cv_task`
 
@@ -16,7 +24,7 @@ Module comes with a set of options:
 
 ## Usage
 
-__Authentication__
+### Authentication
 
 This module uses `HTTPAPI` connection plugin for authentication. These elements shall be declared using this plugin mechanism and are automatically shared with `arista.cvp.cv_*` modules.
 
@@ -34,7 +42,7 @@ ansible_network_os=eos
 ansible_httpapi_port=443
 ```
 
-__Inputs__
+### Inputs example
 
 Below is a basic playbook to collect facts:
 
@@ -52,21 +60,19 @@ tasks:
         wait: 60
 ```
 
-__Result__
+### Result example
 
 Below is an example of expected output
 
 ```json
 {
     "msg": {
-        "changed": false, 
-        "data": {}, 
-        "failed": false, 
+        "changed": false,
+        "data": {},
+        "failed": false,
         "warnings": [
             "No actionable tasks found on CVP"
         ]
     }
 }
 ```
-
-


### PR DESCRIPTION
Summary:
--------
Update code to support deletion of container topology not using CVP root
container.

Deletion example:

```yaml
    CVP_CONTAINERS:
      POD01:
        parent_container: Leafs
```

Fix: #173

Tested with :
-------------
- Addition of a complete topology
- Deletion of POD01
- Creation with partial topology already deployed
- Deletion of full topology

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Related Issue(s)

Fix: #173

## Proposed changes
<!--- Describe your changes in detail -->

## How to test

1. Create topology:

```yaml
- name: Container Management in Cloudvision
  hosts: cv_server
  connection: local
  gather_facts: false
  collections:
    - arista.avd
    - arista.cvp
  vars:
    run_tasks: false
    run_mode: merge
    CVP_CONTAINERS:
      DC2:
        parent_container: Tenant
      Leafs:
        parent_container: DC2
      Spines:
        parent_container: DC2
      POD01:
        parent_container: Leafs

  tasks:
    - name: "collect CV facts on {{inventory_hostname}}"
      arista.cvp.cv_facts:
      register: CVP_FACTS

    - name: 'running cv_container in {{run_mode}} on {{inventory_hostname}}'
      arista.cvp.cv_container:
        cvp_facts: "{{CVP_FACTS.ansible_facts}}"
        topology: "{{CVP_CONTAINERS}}"
        mode: '{{run_mode}}'
      register: result

    - debug:
        msg: '{{result}}'
```

2. Delete topology

```yaml
- name: Container Management in Cloudvision
  hosts: cv_server
  connection: local
  gather_facts: false
  collections:
    - arista.avd
    - arista.cvp
  vars:
    run_tasks: false
    run_mode: delete
    CVP_CONTAINERS:
      POD01:
        parent_container: Leafs

  tasks:
    - name: "collect CV facts on {{inventory_hostname}}"
      arista.cvp.cv_facts:
      register: CVP_FACTS

    - name: 'running cv_container in {{run_mode}} on {{inventory_hostname}}'
      arista.cvp.cv_container:
        cvp_facts: "{{CVP_FACTS.ansible_facts}}"
        topology: "{{CVP_CONTAINERS}}"
        mode: '{{run_mode}}'
      register: result

    - debug:
        msg: '{{result}}'
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/aristanetworks/ansible-cvp/blob/master/contributing.md#branches) document.
- [x] All new and existing tests passed (`make linting` and `make sanity-lint`).