### PR TITLE
Issues/177 cv facts error code

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/cv_client.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/cv_client.py
@@ -440,7 +440,7 @@ class CvpClient(object):
                 CvpRequestError: A CvpRequestError is raised if the request
                     is not properly constructed.
                 CvpSessionLogOutError: A CvpSessionLogOutError is raised if
-                    reponse from server indicates session was logged out.
+                    response from server indicates session was logged out.
                 HTTPError: A HTTPError is raised if there was an invalid HTTP
                     response.
                 ReadTimeout: A ReadTimeout is raised if there was a request
@@ -506,7 +506,7 @@ class CvpClient(object):
                 CvpRequestError: A CvpRequestError is raised if the request
                     is not properly constructed.
                 CvpSessionLogOutError: A CvpSessionLogOutError is raised if
-                    reponse from server indicates session was logged out.
+                    response from server indicates session was logged out.
                 HTTPError: A HTTPError is raised if there was an invalid HTTP
                     response.
                 ReadTimeout: A ReadTimeout is raised if there was a request
@@ -594,7 +594,7 @@ class CvpClient(object):
                 CvpRequestError: A CvpRequestError is raised if the request
                     is not properly constructed.
                 CvpSessionLogOutError: A CvpSessionLogOutError is raised if
-                    reponse from server indicates session was logged out.
+                    response from server indicates session was logged out.
                 HTTPError: A HTTPError is raised if there was an invalid HTTP
                     response.
                 ReadTimeout: A ReadTimeout is raised if there was a request
@@ -709,7 +709,7 @@ class CvpClient(object):
                 CvpRequestError: A CvpRequestError is raised if the request
                     is not properly constructed.
                 CvpSessionLogOutError: A CvpSessionLogOutError is raised if
-                    reponse from server indicates session was logged out.
+                    response from server indicates session was logged out.
                 HTTPError: A HTTPError is raised if there was an invalid HTTP
                     response.
                 ReadTimeout: A ReadTimeout is raised if there was a request
@@ -748,7 +748,7 @@ class CvpClient(object):
                 CvpRequestError: A CvpRequestError is raised if the request
                     is not properly constructed.
                 CvpSessionLogOutError: A CvpSessionLogOutError is raised if
-                    reponse from server indicates session was logged out.
+                    response from server indicates session was logged out.
                 HTTPError: A HTTPError is raised if there was an invalid HTTP
                     response.
                 ReadTimeout: A ReadTimeout is raised if there was a request

--- a/ansible_collections/arista/cvp/plugins/module_utils/cv_client.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/cv_client.py
@@ -408,7 +408,9 @@ class CvpClient(object):
 
         joutput = response.json()
         # CVPRAC deviation related to issue #177
-        if self._finditem(obj=joutput, key='errorCode'):
+        errorCode_result = self._finditem(obj=joutput, key='errorCode')
+        if errorCode_result:
+            err_msg = errorCode_result
             if 'errorMessage' in joutput:
                 err_msg = joutput['errorMessage']
             else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue(s)

#177 

## Proposed changes

Instead of searching `errorCode` string in plain text requests response, a specific function do the search over the key in either `dict` or `list`

## How to test

- Create a configlet with `errorCode` in content
- Run following playbook:

```yaml
---
- name: CV Facts
  hosts: cv_server
  connection: local
  gather_facts: no
  collections:
    - arista.cvp
  vars:
    output_file: 'arista.cvp.facts.json'
  tasks:
    - name: "Gather CVP facts from {{inventory_hostname}}"
      arista.cvp.cv_facts:
      register: cvp_facts

    - name: 'Create File with Facts from {{inventory_hostname}}'
      copy:
        content: '{{ cvp_facts }}'
        dest: '{{output_file}}'
      delegate_to: localhost
```

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/aristanetworks/ansible-cvp/blob/master/contributing.md#branches) document.
- [x] All new and existing tests passed (`make linting` and `make sanity-lint`).