### PR TITLE
Fix #183 - Fix invalid fallback to port 80

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/cv_client.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/cv_client.py
@@ -285,7 +285,7 @@ class CvpClient(object):
         self._create_session(all_nodes=True)
         # Verify that we can connect to at least one node
         if not self.session:
-            self.log.error(' error connecting cvp: %s', str(self.error_msg))
+            self.log.error('error connecting to cvp: %s', str(self.error_msg.replace('\n','')))
             raise CvpLoginError(self.error_msg)
         else:
             # Instantiate the CvpApi class
@@ -307,15 +307,8 @@ class CvpClient(object):
             self.url_prefix = ('https://%s:%d/web' % (host, self.port or 443))
             error = self._reset_session()
             if error and not self.cert:
-                self.log.warning('Failed to connect over https. Potentially'
-                                 ' due to an old version of CVP. Attempting'
-                                 ' fallback to http. Error: %s', error)
-                # Attempt http fallback if no cert file is provided. The
-                # intention here is that a user providing a cert file
-                # forces https.
-                self.url_prefix = ('http://%s:%d/web'
-                                   % (host, self.port or 80))
-                error = self._reset_session()
+                self.log.error('error connecting to cvp (%s:%s)',
+                               host, str(self.port))
             if error is None:
                 break
             self.error_msg += '%s: %s\n' % (host, error)

--- a/ansible_collections/arista/cvp/plugins/module_utils/cv_client.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/cv_client.py
@@ -285,7 +285,7 @@ class CvpClient(object):
         self._create_session(all_nodes=True)
         # Verify that we can connect to at least one node
         if not self.session:
-            self.log.error('error connecting to cvp: %s', str(self.error_msg.replace('\n','')))
+            self.log.error('error connecting to cvp: %s', str(self.error_msg.replace('\n', '')))
             raise CvpLoginError(self.error_msg)
         else:
             # Instantiate the CvpApi class


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue(s)

#183 

## Test results

### Ansible output

```shell
ansible-playbook extract-facts.yml --extra-vars "output_file=arista1.cvp.facts.json"

PLAY [CV Facts] ****

TASK [Gather CVP facts from cv_server] ****
fatal: [cv_server]: FAILED! => changed=false 
  msg: |2-
  
    10.83.28.164: Authenticate: https://10.83.28.164:443/web/login/authenticate.do: Request Error: Invalid credentials

PLAY RECAP ****
cv_server                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```

### Python logging

```
2020-04-22 16:43:52,298 - arista.cvp.cv_client: ERROR - func: _is_good_response (L:420) - Authenticate: https://10.83.28.164:443/web/login/authenticate.do: Request Error: Invalid credentials
2020-04-22 16:43:52,298 - arista.cvp.cv_client: ERROR - func: _reset_session (L:330) - Authenticate: https://10.83.28.164:443/web/login/authenticate.do: Request Error: Invalid credentials
2020-04-22 16:43:52,298 - arista.cvp.cv_client: ERROR - func: _create_session (L:311) - error connecting to cvp (10.83.28.164:443)
2020-04-22 16:43:52,298 - arista.cvp.cv_client: ERROR - func: connect      (L:288) - error connecting to cvp: 10.83.28.164: Authenticate: https://10.83.28.164:443/web/login/authenticate.do: Request Error: Invalid credentials

```

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/aristanetworks/ansible-cvp/blob/master/contributing.md#branches) document.
- [x] All new and existing tests passed (`make linting` and `make sanity-lint`).