### PR TITLE
Add failure if device not available

### DIFF
--- a/ansible_collections/arista/cvp/plugins/modules/cv_device.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_device.py
@@ -556,6 +556,8 @@ def build_new_devices_list(module):
             cvp_device = device_get_from_facts(
                 module=module, device_name=ansible_device_hostname
             )
+            if cvp_device is None:
+                module.fail_json(msg="Device not available on Cloudvision ("+ansible_device_hostname+")")
             if len(cvp_device) >= 0:
                 if is_in_container(device=cvp_device, container="undefined_container"):
                     device_info = {


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue(s)

Fix #200

## Proposed changes

Add a test case to report non-existing device.

If hostname could not be found in CV FACTS data, then, module stop and report error with following error message:

```
TASK [eos_config_deploy_cvp : Configure devices on cv_server] *********************************
fatal: [cv_server]: FAILED! => changed=false 
  msg: Device not available on Cloudvision (DC1-SPINE01)
```

## How to test

Build an AVD topology with devices not in CV

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/aristanetworks/ansible-cvp/blob/master/contributing.md#branches) document.
- [x] All new and existing tests passed (`make linting` and `make sanity-lint`).
