### PR TITLE
Add support for offline dhcpd config

### DIFF
--- a/ansible_collections/arista/cvp/roles/dhcp_configuration/defaults/main.yml
+++ b/ansible_collections/arista/cvp/roles/dhcp_configuration/defaults/main.yml
@@ -6,8 +6,11 @@ ansible_connection: paramiko
 # Method to become root
 ansible_become_method: sudo
 
-# Default password to become root
-# ansible_become_password: '{{ansible_password}}'
+# Default execution mode
+mode: online
+
+# Default folder if mode=offline
+output_dir: '{{ inventory_dir }}'
 
 # List of packages to install to enable DHCP package
 dhcp_packages:

--- a/ansible_collections/arista/cvp/roles/dhcp_configuration/tasks/main.yml
+++ b/ansible_collections/arista/cvp/roles/dhcp_configuration/tasks/main.yml
@@ -1,33 +1,7 @@
 ---
 # tasks file for ztp-setup
-- name: gather os specific variables for Centos / Red Hat OS
-  include_vars: "centos-{{ansible_distribution_major_version}}.yml"
-  when: ansible_distribution == "CentOS" or ansible_distribution == 'Red Hat Enterprise Linux'
-
-- name: gather os specific variables for Debian / Ubuntu OS
-  include_vars: "debian.yml"
-  when: ansible_distribution == "Debian" or ansible_distribution == 'Ubuntu'
-
-- name: Install packages
-  become: true
-  package:
-    name: "{{ dhcp_packages }}"
-    state: "{{ dhcp_packages_state }}"
-
-- include_tasks: fix-debian.yml
-  when: ansible_distribution == "Debian" or ansible_distribution == 'Ubuntu'
-
-- name: 'Generate DHCPd configuration file'
-  become: true
-  template:
-    src: 'dhcpd.conf.j2'
-    dest: '{{ dhcp_config }}'
-    backup: yes
-  notify: "restart dhcpd"
-
-- name: Check & activate DHCP service
-  become: true
-  service:
-    name: '{{ dhcp_service }}'
-    enabled: yes
-    state: started
+# If mode=online launch server configuration
+# If mode=offline generate dhcpd.conf to {{output_dir}}
+- name: Start creation/update process.
+  tags: [provision]
+  include_tasks: "./{{ mode }}.yml"

--- a/ansible_collections/arista/cvp/roles/dhcp_configuration/tasks/offline.yml
+++ b/ansible_collections/arista/cvp/roles/dhcp_configuration/tasks/offline.yml
@@ -1,0 +1,8 @@
+---
+- name: 'Generate DHCPd configuration file'
+  become: true
+  template:
+    src: 'dhcpd.conf.j2'
+    dest: '{{ output_dir }}/dhcpd.conf'
+    backup: yes
+  delegate_to: localhost

--- a/ansible_collections/arista/cvp/roles/dhcp_configuration/tasks/online.yml
+++ b/ansible_collections/arista/cvp/roles/dhcp_configuration/tasks/online.yml
@@ -1,0 +1,32 @@
+---
+- name: gather os specific variables for Centos / Red Hat OS
+  include_vars: "centos-{{ansible_distribution_major_version}}.yml"
+  when: ansible_distribution == "CentOS" or ansible_distribution == 'Red Hat Enterprise Linux'
+
+- name: gather os specific variables for Debian / Ubuntu OS
+  include_vars: "debian.yml"
+  when: ansible_distribution == "Debian" or ansible_distribution == 'Ubuntu'
+
+- name: Install packages
+  become: true
+  package:
+    name: "{{ dhcp_packages }}"
+    state: "{{ dhcp_packages_state }}"
+
+- include_tasks: fix-debian.yml
+  when: ansible_distribution == "Debian" or ansible_distribution == 'Ubuntu'
+
+- name: 'Generate DHCPd configuration file'
+  become: true
+  template:
+    src: 'dhcpd.conf.j2'
+    dest: '{{ dhcp_config }}'
+    backup: yes
+  notify: "restart dhcpd"
+
+- name: Check & activate DHCP service
+  become: true
+  service:
+    name: '{{ dhcp_service }}'
+    enabled: yes
+    state: started


### PR DESCRIPTION
Support mechanism to support offline and online workflows

- online: run all configuration and restart services on server
- offline: generate dhcpd.conf file to manually deploy onto a server.

Add following variables:

- mode: < offline/online - Select if role configure a DHCP server or just generate dhcpd.conf file locally. (default online) >
- output_dir: < path where to save dhcpd.conf file when using offline mode.>

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)

## Related Issue(s)

Fix issue #204

## Proposed changes

Implement a `mode` variable to select either offline or online to only generate a `dhcpd.conf` file to share

## How to test

Use following playbook:

```yaml
---
- name: Configure DHCP service on CloudVision
  hosts: dhcp_server
  gather_facts: false
  collection:
    - arista.cvp
  vars:
    ztp:
      default:
        registration: 'http://10.255.0.1/ztp/bootstrap'
        gateway: 10.255.0.3
        nameservers:
          - '10.255.0.3'
      general:
        subnets:
          - network: 10.255.0.0
            netmask: 255.255.255.0
            gateway: 10.255.0.3
            nameservers:
              - '10.255.0.3'
            start: 10.255.0.200
            end: 10.255.0.250
            lease_time: 300
      clients:
        - name: DC1-SPINE1
          mac: '0c:1d:c0:1d:62:01'
          ip4: 10.255.0.11
        - name: DC1-SPINE2
          mac: '0c:1d:c0:1d:62:02'
          ip4: 10.255.0.12
        - name: DC1-LEAF1A
          mac: '0c:1d:c0:1d:62:11'
          ip4: 10.255.0.13
  tasks:
  - name: 'Execute DHCP configuration role'
    import_role:
      name: arista.cvp.dhcp_configuration
    vars:
      mode: offline
      output_dirs: '{{inventory_dir}}'
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/aristanetworks/ansible-cvp/blob/master/contributing.md#branches) document.
- [x] All new and existing tests passed (`make linting` and `make sanity-lint`).
