### PR TITLE
Fix issue #202

### DIFF
--- a/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
@@ -254,12 +254,14 @@ def build_configlets_list(module):
     # Place to save configlets to delete from CV
     intend['delete'] = list()
 
+    MODULE_LOGGER.info(' * build_configlets_list - configlet filter is: %s', str(module.params['configlet_filter']))
+
     for configlet in module.params['cvp_facts']['configlets']:
         # Only deal with Static configlets not Configletbuilders or
         # their derived configlets
         # Include only configlets that match filter elements "all" or any user's defined names.
         if configlet['type'] == 'Static':
-            if re.search(r"\ball\b", str(module.params['configlet_filter'])) or (
+            if re.search(r"\b(all|none)\b", str(module.params['configlet_filter'])) or (
                any(element in configlet['name'] for element in module.params['configlet_filter'])):
                 # Test if module should keep, update or delete configlet
                 if configlet['name'] in module.params['configlets']:
@@ -292,6 +294,7 @@ def build_configlets_list(module):
                 {'data': {'name': str(ansible_configlet)},
                  'config': str(module.params['configlets'][ansible_configlet])}
             )
+    MODULE_LOGGER.info(' * build_configlets_list - configlet list is: %s', str(intend))
     return intend
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Related Issue(s)

Fix #202

## Proposed changes

Add default value of filter (`['none']`) to condition in __`build_configlets_list`__

## How to test

```yaml
---
- name: lab03 - cv_configlet lab
  hosts: CloudVision
  connection: local
  gather_facts: no

  tasks:
    - name: "Gather CVP facts {{inventory_hostname}}"
      arista.cvp.cv_facts:
        facts:
          configlets
      register: CVP_FACTS

    - name: "Configure configlet on {{inventory_hostname}}"
      arista.cvp.cv_configlet:
        cvp_facts: "{{CVP_FACTS.ansible_facts}}"
        configlets: "{{CVP_CONFIGLETS}}"
        # configlet_filter: ["TRAINING"]
        state: present
      register: CVP_CONFIGLET_RESULT
```

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/aristanetworks/ansible-cvp/blob/master/contributing.md#branches) document.
- [x] All new and existing tests passed (`make linting` and `make sanity-lint`).
