### PR TITLE
Fix #216 - Add test before running update_configlets_on_device

### DIFF
--- a/ansible_collections/arista/cvp/plugins/modules/cv_device.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_device.py
@@ -962,44 +962,45 @@ def devices_update(module, mode="override"):
             module.fail_json("Error - device does not exists on CV side.")
 
         # Execute configlet update on device
-        try:
-            device_action = module.client.api.update_configlets_on_device(
-                app_name="Ansible",
-                device=device_facts,
-                add_configlets=configlets_add,
-                del_configlets=configlets_delete,
-            )
-        except Exception as error:
-            errorMessage = str(error)
-            message = "Device %s Configlets cannot be updated - %s" % (
-                device_update["name"],
-                errorMessage,
-            )
-            result_update.append({device_update["name"]: message})
-        else:
-            # Capture and report error message sent by CV during update
-            if "errorMessage" in str(device_action):
-                message = "Device %s Configlets cannot be Updated - %s" % (
+        if is_list_diff(device_update["configlets"], device_update["cv_configlets"]):
+            try:
+                device_action = module.client.api.update_configlets_on_device(
+                    app_name="Ansible",
+                    device=device_facts,
+                    add_configlets=configlets_add,
+                    del_configlets=configlets_delete,
+                )
+            except Exception as error:
+                errorMessage = str(error)
+                message = "Device %s Configlets cannot be updated - %s" % (
                     device_update["name"],
-                    device_action["errorMessage"],
+                    errorMessage,
                 )
                 result_update.append({device_update["name"]: message})
             else:
-                changed = True  # noqa # pylint: disable=unused-variable
-                if "taskIds" in str(device_action):
-                    devices_updated += 1
-                    for taskId in device_action["data"]["taskIds"]:
-                        result_tasks_generated.append(taskId)
-                    result_update.append(
-                        {
-                            device_update["name"]: "Configlets-%s"
-                            % device_action["data"]["taskIds"]
-                        }
+                # Capture and report error message sent by CV during update
+                if "errorMessage" in str(device_action):
+                    message = "Device %s Configlets cannot be Updated - %s" % (
+                        device_update["name"],
+                        device_action["errorMessage"],
                     )
+                    result_update.append({device_update["name"]: message})
                 else:
-                    result_update.append(
-                        {device_update["name"]: "Configlets-No_Specific_Tasks"}
-                    )
+                    changed = True  # noqa # pylint: disable=unused-variable
+                    if "taskIds" in str(device_action):
+                        devices_updated += 1
+                        for taskId in device_action["data"]["taskIds"]:
+                            result_tasks_generated.append(taskId)
+                        result_update.append(
+                            {
+                                device_update["name"]: "Configlets-%s"
+                                % device_action["data"]["taskIds"]
+                            }
+                        )
+                    else:
+                        result_update.append(
+                            {device_update["name"]: "Configlets-No_Specific_Tasks"}
+                        )
 
     # Build response structure
     data = {


### PR DESCRIPTION
Run update_configlets_on_device only if ansible list of configlets is not equal to CVP list of configlets

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue(s)

Fix #216

## Proposed changes

Add conditional execution for `update_configlets_on_device` to only update devices when list of configlets has changed on Ansible side.

## How to test

Execute following playbook:

```yaml
---
- name: test issue #216
  hosts: CloudVision
  connection: local
  gather_facts: no

  vars:
    CVP_DEVICES:
      leaf1:
        name: 'leaf1'
        parentContainerName: Leaf
        configlets:
            - 'Leaf1-BGP-Lab'
            - 'BaseIPv4_Leaf1'
            - '01TRAINING-01'
        imageBundle: []  # Not yet supported

  tasks:
    - name: "Gather CVP facts {{inventory_hostname}}"
      arista.cvp.cv_facts:
      register: CVP_FACTS

    - name: "Configure devices on {{inventory_hostname}}"
      arista.cvp.cv_device:
        devices: "{{CVP_DEVICES}}"
        cvp_facts: '{{CVP_FACTS.ansible_facts}}'
        device_filter: ['leaf1']
        state: present
      register: CVP_DEVICES_RESULTS

    - name: 'Display cv_configlet result'
      debug:
        msg: '{{CVP_DEVICES_RESULTS}}'
```

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/aristanetworks/ansible-cvp/blob/master/contributing.md#branches) document.
- [x] All new and existing tests passed (`make linting` and `make sanity-lint`).
