### PR TITLE
Add support for SSL Cert validation

### DIFF
--- a/ansible_collections/arista/cvp/docs/how-to/cvp-authentication.md
+++ b/ansible_collections/arista/cvp/docs/how-to/cvp-authentication.md
@@ -50,3 +50,64 @@ ansible_httpapi_host: '{{ ansible_host }}'
 ansible_httpapi_use_ssl: true
 ansible_httpapi_validate_certs: false
 ```
+
+## How to validate SSL certificate
+
+### Validate SSL cert signed by public CA
+
+Starting version `2.1.1`, `arista.cvp` collection supports mechanism to validate SSL certificate. To configure ansible to validate SSL certificate provided by your CV instance, you must update httpapi information like this:
+
+```yaml
+# HTTPAPI plugin configuration
+ansible_httpapi_port: '{{ansible_port}}'
+ansible_httpapi_host: '{{ ansible_host }}'
+ansible_httpapi_use_ssl: true
+ansible_httpapi_validate_certs: true
+```
+
+### Validate SSL cert signed by unknown CA
+
+> This mechanism works also with self-signed certificate
+
+Update httpapi as shown below:
+
+```yaml
+# HTTPAPI plugin configuration
+ansible_httpapi_port: '{{ansible_port}}'
+ansible_httpapi_host: '{{ ansible_host }}'
+ansible_httpapi_use_ssl: true
+ansible_httpapi_validate_certs: true
+```
+
+And then, import your CA or server CRT file into database of your CA for Python
+
+```shell
+# Get CVP SSL Cert (If not already provided by your CV admin)
+$ true | openssl s_client -connect <YOUR-CV-IP>:443 2>/dev/null | openssl x509 > cvp.crt
+
+# Update Python DB for known CA
+$ cat cvp.crt >> `python -m certifi`
+```
+
+> Note it is per virtual environment configuration.
+
+### Invalid SSL certification
+
+If identity cannot be validated by ansible, playbook stops with following error message:
+
+```shell
+$ ansible-playbook playbooks/extract-facts.yml
+
+PLAY [CV Facts] ***************************************************************
+
+TASK [Gather CVP facts from cv_server] ****************************************
+Monday 05 October 2020  21:09:22 +0200 (0:00:00.063)       0:00:00.063 ********
+Monday 05 October 2020  21:09:22 +0200 (0:00:00.063)       0:00:00.063 ********
+fatal: [cv_server]: FAILED! => changed=false
+  msg: |2-
+
+    x.x.x.x: HTTPSConnectionPool(host='x.x.x.x', port=443): Max retries \
+        exceeded with url: /web/login/authenticate.do \
+        (Caused by SSLError(SSLError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] \
+        certificate verify failed (_ssl.c:852)'),))
+```

--- a/ansible_collections/arista/cvp/docs/release-notes/v1.x.md
+++ b/ansible_collections/arista/cvp/docs/release-notes/v1.x.md
@@ -139,7 +139,7 @@ __Supported CloudVision versions:__
 
 __Enhancements__
 
-- New Ansible role to configure ZTP service on Cloudvision: [`arista.cvp.ztp_configuration`](https://github.com/aristanetworks/ansible-cvp/tree/releases/v1.0.x/ansible_collections/arista/cvp/roles/ztp_configuration)
+- New Ansible role to configure ZTP service on Cloudvision: [`arista.cvp.ztp_configuration`](../../roles/dhcp_configuration/README.md)
 - Implement new logging mechanism across all `arista.cvp` modules (Issue: #124 / PR: #146)
 - Enable Continuous Integration using Github Actions (#148)
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/cv_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/cv_tools.py
@@ -53,14 +53,17 @@ def cv_connect(module):
         Instanciated CvpClient with connection information.
     """
     client = CvpClient()
+    LOGGER.info('Connecting to CVP')
     connection = Connection(module._socket_path)
     host = connection.get_option("host")
     port = connection.get_option("port")
     user = connection.get_option("remote_user")
     user_authentication = connection.get_option("password")
-    LOGGER.info('Connecting to CVP')
+    cert_validation = connection.get_option("validate_certs")
+    if cert_validation:
+        LOGGER.debug("  Module will check CV certificate")
     if user == 'cvaas':
-        LOGGER.debug('Connecting to a cvaas instance')
+        LOGGER.debug('  Connecting to a cvaas instance')
         try:
             client.connect(nodes=[host],
                            is_cvaas=True,
@@ -68,13 +71,14 @@ def cv_connect(module):
                            username='',
                            password='',
                            protocol="https",
-                           port=port
+                           port=port,
+                           cert=cert_validation
                            )
         except CvpLoginError as e:
             module.fail_json(msg=str(e))
             LOGGER.error('Cannot connect to CVP: %s', str(e))
     else:
-        LOGGER.debug('Connecting to a on-prem instance')
+        LOGGER.debug('  Connecting to a on-prem instance')
         try:
             client.connect(nodes=[host],
                            username=user,
@@ -82,12 +86,13 @@ def cv_connect(module):
                            protocol="https",
                            is_cvaas=False,
                            port=port,
+                           cert=cert_validation
                            )
         except CvpLoginError as e:
             module.fail_json(msg=str(e))
             LOGGER.error('Cannot connect to CVP: %s', str(e))
 
-    LOGGER.debug('*** Connected to CVP')
+    LOGGER.info('Connected to CVP')
 
     return client
 


### PR DESCRIPTION
Add support for SSL certification with valid SSL certificate leveraging
HTTPAPI syntax:

- On inventory, configure SSL validate_certs with `ansible_httpapi_validate_certs: true`
- Run playbook as usual

__Known limitation__

- Only valid with certificate signed by CA not part of deployed CA
(self-signed and internal CA not deployed)

Error message with invalid certificate:

```shell
fatal: [cv_server]: FAILED! => changed=false
  msg: |2-

    10.83.28.164: HTTPSConnectionPool(host='10.83.28.164', port=443): Max retries exceeded with url: /web/login/authenticate.do (Caused by SSLError(SSLError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852)'),))
```

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes

- [x] New feature (non-breaking change which adds functionality)


## Related Issue(s)

Fix issue #238 

## Proposed changes

On inventory, configure SSL validate_certs with `ansible_httpapi_validate_certs: true`

## How to test

With `ansible_httpapi_validate_certs: true` run your usual playbook.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/aristanetworks/ansible-cvp/blob/master/contributing.md#branches) document.
- [x] All new and existing tests passed (`make linting` and `make sanity-lint`).
