### PR TITLE
Fix cv_configlet issue when state is absent

### DIFF
--- a/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
@@ -612,8 +612,8 @@ def action_manager(module):
 
     # MODULE_LOGGER.debug('Current intended list is: %s', str(intend_list))
 
-    # Create new configlets
-    if len(intend_list['create']) > 0:
+    # Create new configlets and only if state is not absent
+    if len(intend_list['create']) > 0 and module.params['state'] != "absent":
         MODULE_LOGGER.info('Start configlets creation process')
         temp_res = action_create(
             create_configlets=intend_list['create'],
@@ -624,8 +624,8 @@ def action_manager(module):
             type='create',
             module=module)
 
-    # Update existing configlets
-    if len(intend_list['update']) > 0:
+    # Update existing configlets and only if state is not absent
+    if len(intend_list['update']) > 0 and module.params['state'] != "absent":
         MODULE_LOGGER.info('Start configlets update process')
         temp_res = action_update(
             update_configlets=intend_list['update'],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->

Fix #258

## Proposed changes

Implement additional check in `action_manager` to only run create and
update when `state` is not set to absent

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


Tested with [arista-netdevops-community/ansible-cvp-avd-toi](https://github.com/arista-netdevops-community/ansible-cvp-avd-toi) lab04


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/aristanetworks/ansible-cvp/blob/master/contributing.md#branches) document.
- [x] All new and existing tests passed (`make linting` and `make sanity-lint`).
