### PR TITLE
Update GH actions and the python version management

### DIFF
--- a/.github/workflows/ansible_test.yml
+++ b/.github/workflows/ansible_test.yml
@@ -12,12 +12,16 @@ jobs:
     env:
       PY_COLORS: 1 # allows molecule colors to be passed to GitHub Actions
       ANSIBLE_FORCE_COLOR: 1 # allows ansible colors to be passed to GitHub Actions
+    strategy:
+      fail-fast: true
+      matrix:
+        python_version: [ 3.6 ]
     steps:
-      - uses: actions/checkout@master
-      - name: Setup Python 3 on runner
-        uses: actions/setup-python@v1.2.0
+      - uses: actions/checkout@v2
+      - name: Set up Python 3
+        uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: ${{ matrix.python_version }}
 
       - name: update packages
         run: apt-get update

--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -13,7 +13,7 @@ jobs:
     name: 'Update Public documentation'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: 'Setup Python 3 on runner'
         uses: actions/setup-python@v1.2.0
         with:

--- a/.github/workflows/documentation-check.yml
+++ b/.github/workflows/documentation-check.yml
@@ -14,7 +14,7 @@ jobs:
     name: 'Validate mkdoc content'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: 'start docker-compose stack'
         run: |
           cp development/docker-compose.yml .

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     container: avdteam/base:3.6
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: test pre-commit
         run: |
           pip --no-cache-dir install -r development/requirements-dev.txt

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -16,16 +16,17 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
+        python_version: [ 3.6 ]
         avd_scenario:
           - dhcp_configuration
           - cv_configlet
           - cv_device
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Set up Python 3
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: ${{ matrix.python_version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/version_release.yml
+++ b/.github/workflows/version_release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     container: avdteam/base:centos-8
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
 
       - name: 'Ansible Galaxy build'
         run: |

--- a/ansible_collections/arista/cvp/docs/installation/setup-docker.md
+++ b/ansible_collections/arista/cvp/docs/installation/setup-docker.md
@@ -69,7 +69,7 @@ In this folder you have a `Makefile` providing a list of commands to start a dev
 - `dev-run`: Connect to ansible container to run your test playbooks.
 - `dev-reload`: Run stop and start.
 
-If you want to test a specific ansible version, you can refer to this [dedicated page](https://github.com/arista-netdevops-community/docker-avd-base/blob/master/USAGE.md) to start your own docker image. You can also use following make command: `make ANSIBLE_VERSION=2.9.3 run`
+If you want to test a specific ansible version, you can refer to this [dedicated page](https://github.com/arista-netdevops-community/docker-avd-base/blob/master/docs/run-options.md) to start your own docker image. You can also use following make command: `make ANSIBLE_VERSION=2.9.3 run`
 
 Since docker image is now automatically published on [__docker-hub__](https://hub.docker.com/repository/docker/avdteam/base), a dedicated repository is available on [__Arista Netdevops Community__](https://github.com/arista-netdevops-community/docker-avd-base).
 


### PR DESCRIPTION
Use matrix for python version management:

```yaml
jobs:
  molecule:
    runs-on: ubuntu-latest
    strategy:
      fail-fast: true
      matrix:
        python_version: [ 3.6 ]
    steps:
      - uses: actions/checkout@v2
      - name: Set up Python 3
        uses: actions/setup-python@v2
        with:
          python-version: ${{ matrix.python_version }}
```
