### PR TITLE
Add support for ansible timeout to CV

### DIFF
--- a/ansible_collections/arista/cvp/docs/how-to/cvp-authentication.md
+++ b/ansible_collections/arista/cvp/docs/how-to/cvp-authentication.md
@@ -138,3 +138,29 @@ fatal: [cv_server]: FAILED! => changed=false
         (Caused by SSLError(SSLError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] \
         certificate verify failed (_ssl.c:852)'),))
 ```
+
+## Configure connection timeout
+
+When used in large environment, API calls can take more than 30 seconds to run. It can be configured in ansible by leveraging either `ansible.cfg` file or variables.
+
+### Ansible configuration file
+
+Edit `ansible.cfg` file and add the following
+
+```ini
+[persistent_conenction]
+connection_timeout = 120
+command_timeout = 120
+```
+
+> If also configured in variables, it will be overwrite.
+
+### Inventory variables
+
+Add in either inventory file, group_vars or host_vars following lines:
+
+```yaml
+---
+ansible_connect_timeout: 30
+ansible_command_timeout: 90
+```


### PR DESCRIPTION
## Summary

Allow user to configure CV session timeout leveraging `ansible_*_timeout` options.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #276

## Proposed changes

Support configuration using ansible.cfg:

```ini
[persistent_conenction]
connection_timeout = 120
command_timeout = 120
```

Can be also set using variables:

```yaml
ansible_connect_timeout: 111
ansible_command_timeout: 222
```

In log file, output is:

```
2020-11-10 12:54:12,564 - arista.cvp.cv_tools: DEBUG - func: cv_connect   (L:77 ) \
-   Connecting to a CV instance: 10.73.1.239 with timers 111 222
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/aristanetworks/ansible-cvp/blob/master/contributing.md#branches) document.
- [x] All new and existing tests passed (`make linting` and `make sanity-lint`).
