### PR TITLE
fix(logger): Implement UUID in default log file

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/logger.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/logger.py
@@ -22,6 +22,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import logging
+import uuid
 import os
 from logging.handlers import RotatingFileHandler  # noqa # pylint: disable=unused-import
 
@@ -42,9 +43,10 @@ LOGLEVEL = LEVELS.get(LOGGING_LEVEL, logging.NOTSET)
 LOGGING_LEVEL_URLLIB3 = os.getenv('ANSIBLE_CVP_LOG_APICALL', 'warning')
 LOGLEVEL_URLLIB3 = LEVELS.get(LOGGING_LEVEL_URLLIB3, logging.WARNING)
 
-# Get filename to write logs / default /temp/arista.cvp.debug.log
+# Get filename to write logs / default /temp/arista.cvp.debug-<uuid>.log
+DEFAULT_LOG_FILE = '/tmp/arista.cvp.debug.' + str(uuid.uuid4()) + '.log'
 LOGGING_FILENAME = os.getenv(
-    'ANSIBLE_CVP_LOG_FILE', '/tmp/arista.cvp.debug.log')
+    'ANSIBLE_CVP_LOG_FILE', DEFAULT_LOG_FILE)
 
 # set a format which is simpler for console use
 formatter = logging.Formatter(


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #303

## Proposed changes

Automatically generate an UUID part of the default log file to support
multi-user execution on the same environment.

## How to test

Run any arista.cvp task with no specific logging set.
Inspect folder: `/tmp`

```bash
ls /tmp | grep arista.cvp
arista.cvp.debug-4dfc6af1-040e-4922-8358-d38350313049.log
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/aristanetworks/ansible-cvp/blob/master/contributing.md#branches) document.
- [x] All new and existing tests passed (`make linting` and `make sanity-lint`).
