### PR TITLE
cv_configlet_v3: add delete configlet failure message

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/configlet_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/configlet_tools.py
@@ -441,6 +441,7 @@ class CvConfigletTools(object):
                     # Generate logging error message
                     MODULE_LOGGER.error('Error deleting configlet %s: %s', str(
                         configlet['name']), str(error))
+                    self._ansible.fail_json(msg=message)
                 else:
                     if "errorMessage" in str(delete_resp):
                         # Mark module execution with error
@@ -452,6 +453,7 @@ class CvConfigletTools(object):
                         # Generate logging error message
                         MODULE_LOGGER.error(
                             'Error deleting configlet %s: %s', str(configlet['name']), str(delete_resp))
+                        self._ansible.fail_json(msg=message)
                     else:
                         change_response.add_entry('configlet deleted')
                         change_response.changed = True

--- a/ansible_collections/arista/cvp/plugins/module_utils/configlet_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/configlet_tools.py
@@ -303,6 +303,7 @@ class CvConfigletTools(object):
                     # Generate logging error message
                     MODULE_LOGGER.error('Error updating configlet %s: %s', str(
                         configlet['name']), str(error))
+                    self._ansible.fail_json(msg=message)
                 else:
                     if "errorMessage" in str(update_resp):
                         # Mark module execution with error
@@ -314,6 +315,7 @@ class CvConfigletTools(object):
                         # Generate logging error message
                         MODULE_LOGGER.error('Error updating configlet %s: %s', str(
                             configlet['name']), str(update_resp['errorMessage']))
+                        self._ansible.fail_json(msg=message)
                     else:
                         # Inform module a changed has been done
                         change_response.changed = False
@@ -396,6 +398,7 @@ class CvConfigletTools(object):
                     # Generate logging error message
                     MODULE_LOGGER.error('Error creating configlet %s: %s', str(
                         configlet['name']), str(error))
+                    self._ansible.fail_json(msg=message)
                 else:
                     if "errorMessage" in str(new_resp):
                         # Mark module execution with error
@@ -408,6 +411,7 @@ class CvConfigletTools(object):
                         # Generate logging error message
                         MODULE_LOGGER.error(
                             'Error creating configlet %s: %s', str(configlet['name']), str(new_resp))
+                        self._ansible.fail_json(msg=message)
                     else:
                         self._cvp_client.api.add_note_to_configlet(new_resp, configlets_notes)
                         change_response.add_entry('configlet created')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Proposed changes
When deleting configets that are assigned to containers or devices, ansible was stating that the playbook could run successfully, however configlets that are mapped cannot be deleted and CVP returns an error message, e.g.: `Configlets assigned to device(s)/container(s) cannot be deleted`. The change returns that error message and fails the module.

