### PR TITLE
fix(json_schema): Enable whitespace support in path name

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/schema.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/schema.py
@@ -46,7 +46,7 @@ SCHEMA_CV_CONFIGLET = {
     ],
     "type": "object",
     "patternProperties": {
-        "^[A-Za-z0-9\\._%\\+-]+$": {
+        "^[A-Za-z0-9\\s\\._%\\+-]+$": {
             "type": "string"
         }
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #313 

## Proposed changes

Enhance configlet schema to support lookup file with space in filename

## How to test

Refer to original issue

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/aristanetworks/ansible-cvp/blob/master/contributing.md#branches) document.
- [x] All new and existing tests passed (`make linting` and `make sanity-lint`).
