### PR TITLE
Container v3 error handling

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
@@ -372,9 +372,10 @@ class CvContainerTools(object):
                         container=container,
                         create_task=save_topology
                     )
-                except CvpApiError:
-                    MODULE_LOGGER.error('Error configuring configlets %s to container %s', str(
-                        configlets), str(container))
+                except CvpApiError as e:
+                    message = "Error configuring configlets {} to container {}. Exception: {}".format(str(configlets), str(container), str(e))
+                    MODULE_LOGGER.error(message)
+                    self.__ansible.fail_json(msg=message)
                 else:
                     if 'data' in resp and resp['data']['status'] == 'success':
                         # We assume there is a change as API does not provide information

--- a/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
@@ -617,10 +617,11 @@ class CvContainerTools(object):
                     try:
                         resp = self.__cvp_client.api.add_container(
                             container_name=container, parent_key=parent_id, parent_name=parent)
-                    except CvpApiError:
+                    except CvpApiError as e:
                         # Add Ansible error management
-                        MODULE_LOGGER.error(
-                            "Error creating container %s on CV", str(container))
+                        message = "Error creating container {} on CV. Exception: {}".format(str(container), str(e))
+                        MODULE_LOGGER.error(message)
+                        self.__ansible.fail_json(msg=message)
                     else:
                         if resp['data']['status'] == "success":
                             change_result.taskIds = resp['data']['taskIds']

--- a/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
@@ -683,9 +683,9 @@ class CvContainerTools(object):
                 try:
                     resp = self.__cvp_client.api.delete_container(
                         container_name=container, container_key=container_id, parent_key=parent_id, parent_name=parent)
-                except CvpApiError:
+                except CvpApiError as e:
                     # Add Ansible error management
-                    message = "Error deleting container {} on CV. Exception: {}".format(str(container), str(CvpApiError))
+                    message = "Error deleting container {} on CV. Exception: {}".format(str(container), str(e))
                     MODULE_LOGGER.error(message)
                     self.__ansible.fail_json(msg=message)
                 else:

--- a/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
@@ -669,7 +669,7 @@ class CvContainerTools(object):
             MODULE_LOGGER.error(message)
             self.__ansible.fail_json(msg=message)
         elif self.is_empty(container_name=container) == False:
-            message = "Unable to delete container {}: container not empty - either it has child container(s) or some device(s) are attached on CVP".format(str(container))
+            message = "Unable to delete container {}: container not empty - either it has child container(s) or some device(s) are attached to it on CVP".format(str(container))
             MODULE_LOGGER.error(message)
             self.__ansible.fail_json(msg=message)
         else:

--- a/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
@@ -567,7 +567,9 @@ class CvContainerTools(object):
         try:
             cv_data = self.__cvp_client.api.get_container_by_name(name=container_name)
         except (CvpApiError, CvpClientError) as error:
-            MODULE_LOGGER.error('Error getting information for container %s: %s', str(container_name), str(error))
+            message = "Error getting information for container {}: {}".format(str(container_name), str(error))
+            MODULE_LOGGER.error(message)
+            self.__ansible.fail_json(msg=message)
             return True
         if cv_data is not None:
             return True

--- a/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
@@ -665,11 +665,11 @@ class CvContainerTools(object):
         resp = dict()
         change_result = CvApiResult(action_name=container)
         if self.is_container_exists(container_name=container) == False:
-            message = "Container {} does not exist on CVP - unable to delete it".format(str(container))
+            message = "Unable to delete container {}: container does not exist on CVP".format(str(container))
             MODULE_LOGGER.error(message)
             self.__ansible.fail_json(msg=message)
         elif self.is_empty(container_name=container) == False:
-            message = "Container {} is not empty: either it has child container(s) or device(s) attached on CVP - unable to delete it".format(str(container))
+            message = "Unable to delete container {}: container not empty - either it has child container(s) or some device(s) are attached on CVP".format(str(container))
             MODULE_LOGGER.error(message)
             self.__ansible.fail_json(msg=message)
         else:

--- a/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
@@ -435,9 +435,10 @@ class CvContainerTools(object):
                     container=container,
                     create_task=save_topology
                 )
-            except CvpApiError:
-                MODULE_LOGGER.error('Error removing configlets %s from container %s', str(
-                    configlets), str(container))
+            except CvpApiError as e:
+                message = "Error removing configlets {} from container {}. Exception: {}".format(str(configlets), str(container), str(e))
+                MODULE_LOGGER.error(message)
+                self.__ansible.fail_json(msg=message)
             else:
                 if 'data' in resp and resp['data']['status'] == 'success':
                     change_response.taskIds = resp['data']['taskIds']


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
https://github.com/aristanetworks/ansible-cvp/issues/317

## Proposed changes
Better handling of some failure scenario in container_v3 module. 

Scenario1: Trying to create a container without an existing parent now fail with a proper error message: 
```
- hosts: cv_server
  vars:
    containers:
      container-with-undefinied-parent:
        parentContainerName: unexisting-container
  tasks:
    - name: "Build Container topology on {{inventory_hostname}}"
      arista.cvp.cv_container_v3:
        topology: "{{containers}}"
        state: present

Result: 
TASK [Build Container topology on cv_server] *********************************************************************************************************************************************************************************
fatal: [cv_server]: FAILED! => changed=false 
  msg: Parent container (unexisting-container) is missing for container container-with-undefinied-parent
PLAY RECAP *******************************************************************************************************************************************************************************************************************
cv_server                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0  
```


Scenario 2: Trying to delete a non-existing container fails with a proper error message: 
```
- hosts: cv_server
  vars:
    containers:
      non-existing-container:
        parentContainerName: Tenant
  tasks:
    - name: "Delete container on {{inventory_hostname}}"
      arista.cvp.cv_container_v3:
        topology: "{{containers}}"
        state: absent

Result: 
TASK [Delete container on cv_server] *****************************************************************************************************************************************************************************************
fatal: [cv_server]: FAILED! => changed=false 
  msg: 'Unable to delete container non-existing-container: container does not exist on CVP'

PLAY RECAP *******************************************************************************************************************************************************************************************************************
cv_server                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```

Scenario 3: Trying to delete a container that has child containers or some devices attached fail with a proper error message: 
```
- hosts: cv_server
  vars:
    containers:
      B:
        parentContainerName: A
  tasks:
    - name: "Delete container on {{inventory_hostname}}"
      arista.cvp.cv_container_v3:
        topology: "{{containers}}"
        state: absent

Result:

TASK [Delete container on cv_server] *****************************************************************************************************************************************************************************************
fatal: [cv_server]: FAILED! => changed=false 
  msg: 'Unable to delete container B: container not empty - either it has child container(s) or some device(s) are attached to it on CVP'

PLAY RECAP *******************************************************************************************************************************************************************************************************************
cv_server                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```

Moreover, for most of the API calls, the ansible fail handling has been added. Example: 
```
            else:
                try:
                    resp = self.__cvp_client.api.apply_configlets_to_container(
                        app_name="ansible_cv_container",
                        new_configlets=configlets,
                        container=container,
                        create_task=save_topology
                    )
                **except CvpApiError as e:
                    message = "Error configuring configlets {} to container {}. Exception: {}".format(str(configlets), str(container), str(e))
                    MODULE_LOGGER.error(message)
                    self.__ansible.fail_json(msg=message)**
```

In function `ordered_list_containers`, I also added a toggle to avoid having an infinite loop when the topology is incorrect (i.e. parent of a container is not present in the topology). 


## How to test
See scenarios above.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/aristanetworks/ansible-cvp/blob/master/contributing.md#branches) document.
- [ ] All new and existing tests passed (`make linting` and `make sanity-lint`).
