### PR TITLE
Use multiple version of JSON schema to support v1 and v3 in parallel

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/configlet_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/configlet_tools.py
@@ -40,7 +40,7 @@ except ImportError:
 #     HAS_JSONSCHEMA = True
 # except ImportError:
 #     HAS_JSONSCHEMA = False
-import ansible_collections.arista.cvp.plugins.module_utils.schema as schema
+import ansible_collections.arista.cvp.plugins.module_utils.schema_v3 as schema
 try:
     import difflib
     HAS_DIFFLIB = True

--- a/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
@@ -41,7 +41,7 @@ except ImportError:
 #     HAS_JSONSCHEMA = True
 # except ImportError:
 #     HAS_JSONSCHEMA = False
-import ansible_collections.arista.cvp.plugins.module_utils.schema as schema
+import ansible_collections.arista.cvp.plugins.module_utils.schema_v3 as schema
 
 MODULE_LOGGER = logging.getLogger('arista.cvp.container_tools_v3')
 MODULE_LOGGER.info('Start cv_container_v3 module execution')

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -29,7 +29,7 @@ from ansible.module_utils.basic import AnsibleModule
 import ansible_collections.arista.cvp.plugins.module_utils.logger   # noqa # pylint: disable=unused-import
 from ansible_collections.arista.cvp.plugins.module_utils.response import CvApiResult, CvManagerResult, CvAnsibleResponse
 from ansible_collections.arista.cvp.plugins.module_utils.generic_tools import CvElement
-import ansible_collections.arista.cvp.plugins.module_utils.schema as schema
+import ansible_collections.arista.cvp.plugins.module_utils.schema_v3 as schema
 try:
     from cvprac.cvp_client import CvpClient  # noqa # pylint: disable=unused-import
     from cvprac.cvp_client_errors import CvpApiError, CvpRequestError  # noqa # pylint: disable=unused-import

--- a/ansible_collections/arista/cvp/plugins/module_utils/schema_v1.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/schema_v1.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python
+# coding: utf-8 -*-
+#
+# GNU General Public License v3.0+
+#
+# Copyright 2019 Arista Networks AS-EMEA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import logging
+try:
+    import jsonschema
+    HAS_JSONSCHEMA = True
+except ImportError:
+    HAS_JSONSCHEMA = False
+
+
+LOGGER = logging.getLogger('arista.cvp.json_schema')
+
+# JSON Schema to represent CV_CONFIGLET inputs.
+SCHEMA_CV_CONFIGLET = {
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "http://example.com/example.json",
+    "title": "CV CONFIGLET SCHEMA",
+    "description": "The root schema to validate cv_configlet inputs",
+    "default": {},
+    "examples": [
+        {
+            "TEAM01-alias": "alias a1 show version",
+            "TEAM01-another-configlet": "alias a2 show version"
+        }
+    ],
+    "type": "object",
+    "patternProperties": {
+        "^[A-Za-z0-9\\s\\._%\\+-]+$": {
+            "type": "string"
+        }
+    },
+    "additionalProperties": False
+}
+
+# JSON Schema to represent CV_DEVICE inputs.
+SCHEMA_CV_DEVICE = {
+    "type": "object",
+    "$schema": "http://json-schema.org/draft-03/schema",
+    "id": "#",
+    "title": "CV DEVICE SCHEMA",
+    "description": "The root schema to validate cv_device inputs",
+    "default": {},
+    "examples": [
+        {
+            "DC1-SPINE1": {
+                "name": "DC1-SPINE1",
+                "parentContainerName": "DC1_SPINES",
+                "configlets": [
+                    "AVD_DC1-SPINE1",
+                    "01TRAINING-01"
+                ],
+                "imageBundle": []
+            },
+            "DC1-SPINE2": {
+                "name": "DC1-SPINE1",
+                "parentContainerName": "DC1_SPINES",
+                "configlets": [
+                    "AVD_DC1-SPINE2",
+                    "01TRAINING-01"
+                ],
+                "imageBundle": []
+            }
+        }
+    ],
+    "patternProperties": {
+        "^[A-Za-z0-9\\._%\\+-]+$": {
+            "type": "object",
+            "properties": {
+                "parentContainerName": {
+                    "id": "parentContainerName",
+                    "type": "string",
+                    "required": True
+                },
+                "configlets": {
+                    "id": "configlets",
+                    "type": "array",
+                    "contains": {
+                        "type": "string"
+                    },
+                    "required": False
+                },
+                "imageBundle": {
+                    "id": "imageBundle",
+                    "type": "array",
+                    "contains": {
+                        "type": "string"
+                    },
+                    "required": False
+                },
+            }
+        }
+    }
+}
+
+# JSON Schema to represent CV_CONTAINER inputs.
+SCHEMA_CV_CONTAINER = {
+    "type": "object",
+    "$schema": "http://json-schema.org/draft-03/schema",
+    "id": "#",
+    "title": "CV CONTAINER SCHEMA",
+    "description": "The root schema to validate cv_container inputs",
+    "default": {},
+    "examples": [
+        {
+            "DC2": {
+                "parent_container": "Tenant"
+            },
+            "Leafs": {
+                "parent_container": "DC2"
+            },
+            "Spines": {
+                "parent_container": "DC2"
+            },
+            "POD01": {
+                "parent_container": "Leafs"
+            }
+        }
+    ],
+    "required": True,
+    "patternProperties": {
+        "^[A-Za-z0-9\\._%\\+-]+$": {
+            "type": "object",
+            "required": True,
+            "properties": {
+                "parent_container": {
+                    "id": "parent_container",
+                    "type": "string",
+                    "required": True
+                },
+                "configlets": {
+                    "id": "configlets",
+                    "type": "array",
+                    "contains": {
+                        "type": "string"
+                    },
+                    "required": False
+                },
+                "devices": {
+                    "id": "devices",
+                    "type": "array",
+                    "contains": {
+                        "type": "string"
+                    },
+                    "required": False
+                },
+            }
+        }
+    }
+}
+
+
+def validate_cv_inputs(user_json, schema):
+    """
+    validate_cv_inputs JSON SCHEMA Validation.
+
+    Run a JSON validation against a muser's defined JSONSCHEMA.
+
+    Parameters
+    ----------
+    user_json : json
+        JSON to validate
+    schema : JSON
+        JSON Schema to use to validate JSON
+
+    Returns
+    -------
+    boolean
+        True if valid, False if not.
+    """
+    try:
+        jsonschema.validate(instance=user_json, schema=schema)
+    except jsonschema.ValidationError as error_message:
+        LOGGER.error("Invalid inputs %s", str(error_message))
+        return False
+    return True

--- a/ansible_collections/arista/cvp/plugins/module_utils/schema_v3.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/schema_v3.py
@@ -194,65 +194,6 @@ SCHEMA_CV_DEVICE = {
     }
 }
 
-SCHEMA_CV_DEVICE_OLD = {
-    "type": "object",
-    "$schema": "http://json-schema.org/draft-03/schema",
-    "id": "#",
-    "title": "CV DEVICE SCHEMA",
-    "description": "The root schema to validate cv_device inputs",
-    "default": {},
-    "examples": [
-        {
-            "DC1-SPINE1": {
-                "name": "DC1-SPINE1",
-                "parentContainerName": "DC1_SPINES",
-                "configlets": [
-                    "AVD_DC1-SPINE1",
-                    "01TRAINING-01"
-                ],
-                "imageBundle": []
-            },
-            "DC1-SPINE2": {
-                "name": "DC1-SPINE1",
-                "parentContainerName": "DC1_SPINES",
-                "configlets": [
-                    "AVD_DC1-SPINE2",
-                    "01TRAINING-01"
-                ],
-                "imageBundle": []
-            }
-        }
-    ],
-    "patternProperties": {
-        "^[A-Za-z0-9\\._%\\+-]+$": {
-            "type": "object",
-            "properties": {
-                "parentContainerName": {
-                    "id": "parentContainerName",
-                    "type": "string",
-                    "required": True
-                },
-                "configlets": {
-                    "id": "configlets",
-                    "type": "array",
-                    "contains": {
-                        "type": "string"
-                    },
-                    "required": False
-                },
-                "imageBundle": {
-                    "id": "imageBundle",
-                    "type": "array",
-                    "contains": {
-                        "type": "string"
-                    },
-                    "required": False
-                },
-            }
-        }
-    }
-}
-
 # JSON Schema to represent CV_CONTAINER inputs.
 SCHEMA_CV_CONTAINER = {
     "type": "object",

--- a/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
@@ -117,7 +117,7 @@ from ansible.module_utils.basic import AnsibleModule
 import ansible_collections.arista.cvp.plugins.module_utils.logger   # noqa # pylint: disable=unused-import
 import ansible_collections.arista.cvp.plugins.module_utils.tools_cv as tools_cv
 import ansible_collections.arista.cvp.plugins.module_utils.tools as tools
-import ansible_collections.arista.cvp.plugins.module_utils.schema as schema
+import ansible_collections.arista.cvp.plugins.module_utils.schema_v1 as schema
 
 MODULE_LOGGER = logging.getLogger('arista.cvp.cv_configlet')
 MODULE_LOGGER.info('Start cv_configlet module execution')

--- a/ansible_collections/arista/cvp/plugins/modules/cv_configlet_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_configlet_v3.py
@@ -87,7 +87,7 @@ from ansible.module_utils.basic import AnsibleModule
 import ansible_collections.arista.cvp.plugins.module_utils.logger   # noqa # pylint: disable=unused-import
 from ansible_collections.arista.cvp.plugins.module_utils.response import CvAnsibleResponse
 import ansible_collections.arista.cvp.plugins.module_utils.tools_cv as tools_cv
-import ansible_collections.arista.cvp.plugins.module_utils.schema as schema
+import ansible_collections.arista.cvp.plugins.module_utils.schema_v3 as schema
 from ansible_collections.arista.cvp.plugins.module_utils.configlet_tools import ConfigletInput, CvConfigletTools
 try:
     from cvprac.cvp_client_errors import CvpClientError, CvpApiError, CvpRequestError  # noqa # pylint: disable=unused-import

--- a/ansible_collections/arista/cvp/plugins/modules/cv_container.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_container.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python
 # coding: utf-8 -*-
 # pylint: disable=bare-except
+# pylint: disable=logging-format-interpolation
+# flake8: noqa: W1202
 #
 # GNU General Public License v3.0+
 #
@@ -20,6 +22,7 @@
 #
 
 from __future__ import absolute_import, division, print_function
+import ansible_collections.arista.cvp.plugins.module_utils.schema_v1 as schema
 
 __metaclass__ = type
 
@@ -98,7 +101,6 @@ import ansible_collections.arista.cvp.plugins.module_utils.logger   # noqa # pyl
 import ansible_collections.arista.cvp.plugins.module_utils.tools_cv as tools_cv
 import ansible_collections.arista.cvp.plugins.module_utils.tools as tools
 import ansible_collections.arista.cvp.plugins.module_utils.tools_tree as tools_tree
-import ansible_collections.arista.cvp.plugins.module_utils.schema as schema
 from ansible.module_utils.basic import AnsibleModule
 
 # List of Ansible default containers
@@ -841,7 +843,7 @@ def main():
 
     if not schema.validate_cv_inputs(user_json=module.params['topology'], schema=schema.SCHEMA_CV_CONTAINER):
         MODULE_LOGGER.error("Invalid configlet input : %s",
-                            str(module.params['configlets']))
+                            str(module.params['topology']))
         module.fail_json(
             msg='Container input data are not compliant with module.')
 

--- a/ansible_collections/arista/cvp/plugins/modules/cv_container_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_container_v3.py
@@ -3,6 +3,8 @@
 # pylint: disable=bare-except
 # pylint: disable=dangerous-default-value
 # flake8: noqa: W503
+# pylint: disable=logging-format-interpolation
+# flake8: noqa: W1202
 #
 # GNU General Public License v3.0+
 #
@@ -74,7 +76,7 @@ import traceback
 import ansible_collections.arista.cvp.plugins.module_utils.logger   # noqa # pylint: disable=unused-import
 from ansible.module_utils.basic import AnsibleModule
 import ansible_collections.arista.cvp.plugins.module_utils.tools_cv as tools_cv
-import ansible_collections.arista.cvp.plugins.module_utils.schema as schema
+import ansible_collections.arista.cvp.plugins.module_utils.schema_v3 as schema
 from ansible_collections.arista.cvp.plugins.module_utils.container_tools import CvContainerTools, ContainerInput
 from ansible_collections.arista.cvp.plugins.module_utils.response import CvAnsibleResponse
 try:

--- a/ansible_collections/arista/cvp/plugins/modules/cv_device.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_device.py
@@ -125,7 +125,7 @@ import ansible_collections.arista.cvp.plugins.module_utils.logger   # noqa # pyl
 from ansible.module_utils.basic import AnsibleModule
 import ansible_collections.arista.cvp.plugins.module_utils.tools_cv as tools_cv
 import ansible_collections.arista.cvp.plugins.module_utils.tools as tools
-import ansible_collections.arista.cvp.plugins.module_utils.schema as schema
+import ansible_collections.arista.cvp.plugins.module_utils.schema_v1 as schema
 
 
 MODULE_LOGGER = logging.getLogger('arista.cvp.cv_device')

--- a/ansible_collections/arista/cvp/plugins/modules/cv_device_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_device_v3.py
@@ -75,7 +75,7 @@ import traceback
 import ansible_collections.arista.cvp.plugins.module_utils.logger   # noqa # pylint: disable=unused-import
 from ansible.module_utils.basic import AnsibleModule
 import ansible_collections.arista.cvp.plugins.module_utils.tools_cv as tools_cv
-import ansible_collections.arista.cvp.plugins.module_utils.schema as schema
+import ansible_collections.arista.cvp.plugins.module_utils.schema_v3 as schema
 from ansible_collections.arista.cvp.plugins.module_utils.device_tools import CvDeviceTools, DeviceInventory
 try:
     from cvprac.cvp_client_errors import CvpClientError, CvpApiError, CvpRequestError  # noqa # pylint: disable=unused-import


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Proposed changes

- Move schema for v1 in schema_v1.py
- Move schema for v3 in schema_v3.py

## How to test

Run usual playbooks

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/aristanetworks/ansible-cvp/blob/master/contributing.md#branches) document.
- [x] All new and existing tests passed (`make linting` and `make sanity-lint`).
