### PR TITLE
Add apply_mode feature to cv_container_v3

### DIFF
--- a/ansible_collections/arista/cvp/docs/_build/cv_container_v3.rst
+++ b/ansible_collections/arista/cvp/docs/_build/cv_container_v3.rst
@@ -42,6 +42,17 @@ The following options may be specified for this module:
     </tr>
 
     <tr>
+    <td>apply_mode<br/><div style="font-size: small;"></div></td>
+    <td>str</td>
+    <td>no</td>
+    <td>loose</td>
+    <td><ul><li>loose</li><li>strict</li></ul></td>
+    <td>
+        <div>Set how configlets are attached/detached on container. If set to strict all configlets not listed in your vars are detached.</div>
+    </td>
+    </tr>
+
+    <tr>
     <td>state<br/><div style="font-size: small;"></div></td>
     <td>str</td>
     <td>no</td>
@@ -73,6 +84,7 @@ Examples:
 
 ::
 
+    # task in loose mode (default)
     - name: Create container topology on CVP
       hosts: cvp
       connection: local
@@ -90,6 +102,26 @@ Examples:
         - name: 'running cv_container'
           arista.cvp.cv_container_v3:
             topology: "{{CVP_CONTAINERS}}"
+
+    # task in strict mode
+    - name: Create container topology on CVP
+      hosts: cvp
+      connection: local
+      gather_facts: no
+      vars:
+        verbose: False
+        containers:
+            Fabric:
+                parentContainerName: Tenant
+            Spines:
+                parentContainerName: Fabric
+                configlets:
+                    - container_configlet
+      tasks:
+        - name: 'running cv_container'
+          arista.cvp.cv_container_v3:
+            topology: "{{CVP_CONTAINERS}}"
+            apply_mode: strict
 
 
 

--- a/ansible_collections/arista/cvp/docs/contributing.md
+++ b/ansible_collections/arista/cvp/docs/contributing.md
@@ -1,5 +1,20 @@
 # Contribute to Arista ansible-cvp collection
 
+<!-- @import "[TOC]" {cmd="toc" depthFrom=1 depthTo=6 orderedList=false} -->
+
+<!-- code_chunk_output -->
+
+- [Contribute to Arista ansible-cvp collection](#contribute-to-arista-ansible-cvp-collection)
+  - [Reporting Bugs](#reporting-bugs)
+  - [Feature Requests](#feature-requests)
+  - [Using the issue tracker](#using-the-issue-tracker)
+  - [Branches](#branches)
+    - [Current active branches](#current-active-branches)
+  - [Pull requests](#pull-requests)
+
+<!-- /code_chunk_output -->
+
+
 Please take a moment to review this document in order to make the contribution
 process easy and effective for everyone involved.
 

--- a/ansible_collections/arista/cvp/docs/how-to/v3/cv_container_v3.md
+++ b/ansible_collections/arista/cvp/docs/how-to/v3/cv_container_v3.md
@@ -39,6 +39,10 @@ CVP_CONTAINERS:
 #### Optional inputs
 
 - `state`: Keyword to define if we want to create(present) or delete(absent) configlets. Default is set to `present`
+- `apply_mode`: Define how configlets configured to the containers are managed by ansible:
+  - `loose` (default): Configure new configlets to containers and __ignore__ configlet already configured but not listed.
+  - `strict`: Configure new configlets to containers and __remove__ configlet already configured but not listed.
+
 
 ```yaml
 - name: lab04 - cv_container lab

--- a/ansible_collections/arista/cvp/docs/modules/cv_container_v3.rst.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_container_v3.rst.md
@@ -31,6 +31,17 @@ The following options may be specified for this module:
 </tr>
 
 <tr>
+<td>apply_mode<br/><div style="font-size: small;"></div></td>
+<td>str</td>
+<td>no</td>
+<td>loose</td>
+<td><ul><li>loose</li><li>strict</li></ul></td>
+<td>
+    <div>Set how configlets are attached/detached on container. If set to strict all configlets not listed in your vars are detached.</div>
+</td>
+</tr>
+
+<tr>
 <td>state<br/><div style="font-size: small;"></div></td>
 <td>str</td>
 <td>no</td>
@@ -57,6 +68,7 @@ The following options may be specified for this module:
 
 ## Examples:
 
+    # task in loose mode (default)
     - name: Create container topology on CVP
       hosts: cvp
       connection: local
@@ -74,6 +86,26 @@ The following options may be specified for this module:
         - name: 'running cv_container'
           arista.cvp.cv_container_v3:
             topology: "{{CVP_CONTAINERS}}"
+
+    # task in strict mode
+    - name: Create container topology on CVP
+      hosts: cvp
+      connection: local
+      gather_facts: no
+      vars:
+        verbose: False
+        containers:
+            Fabric:
+                parentContainerName: Tenant
+            Spines:
+                parentContainerName: Fabric
+                configlets:
+                    - container_configlet
+      tasks:
+        - name: 'running cv_container'
+          arista.cvp.cv_container_v3:
+            topology: "{{CVP_CONTAINERS}}"
+            apply_mode: strict
 
 ### Author
 

--- a/ansible_collections/arista/cvp/docs/release-notes/v3.x.md
+++ b/ansible_collections/arista/cvp/docs/release-notes/v3.x.md
@@ -1,11 +1,11 @@
 # Release Notes For Ansible CVP 3.x
 
 !!! info
-    Documentation for 3.x.x branch [available here](https://cvp.avd.sh/en/releases-v3.x.x/)
+    Documentation for 3.x.x branch [available here](https://cvp.avd.sh/en/latest/)
 
 ## Release 3.0.0
 
-Documentation for 3.x.x branch [available here](https://cvp.avd.sh/en/releases-v3.x.x/)
+Documentation for 3.x.x branch [available here](https://cvp.avd.sh/en/latest/)
 
 ### Supported CloudVision version:
 
@@ -39,7 +39,7 @@ Documentation for 3.x.x branch [available here](https://cvp.avd.sh/en/releases-v
     configlets: "{{CVP_CONFIGLETS}}"
 ```
 
-- New module to manage tasks: [cv_task_v3](../../how-to/v3/cv_task_v3/)
+- New module to manage tasks: cv_task_v3
 
 With this new version of modules, `cv_facts` is not required anymore and execution should be significally higher than v1 version.
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/response.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/response.py
@@ -301,9 +301,9 @@ class CvManagerResult():
     }
 
     """
-    def __init__(self, builder_name: str):
+    def __init__(self, builder_name: str, default_success: bool = False):
         self.__name = builder_name
-        self.__success = False
+        self.__success = default_success
         self.__changed = False
         self.__counter: int = 0
         self.__taskIds = list()

--- a/tests/unit/test_cvContainerTools.py
+++ b/tests/unit/test_cvContainerTools.py
@@ -222,6 +222,7 @@ class TestCvContainerTools():
     def test_get_configlet_from_container(self, UNIT_TEST):
         requests.packages.urllib3.disable_warnings()
         configlets = self.inventory.get_configlets(container_name='DC1_L3LEAFS')
+        assert len(configlets) > 0
         for configlet in configlets:
             assert configlet['name'] in ['ASE_GLOBAL-ALIASES', 'ASE_GLOBAL-ALIASES2']
             logging.info('CVP returned {} and it is in the expected list'.format(configlet['name']))

--- a/tests/unit/test_cvContainerTools.py
+++ b/tests/unit/test_cvContainerTools.py
@@ -131,7 +131,6 @@ class TestCvContainerTools():
             container_name=CV_CONTAINER['name']) is False
         logging.info('Container {} is empty'.format(CV_CONTAINER))
 
-
     @pytest.mark.parametrize('UNIT_TEST', get_unit_container())
     @pytest.mark.api
     @pytest.mark.create
@@ -217,6 +216,16 @@ class TestCvContainerTools():
             logging.info(
                 'Container {} deleted from cloudvision: {}'.format(UNIT_TEST['name'], result.results))
 
+    @pytest.mark.parametrize('UNIT_TEST', get_unit_container())
+    @pytest.mark.api
+    @pytest.mark.delete
+    def test_get_configlet_from_container(self, UNIT_TEST):
+        requests.packages.urllib3.disable_warnings()
+        configlets = self.inventory.get_configlets(container_name='DC1_L3LEAFS')
+        for configlet in configlets:
+            assert configlet['name'] in ['ASE_GLOBAL-ALIASES', 'ASE_GLOBAL-ALIASES2']
+            logging.info('CVP returned {} and it is in the expected list'.format(configlet['name']))
+        logging.info('All returned configlets are in expected list')
 
 @pytest.mark.usefixtures("CvContainerTools_Manager")
 @pytest.mark.api
@@ -235,13 +244,14 @@ class TestCvContainerToolsTopology():
         assert True
 
     @pytest.mark.parametrize('USER_INPUT', get_topology_user_input())
+    @pytest.mark.parametrize('APPLY_MODE', ['strict', 'loose'])
     @pytest.mark.api
-    def test_build_topology(self, USER_INPUT):
+    def test_build_topology(self, USER_INPUT, APPLY_MODE):
         requests.packages.urllib3.disable_warnings()
         user_inventory = ContainerInput(user_topology=USER_INPUT)
         logging.info('Start of topology build process at {}'.format(time_log()))
         result = self.inventory.build_topology(
-            user_topology=user_inventory, present=True)
+            user_topology=user_inventory, present=True, apply_mode=APPLY_MODE)
         logging.info('End of topology build process at {}'.format(time_log()))
         # assert result.success is True
         assert result.success is True


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [x] Other (please describe): Update in JSON scehma

## Related Issue(s)

Fixes #321

## Proposed changes
<!--- Describe your changes in detail -->

Add a new knob in `cv_container_v3` to support strict mode

- `apply_mode`: Define how configlets configured to the container are managed by ansible:
  - `loose` (default): Configure new configlets to container and ignore configlet already configured but not listed.
  - `strict`: Configure new configlets to container and remove configlet already configured but not listed.

```yaml
# Use strict apply_mode
- name: "Configure devices on {{inventory_hostname}}"
  arista.cvp.cv_container_v3:
    topology: "{{CVP_CONTAINER_TOPO}}"
    apply_mode: strict
```

## How to test

Run pytest:

```bash
$ cd tests/unit

$ pytest test_cvContainerTools.py::TestCvContainerToolsTopology::test_build_topology -v
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/aristanetworks/ansible-cvp/blob/master/contributing.md#branches) document.
- [x] All new and existing tests passed (`make linting` and `make sanity-lint`).
