### PR TITLE
device_tools: fix DEBUG message error where a list was added instead …

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -678,7 +678,7 @@ class CvDeviceTools(object):
                 configlets_info = list()
                 configlets_attached = self.get_device_configlets(
                     device_lookup=device.fqdn)
-                MODULE_LOGGER.debug('Attached configlets for device ' + device.fqdn + ': ' + configlets_attached)
+                MODULE_LOGGER.debug('Attached configlets for device ' + device.fqdn + ': ' + str(configlets_attached))
                 # Pour chaque configlet not in the list, add to list of configlets to remove
                 for configlet in device.configlets:
                     if configlet not in [x.name for x in configlets_attached]:


### PR DESCRIPTION
When debugging is enabled we were getting the following error because in the logged DEBUG message the `configlet_attached ` variable is a list not a string```
"/var/folders/nc/chjjl2jn43j0y5jtc60xlr0c0000gn/T/ansible_arista.cvp.cv_device_v3_payload_bm29n3sx/ansible_arista.cvp.cv_device_v3_payload.zip/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py", line 681, in apply_configlets
    TypeError: can only concatenate str (not "list") to str
 ```
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):


## Proposed changes
Fixed the above by converting the list to string, ie `str(configlet_attached)`

## How to test
Doesn't affect testing
