### PR TITLE
cv_device_v3 error handling improvments

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -720,11 +720,16 @@ class CvDeviceTools(object):
                 configlets_attached = self.get_device_configlets(
                     device_lookup=device.fqdn)
                 MODULE_LOGGER.debug('Attached configlets for device %s : %s', str(device.fqdn), str(configlets_attached))
-                # Pour chaque configlet not in the list, add to list of configlets to remove
+                # For each configlet not in the list, add to list of configlets to remove
                 for configlet in device.configlets:
                     if configlet not in [x.name for x in configlets_attached]:
-                        configlets_info.append(
-                            self.__get_configlet_info(configlet_name=configlet))
+                        new_configlet = self.__get_configlet_info(configlet_name=configlet)
+                        if new_configlet is None:
+                            error_message = "The configlet \'{}\' defined to be applied on the device \'{}\' does not exist on the CVP server.".format(str(configlet), str(device.fqdn))
+                            MODULE_LOGGER.error(error_message)
+                            self.__ansible.fail_json(msg=error_message)
+                        else:
+                            configlets_info.append(new_configlet)
                 # get device facts from CV
                 device_facts = dict()
                 if self.__search_by == FIELD_FQDN:

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -554,7 +554,6 @@ class CvDeviceTools(object):
                 if self.is_device_exist(device.system_mac) == False:
                     device_not_present.append(device.system_mac)
                     MODULE_LOGGER.error('Device not present in CVP but in the user_inventory: %s', device.system_mac)
-            
         return device_not_present
 
     # ------------------------------------------ #
@@ -593,7 +592,7 @@ class CvDeviceTools(object):
 
         # Check if the devices defined exist in CVP
         list_non_existing_devices = self.check_device_exist(user_inventory=user_inventory, search_mode=search_mode)
-        if list_non_existing_devices is not None and len(list_non_existing_devices) > 0: 
+        if list_non_existing_devices is not None and len(list_non_existing_devices) > 0:
             error_message = 'Error - the following devices do not exist in CVP {} but are defined in the playbook. \
             \nMake sure that the devices are provisioned and defined with the full fqdn name (including the domain name) if needed.'.format(str(list_non_existing_devices))
             MODULE_LOGGER.error(error_message)

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -656,10 +656,12 @@ class CvDeviceTools(object):
             result_data = CvApiResult(
                 action_name='{}_to_{}'.format(device.fqdn, *device.container))
             if device.system_mac is not None:
-                new_container_info = self.get_container_info(
-                    container_name=device.container)
-                current_container_info = self.get_container_current(
-                    device_mac=device.system_mac)
+                new_container_info = self.get_container_info(container_name=device.container)
+                if new_container_info is None: 
+                    error_message = 'The target container \'{}\' for the device \'{}\' does not exist on CVP.'.format(device.container, device.fqdn)
+                    MODULE_LOGGER.error(error_message)
+                    self.__ansible.fail_json(msg=error_message)
+                current_container_info = self.get_container_current(device_mac=device.system_mac)
                 # Move devices when they are not in undefined container
                 if (current_container_info is not None
                     and current_container_info['name'] != UNDEFINED_CONTAINER

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -657,7 +657,7 @@ class CvDeviceTools(object):
                 action_name='{}_to_{}'.format(device.fqdn, *device.container))
             if device.system_mac is not None:
                 new_container_info = self.get_container_info(container_name=device.container)
-                if new_container_info is None: 
+                if new_container_info is None:
                     error_message = 'The target container \'{}\' for the device \'{}\' does not exist on CVP.'.format(device.container, device.fqdn)
                     MODULE_LOGGER.error(error_message)
                     self.__ansible.fail_json(msg=error_message)
@@ -882,7 +882,7 @@ class CvDeviceTools(object):
                     else:
                         ## Check if the target container exists
                         target_container_info = self.get_container_info(container_name=device.container)
-                        if target_container_info is None: 
+                        if target_container_info is None:
                             error_message = 'The target container \'{}\' for the device \'{}\' does not exist on CVP.'.format(device.container, device.fqdn)
                             MODULE_LOGGER.error(error_message)
                             self.__ansible.fail_json(msg=error_message)

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -591,11 +591,7 @@ class CvDeviceTools(object):
         cv_configlets_attach = CvManagerResult(builder_name='configlets_attached')
         cv_configlets_detach = CvManagerResult(builder_name='configlets_detached')
 
-        MODULE_LOGGER.debug('user_inventory: %s ', str(user_inventory))
-        MODULE_LOGGER.debug('user_inventory.devices: %s ', str(user_inventory.devices))
-        # MODULE_LOGGER.debug('user_inventory.devices.fqdn: %s ', str(user_inventory.devices.fqdn))
-        # MODULE_LOGGER.debug('user_inventory.devices.system_mac: %s ', str(user_inventory.devices.system_mac))
-
+        # Check if the devices defined exist in CVP
         list_non_existing_devices = self.check_device_exist(user_inventory=user_inventory, search_mode=search_mode)
         if list_non_existing_devices is not None and len(list_non_existing_devices) > 0: 
             error_message = 'Error - the following devices do not exist in CVP {} but are defined in the playbook. \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
https://github.com/aristanetworks/ansible-cvp/issues/317 

## Proposed changes
The following failure scenario are now returning an understandable error message and the playbook is failing.
* Device not present in CVP. Error message: 
```
fatal: [cv_server]: FAILED! => changed=false 
  msg: |-
    Error - the following devices do not exist in CVP ['non-existing-device'] but are defined in the playbook.
    Make sure that the devices are provisioned and defined with the full fqdn name (including the domain name) if needed.
    
    PLAY RECAP ***********************************************************************************************************************************************************************************************************************
cv_server                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```
* Target container not present in CVP (both from Undefinied container and from non-Undefinied container). Error message: 
```
fatal: [cv_server]: FAILED! => changed=false 
  msg: The target container 'non-existing-container' for the device 'mydevice' does not exist on CVP.
  
  PLAY RECAP ***********************************************************************************************************************************************************************************************************************
cv_server                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```
* Configlet not present in CVP (Both from Undefinied container and from non-Undefinied container). Error message: 
```
fatal: [cv_server]: FAILED! => changed=false 
  msg: The configlet 'unexisting configlet' defined to be applied on the device 'mydevice' does not exist on the CVP server.

PLAY RECAP ***********************************************************************************************************************************************************************************************************************
cv_server                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

See the scenarios describe above.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/aristanetworks/ansible-cvp/blob/master/contributing.md#branches) document.
- [x] All new and existing tests passed (`make linting` and `make sanity-lint`).
