### PR TITLE
cv_device_v3: Add support for absent and factory_reset

### DIFF
--- a/ansible_collections/arista/cvp/plugins/modules/cv_device_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_device_v3.py
@@ -140,7 +140,7 @@ def main():
         state=dict(type='str',
                    required=False,
                    default='present',
-                   choices=['present', 'absent']),
+                   choices=['present', 'absent', 'factory_reset']),
         apply_mode=dict(type='str',
                         required=False,
                         default='loose',
@@ -154,9 +154,6 @@ def main():
     result = dict(changed=False, data={}, failed=False)
     result['data']['taskIds'] = list()
     result['data']['tasks'] = list()
-
-    if ansible_module.params['state'] == 'absent':
-        ansible_module.fail_json(msg='State==absent is not yet supported !')
 
     # Test all libs are correctly installed
     check_import(ansible_module=ansible_module)
@@ -175,7 +172,7 @@ def main():
     cv_topology = CvDeviceTools(
         cv_connection=cv_client, ansible_module=ansible_module, check_mode=ansible_module.check_mode)
 
-    result = cv_topology.manager(user_inventory=user_topology, apply_mode=ansible_module.params['apply_mode'])
+    result = cv_topology.manager(user_inventory=user_topology, state=ansible_module.params['state'], apply_mode=ansible_module.params['apply_mode'])
 
     ansible_module.exit_json(**result)
 


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #361

## Component(s) name

`arista.cvp.cv_device_v3`

## Proposed changes
Add support for absent and factory_reset of devices. 

* Remove the device from the provisioning page (same action as in the UI: right-click on device > Remove). 
```
Syntax :
    - name: "Absent device"
      arista.cvp.cv_device_v3:
        devices: "{{devices}}"
        state: absent
```
* Factory reset the device (in the UI: right-click on device > Factory Reset)
Syntax:
```
    - name: "Factory reset device"
      arista.cvp.cv_device_v3:
        devices: "{{devices}}"
        state: factory_reset
```

It is also possible to run automatically the generated task by the `factory_reset`: 

```
    - name: "Factory reset device"
      arista.cvp.cv_device_v3:
        devices: "{{devices}}"
        state: factory_reset
      register: CV_DEVICE_OUTPUT

    - name: Execute generated tasks
      arista.cvp.cv_task_v3:
        tasks: "{{ CV_DEVICE_OUTPUT.taskIds }}"
      register: CVP_FACTS
```

## How to test
Playbook 1: Absent 
```
  tasks:
    - name: "Absent device"
      arista.cvp.cv_device_v3:
        devices: "{{devices}}"
        state: absent
```

Playbook 2: Factory reset
```
  tasks:
    - name: "Factory reset device"
      arista.cvp.cv_device_v3:
        devices: "{{devices}}"
        state: factory_reset
      register: CV_DEVICE_OUTPUT

    - name: Print return information from the previous task
      debug:
        msg: '{{ CV_DEVICE_OUTPUT }}'

    - name: Execute generated tasks
      arista.cvp.cv_task_v3:
        tasks: "{{ CV_DEVICE_OUTPUT.taskIds }}"
      register: CVP_FACTS
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
