### PR TITLE
Implement default search on Hostname field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ webdoc: ## Build documentation to publish static content
 
 .PHONY: check-cvp-404
 check-cvp-404: ## Check local 404 links for AVD documentation
-	docker run --rm --network container:webdoc_cvp raviqqe/muffet:1.5.7 http://127.0.0.1:8000 -e ".*fonts.gstatic.com.*" -e ".*edit.*" -f --limit-redirections=3 --timeout=$(MUFFET_TIMEOUT)
+	docker run --rm --network container:webdoc_cvp raviqqe/muffet:1.5.7 http://127.0.0.1:8000 -e ".*fonts.googleapis.com.*" -e ".*fonts.gstatic.com.*" -e ".*edit.*" -f --limit-redirections=3 --timeout=${MUFFET_TIMEOUT}
 
 #########################################
 # Misc Actions 							#

--- a/ansible_collections/arista/cvp/README.md
+++ b/ansible_collections/arista/cvp/README.md
@@ -185,4 +185,4 @@ Contributing pull requests are gladly welcomed for this repository. If you are p
 
 You can also open an [issue](https://github.com/aristanetworks/ansible-cvp/issues) to report any problem or to submit enhancement.
 
-A more complete [guide for contribution](https://www.avd.sh/en/latest/docs/contributing/) is available in the repository
+A more complete [guide for contribution](https://avd.sh/en/latest/docs/contribution/overview.html) is available in the repository

--- a/ansible_collections/arista/cvp/docs/_build/cv_device_v3.rst
+++ b/ansible_collections/arista/cvp/docs/_build/cv_device_v3.rst
@@ -63,6 +63,17 @@ The following options may be specified for this module:
     </tr>
 
     <tr>
+    <td>search_key<br/><div style="font-size: small;"></div></td>
+    <td>str</td>
+    <td>no</td>
+    <td>hostname</td>
+    <td><ul><li>fqdn</li><li>hostname</li></ul></td>
+    <td>
+        <div>Key name to use to look for device in Cloudvision.</div>
+    </td>
+    </tr>
+
+    <tr>
     <td>state<br/><div style="font-size: small;"></div></td>
     <td>str</td>
     <td>no</td>

--- a/ansible_collections/arista/cvp/docs/modules/cv_device_v3.rst.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_device_v3.rst.md
@@ -52,6 +52,17 @@ The following options may be specified for this module:
 </tr>
 
 <tr>
+<td>search_key<br/><div style="font-size: small;"></div></td>
+<td>str</td>
+<td>no</td>
+<td>hostname</td>
+<td><ul><li>fqdn</li><li>hostname</li></ul></td>
+<td>
+    <div>Key name to use to look for device in Cloudvision.</div>
+</td>
+</tr>
+
+<tr>
 <td>state<br/><div style="font-size: small;"></div></td>
 <td>str</td>
 <td>no</td>

--- a/ansible_collections/arista/cvp/docs/release-notes/v1.x.md
+++ b/ansible_collections/arista/cvp/docs/release-notes/v1.x.md
@@ -16,7 +16,7 @@ __Enhancements__
 - Report better error message when device not reachable (#205)
 - Add role to support configlets synchronisation between cloudvision servers (#196)
 - Allow `dhcp_configuration` role to only generate `dhcpd.conf` file (#206)
-- Publish collection documentation on [github.io](https://aristanetworks.github.io/ansible-cvp)
+- Publish collection documentation on github.io
 
 __Fixed issues__
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
@@ -86,7 +86,7 @@ class ContainerInput(object):
         """
         for container_name in self.__topology:
             if FIELD_CONFIGLETS not in self.__topology[container_name]:
-                self.__topology[container_name].update({FIELD_CONFIGLETS:[]})
+                self.__topology[container_name].update({FIELD_CONFIGLETS: []})
 
     def __get_container_data(self, container_name: str, key_name: str):
         """

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -552,7 +552,7 @@ class CvDeviceTools(object):
         device_not_present: list = list()
         for device in user_inventory.devices:
             if self.__search_by == FIELD_HOSTNAME or search_mode == FIELD_HOSTNAME:
-                if self.is_device_exist(device.fqdn, search_field=FIELD_HOSTNAME) is False:
+                if self.is_device_exist(device.fqdn) is False:
                     device_not_present.append(device.fqdn)
                     MODULE_LOGGER.error('Device not present in CVP but in the user_inventory: %s', device.fqdn)
 
@@ -608,6 +608,9 @@ class CvDeviceTools(object):
         # Need to collect all missing device systemMacAddress
         # deploy needs to locate devices by mac-address
         if self.__search_by == FIELD_FQDN or search_mode == FIELD_FQDN:
+            user_inventory = self.refresh_systemMacAddress(user_inventory=user_inventory)
+
+        if self.__search_by == FIELD_HOSTNAME or search_mode == FIELD_HOSTNAME:
             user_inventory = self.refresh_systemMacAddress(user_inventory=user_inventory)
 
         action_result = self.deploy_device(user_inventory=user_inventory)

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -552,12 +552,12 @@ class CvDeviceTools(object):
         device_not_present: list = list()
         for device in user_inventory.devices:
             if self.__search_by == FIELD_HOSTNAME or search_mode == FIELD_HOSTNAME:
-                if self.is_device_exist(device.fqdn, search_field=FIELD_HOSTNAME) == False:
+                if self.is_device_exist(device.fqdn, search_field=FIELD_HOSTNAME) is False:
                     device_not_present.append(device.fqdn)
                     MODULE_LOGGER.error('Device not present in CVP but in the user_inventory: %s', device.fqdn)
 
             elif self.__search_by == FIELD_SYSMAC:
-                if self.is_device_exist(device.system_mac) == False:
+                if self.is_device_exist(device.system_mac) is False:
                     device_not_present.append(device.system_mac)
                     MODULE_LOGGER.error('Device not present in CVP but in the user_inventory: %s', device.system_mac)
         return device_not_present
@@ -599,11 +599,11 @@ class CvDeviceTools(object):
         # Check if the devices defined exist in CVP
         list_non_existing_devices = self.check_device_exist(user_inventory=user_inventory, search_mode=search_mode)
         if list_non_existing_devices is not None and len(list_non_existing_devices) > 0:
-            error_message = 'Error - the following devices do not exist in CVP {} but are defined in the playbook. \
-            \nMake sure that the devices are provisioned and defined with the full fqdn name (including the domain name) if needed.'.format(str(list_non_existing_devices))
+            error_message = 'Error - the following devices do not exist in CVP {1} but are defined in the playbook. \
+                \nMake sure that the devices are provisioned and defined with the full fqdn name \
+                (including the domain name) if needed.'.format(str(list_non_existing_devices))
             MODULE_LOGGER.error(error_message)
             self.__ansible.fail_json(msg=error_message)
-
 
         # Need to collect all missing device systemMacAddress
         # deploy needs to locate devices by mac-address
@@ -663,7 +663,7 @@ class CvDeviceTools(object):
             if device.system_mac is not None:
                 new_container_info = self.get_container_info(container_name=device.container)
                 if new_container_info is None:
-                    error_message = 'The target container \'{}\' for the device \'{}\' does not exist on CVP.'.format(device.container, device.fqdn)
+                    error_message = 'The target container \'{1}\' for the device \'{2}\' does not exist on CVP.'.format(device.container, device.fqdn)
                     MODULE_LOGGER.error(error_message)
                     self.__ansible.fail_json(msg=error_message)
                 current_container_info = self.get_container_current(device_mac=device.system_mac)
@@ -730,7 +730,8 @@ class CvDeviceTools(object):
                     if configlet not in [x.name for x in configlets_attached]:
                         new_configlet = self.__get_configlet_info(configlet_name=configlet)
                         if new_configlet is None:
-                            error_message = "The configlet \'{}\' defined to be applied on the device \'{}\' does not exist on the CVP server.".format(str(configlet), str(device.fqdn))
+                            error_message = "The configlet \'{1}\' defined to be applied on the device \'{2}\' does not \
+                                exist on the CVP server.".format(str(configlet), str(device.fqdn))
                             MODULE_LOGGER.error(error_message)
                             self.__ansible.fail_json(msg=error_message)
                         else:
@@ -877,7 +878,8 @@ class CvDeviceTools(object):
                 for configlet in device.configlets:
                     new_configlet = self.__get_configlet_info(configlet_name=configlet)
                     if new_configlet is None:
-                        error_message = "The configlet \'{}\' defined to be applied on the device \'{}\' does not exist on the CVP server.".format(str(configlet), str(device.fqdn))
+                        error_message = "The configlet \'{1}\' defined to be applied on the device \'{2}\' does not \
+                            exist on the CVP server.".format(str(configlet), str(device.fqdn))
                         MODULE_LOGGER.error(error_message)
                         self.__ansible.fail_json(msg=error_message)
                     else:
@@ -894,10 +896,10 @@ class CvDeviceTools(object):
                         result_data.success = True
                         result_data.taskIds = ['unsupported_in_check_mode']
                     else:
-                        ## Check if the target container exists
+                        # Check if the target container exists
                         target_container_info = self.get_container_info(container_name=device.container)
                         if target_container_info is None:
-                            error_message = 'The target container \'{}\' for the device \'{}\' does not exist on CVP.'.format(device.container, device.fqdn)
+                            error_message = 'The target container \'{1}\' for the device \'{2}\' does not exist on CVP.'.format(device.container, device.fqdn)
                             MODULE_LOGGER.error(error_message)
                             self.__ansible.fail_json(msg=error_message)
                         try:

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -648,7 +648,7 @@ class CvDeviceTools(object):
         # Check if the devices defined exist in CVP
         list_non_existing_devices = self.check_device_exist(user_inventory=user_inventory, search_mode=search_mode)
         if list_non_existing_devices is not None and len(list_non_existing_devices) > 0:
-            error_message = 'Error - the following devices do not exist in CVP {1} but are defined in the playbook. \
+            error_message = 'Error - the following devices do not exist in CVP {0} but are defined in the playbook. \
                 \nMake sure that the devices are provisioned and defined with the full fqdn name \
                 (including the domain name) if needed.'.format(str(list_non_existing_devices))
             MODULE_LOGGER.error(error_message)

--- a/ansible_collections/arista/cvp/plugins/modules/cv_container_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_container_v3.py
@@ -148,9 +148,9 @@ def main():
                    default='present',
                    choices=['present', 'absent']),
         apply_mode=dict(type='str',
-                   required=False,
-                   default='loose',
-                   choices=['loose', 'strict'])
+                        required=False,
+                        default='loose',
+                        choices=['loose', 'strict'])
     )
 
     # Make module global to use it in all functions when required

--- a/ansible_collections/arista/cvp/plugins/modules/cv_device_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_device_v3.py
@@ -52,6 +52,12 @@ options:
     default: 'loose'
     choices: ['loose', 'strict']
     type: str
+  search_key:
+    description: Key name to use to look for device in Cloudvision.
+    required: false
+    default: 'hostname'
+    choices: ['fqdn', 'hostname']
+    type: str
 '''
 
 EXAMPLES = r'''
@@ -144,7 +150,11 @@ def main():
         apply_mode=dict(type='str',
                         required=False,
                         default='loose',
-                        choices=['loose', 'strict'])
+                        choices=['loose', 'strict']),
+        search_key=dict(type='str',
+                        required=False,
+                        default='hostname',
+                        choices=['fqdn', 'hostname'])
     )
 
     # Make module global to use it in all functions when required
@@ -173,9 +183,14 @@ def main():
 
     # Instantiate data
     cv_topology = CvDeviceTools(
-        cv_connection=cv_client, ansible_module=ansible_module, check_mode=ansible_module.check_mode)
+        cv_connection=cv_client,
+        ansible_module=ansible_module,
+        check_mode=ansible_module.check_mode)
 
-    result = cv_topology.manager(user_inventory=user_topology, apply_mode=ansible_module.params['apply_mode'])
+    result = cv_topology.manager(
+        user_inventory=user_topology,
+        apply_mode=ansible_module.params['apply_mode'],
+        search_mode=ansible_module.params['search_key'])
 
     ansible_module.exit_json(**result)
 

--- a/ansible_collections/arista/cvp/requirements.txt
+++ b/ansible_collections/arista/cvp/requirements.txt
@@ -2,6 +2,6 @@ netaddr>=0.7.19
 Jinja2>=2.10.3
 paramiko>=2.7.1
 requests==2.22.0
-cvprac>=1.0.5
+cvprac>=1.0.7
 jsonschema>=3.2.0
 treelib==1.5.5

--- a/tests/unit/test_cvDeviceTools.py
+++ b/tests/unit/test_cvDeviceTools.py
@@ -17,7 +17,7 @@ sys.path.append("../")
 sys.path.append("../../")
 from cvprac.cvp_client import CvpClient
 from ansible_collections.arista.cvp.plugins.module_utils.device_tools import DeviceInventory, CvDeviceTools, FIELD_CONTAINER_NAME
-from ansible_collections.arista.cvp.plugins.module_utils.device_tools import FIELD_FQDN, FIELD_SYSMAC, FIELD_ID, FIELD_PARENT_NAME, FIELD_PARENT_ID
+from ansible_collections.arista.cvp.plugins.module_utils.device_tools import FIELD_FQDN, FIELD_SYSMAC, FIELD_ID, FIELD_PARENT_NAME, FIELD_PARENT_ID, FIELD_HOSTNAME
 # from ansible_collections.arista.cvp.plugins.module_utils.response import CvApiResult, CvManagerResult
 import config
 
@@ -26,6 +26,8 @@ import ssl
 import requests.packages.urllib3
 ssl._create_default_https_context = ssl._create_unverified_context
 requests.packages.urllib3.disable_warnings()
+
+ANSIBLE_CV_SEARCH_MODE = 'hostname'
 
 CVP_DEVICES = [
     {
@@ -37,7 +39,6 @@ CVP_DEVICES = [
                 "01TRAINING-01",
                 "CV-EOS-ANSIBLE01"
         ],
-        "imageBundle": []
     }
 ]
 CVP_DEVICES_UNKNOWN = [
@@ -171,6 +172,9 @@ class TestCvDeviceTools():
         logging.info('Setter & Getter for search_by using {} is valid'.format(FIELD_SYSMAC))
         self.inventory.search_by = FIELD_FQDN
         assert self.inventory.search_by == FIELD_FQDN
+        self.inventory.search_by = FIELD_HOSTNAME
+        assert self.inventory.search_by == FIELD_HOSTNAME
+        self.inventory.search_by = ANSIBLE_CV_SEARCH_MODE
         logging.info(
             'Setter & Getter for search_by using {} is valid'.format(FIELD_FQDN))
 
@@ -224,7 +228,10 @@ class TestCvDeviceTools():
         logging.info('End of CV query at {}'.format(time_log()))
         assert device_facts is not None
         assert FIELD_FQDN in device_facts
-        assert device_facts[FIELD_FQDN] == CV_DEVICE[FIELD_FQDN]
+        if self.inventory.search_by == 'fqdn':
+            assert device_facts[FIELD_FQDN] == CV_DEVICE[FIELD_FQDN]
+        elif self.inventory.search_by == 'hostname':
+            assert device_facts[FIELD_FQDN].split(".")[0] == CV_DEVICE[FIELD_FQDN]
         logging.info('Facts for device {} are correct: {}'.format(CV_DEVICE[FIELD_FQDN], device_facts))
 
 
@@ -329,7 +336,7 @@ class TestCvDeviceTools():
         for device in user_inventory.devices:
             result = self.inventory.get_device_container(
                 device_lookup=device.fqdn)[FIELD_PARENT_NAME]
-            cv_result = self.cvp.api.get_device_by_name(device.fqdn)[FIELD_CONTAINER_NAME]
+            cv_result = self.cvp.api.get_device_by_name(device.fqdn, search_field=ANSIBLE_CV_SEARCH_MODE)[FIELD_CONTAINER_NAME]
             assert result == cv_result
             logging.info(
                 'Collection: {} - CV: {}'.format(result, cv_result))
@@ -344,7 +351,7 @@ class TestCvDeviceTools():
             result = self.inventory.get_device_container(
                 device_lookup=device.fqdn)[FIELD_PARENT_ID]
             cv_result = self.cvp.api.get_device_by_name(
-                device.fqdn)[FIELD_PARENT_ID]
+                device.fqdn, search_field=ANSIBLE_CV_SEARCH_MODE)[FIELD_PARENT_ID]
             assert result == cv_result
             logging.info(
                 'Collection: {} - CV: {}'.format(result, cv_result))
@@ -359,7 +366,7 @@ class TestCvDeviceTools():
                 self.inventory.search_by = FIELD_SYSMAC
                 device_info = self.inventory.get_device_facts(
                     device_lookup=device.system_mac)
-                assert device_info[FIELD_FQDN] == device.fqdn
+                assert device_info[FIELD_FQDN].split(".")[0] == device.fqdn
                 assert device_info[FIELD_SYSMAC] == device.system_mac
                 self.inventory.search_by = FIELD_FQDN
                 logging.info('Data for device {} ({}) are correct'.format(

--- a/tests/unit/test_cvDeviceTools.py
+++ b/tests/unit/test_cvDeviceTools.py
@@ -28,6 +28,8 @@ ssl._create_default_https_context = ssl._create_unverified_context
 requests.packages.urllib3.disable_warnings()
 
 ANSIBLE_CV_SEARCH_MODE = 'hostname'
+# IS_HOSTNAME_SEARCH = True
+
 
 CVP_DEVICES = [
     {
@@ -336,7 +338,7 @@ class TestCvDeviceTools():
         for device in user_inventory.devices:
             result = self.inventory.get_device_container(
                 device_lookup=device.fqdn)[FIELD_PARENT_NAME]
-            cv_result = self.cvp.api.get_device_by_name(device.fqdn, search_field=ANSIBLE_CV_SEARCH_MODE)[FIELD_CONTAINER_NAME]
+            cv_result = self.cvp.api.get_device_by_name(device.fqdn, search_by_hostname=ANSIBLE_CV_SEARCH_MODE)[FIELD_CONTAINER_NAME]
             assert result == cv_result
             logging.info(
                 'Collection: {} - CV: {}'.format(result, cv_result))
@@ -351,7 +353,7 @@ class TestCvDeviceTools():
             result = self.inventory.get_device_container(
                 device_lookup=device.fqdn)[FIELD_PARENT_ID]
             cv_result = self.cvp.api.get_device_by_name(
-                device.fqdn, search_field=ANSIBLE_CV_SEARCH_MODE)[FIELD_PARENT_ID]
+                device.fqdn, search_by_hostname=ANSIBLE_CV_SEARCH_MODE)[FIELD_PARENT_ID]
             assert result == cv_result
             logging.info(
                 'Collection: {} - CV: {}'.format(result, cv_result))


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #365

## Component(s) name

`arista.cvp.cv_device_v3`

## Proposed changes

Use hostname field instead of FQDN to avoid issue when inventory use hostname only and devices configured with `dns domain`
    
It is required to fix issue [#152](https://github.com/aristanetworks/cvprac/issues/152) in cvprac.

New module option:

```yaml
- name: Device Management in Cloudvision
  hosts: cv_server
  connection: local
  gather_facts: false
  tasks:
    - name: "Configure devices on {{inventory_hostname}}"
      arista.cvp.cv_device_v3:
        devices: '{{CVP_DEVICES}}'
        state: present
        apply_mode: strict
        # supported options: ['hostname', 'fqdn'] default is `hostname`
        search_key: hostname
```

## How to test

Pytest CI has been updated to reflect this change

15 passed, 3 skipped in 15.13s

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
