### PR TITLE
Add support for reordering of configlet in cv_device_v3

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -753,11 +753,9 @@ class CvDeviceTools(object):
                                                                            create_task=True,
                                                                            reorder_configlets=True)
                 except TypeError:
-                    MODULE_LOGGER.warning('The function to reorder the configlet is not present. Check cvprac version. Continuing without reordering.')
-                    resp = self.__cv_client.api.apply_configlets_to_device(app_name='CvDeviceTools.apply_configlets',
-                                                                           dev=device_facts,
-                                                                           new_configlets=new_configlets_list,
-                                                                           create_task=True)
+                    error_message = 'The function to reorder the configlet is not present. Please, check your cvprac version ( >= 1.0.7 required).'
+                    MODULE_LOGGER.error(error_message)
+                    self.__ansible.fail_json(msg=error_message)
                 except CvpApiError:
                     MODULE_LOGGER.error('Error applying configlets to device')
                     self.__ansible.fail_json(msg='Error applying configlets to device')

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -714,7 +714,7 @@ class CvDeviceTools(object):
             if (device.configlets is None or current_container_info['name'] == UNDEFINED_CONTAINER):
                 continue
             # get configlet information from CV
-            configlets_info = list()
+            new_configlets_list = list()
             configlets_attached = self.get_device_configlets(device_lookup=device.fqdn)
             MODULE_LOGGER.debug('Attached configlets for device %s : %s', str(device.fqdn), str([x.name for x in configlets_attached ]))
             
@@ -727,18 +727,18 @@ class CvDeviceTools(object):
                 
                 # If the configlet is not applied, add it to the list
                 if configlet not in [x.name for x in configlets_attached]:
-                    configlets_info.append(new_configlet)
+                    new_configlets_list.append(new_configlet)
 
                 # If the confilet is already applied, remove it from the main list and add it to the end of the new list
                 else: 
-                    MODULE_LOGGER.warning("Removing the configlet %s from the current configlet list and adding it to the new list.", str(configlet))
+                    MODULE_LOGGER.debug("Removing the configlet %s from the current configlet list and adding it to the new list.", str(configlet))
                     for x in configlets_attached:
                         if x.name == configlet:
                             configlets_attached.remove(x)
-                            configlets_info.append(new_configlet)
+                            new_configlets_list.append(new_configlet)
             configlets_attached_get_configlet_info =  [ self.__get_configlet_info(configlet_name=x.name) for x in configlets_attached ]
             # Joining the 2 new list (configlets already present + new configlet in right order)
-            configlets_joined = configlets_attached_get_configlet_info + configlets_info
+            configlets_joined = configlets_attached_get_configlet_info + new_configlets_list
             MODULE_LOGGER.debug("Final configlet list for device  [%s] is: %s", str(device.fqdn), str( [ x['name'] for x in configlets_joined ] ))
             # get device facts from CV
             device_facts = dict()
@@ -747,17 +747,16 @@ class CvDeviceTools(object):
             # Attach configlets to device
             if len(configlets_joined) > 0:
                 try:
-                    
                     resp = self.__cv_client.api.apply_configlets_to_device(app_name='CvDeviceTools.apply_configlets',
                                                                             dev=device_facts,
                                                                             new_configlets=configlets_joined,
                                                                             create_task=True, 
                                                                             reorder_configlets = True) 
                 except TypeError as e:
-                    MODULE_LOGGER.warning("The function to reorder the configlet is not present. Please check your cvprac version. Continuing without reordering.")
+                    MODULE_LOGGER.warning("The function to reorder the configlet is not present. Please check your cvprac version if re-ordering the configlets is needed. Continuing without reordering.")
                     resp = self.__cv_client.api.apply_configlets_to_device(app_name='CvDeviceTools.apply_configlets',
                                                                             dev=device_facts,
-                                                                            new_configlets=configlets_info,
+                                                                            new_configlets=new_configlets_list,
                                                                             create_task=True) 
                 except CvpApiError:
                     MODULE_LOGGER.error('Error applying configlets to device')

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -706,29 +706,57 @@ class CvDeviceTools(object):
         list
             List of CvApiResult for all API calls
         """
+        MODULE_LOGGER.debug('FIND ME: Using the apply_configlets PR function')
         results = list()
         for device in user_inventory.devices:
             result_data = CvApiResult(
                 action_name=device.fqdn + '_configlet_attached')
             current_container_info = self.get_container_current(
                 device_mac=device.system_mac)
-            if (device.configlets is not None
-                    and current_container_info['name'] != UNDEFINED_CONTAINER):
+            if (device.configlets is not None and current_container_info['name'] != UNDEFINED_CONTAINER):
                 # get configlet information from CV
                 configlets_info = list()
                 configlets_attached = self.get_device_configlets(
                     device_lookup=device.fqdn)
                 MODULE_LOGGER.debug('Attached configlets for device %s : %s', str(device.fqdn), str(configlets_attached))
-                # For each configlet not in the list, add to list of configlets to remove
+                
                 for configlet in device.configlets:
+                    new_configlet = self.__get_configlet_info(configlet_name=configlet)
+                    if new_configlet is None:
+                        error_message = "The configlet \'{}\' defined to be applied on the device \'{}\' does not exist on the CVP server.".format(str(configlet), str(device.fqdn))
+                        MODULE_LOGGER.error(error_message)
+                        self.__ansible.fail_json(msg=error_message)
+                    
+                    MODULE_LOGGER.debug("Configlets attached: %s", str(configlets_attached))
+
+
+
+                    ### TODO: TO DEBUG
+                    configlets_attached_only_names =  [x.name for x in configlets_attached ]
+                    MODULE_LOGGER.debug("configlets_attached_only_names: %s", str(configlets_attached_only_names))
+
+                    # If the configlet is not applied, add it to the list
                     if configlet not in [x.name for x in configlets_attached]:
-                        new_configlet = self.__get_configlet_info(configlet_name=configlet)
-                        if new_configlet is None:
-                            error_message = "The configlet \'{}\' defined to be applied on the device \'{}\' does not exist on the CVP server.".format(str(configlet), str(device.fqdn))
-                            MODULE_LOGGER.error(error_message)
-                            self.__ansible.fail_json(msg=error_message)
-                        else:
-                            configlets_info.append(new_configlet)
+                        configlets_info.append(new_configlet)
+
+                    # If the confilet is already applied, remove it from the main list and add it to the end of the new list
+                    else: 
+                        MODULE_LOGGER.warning("Removing the configlet %s from the main list", str(configlet))
+                        for x in configlets_attached:
+                            if x.name == configlet:
+                                configlets_attached.remove(x)
+                                configlets_info.append(new_configlet)
+
+                configlets_attached_get_configlet_info =  [ self.__get_configlet_info(configlet_name=x.name) for x in configlets_attached ]
+                
+                MODULE_LOGGER.debug("configlets_attached: %s", str(configlets_attached))
+                MODULE_LOGGER.debug("configlets_attached_get_configlet_info: %s", str(configlets_attached_get_configlet_info))
+                MODULE_LOGGER.debug("configlets_info: %s", str(configlets_info))
+
+                # Joining the 2 new list (configlets already present + new configlet in right order)
+                configlets_info = configlets_attached_get_configlet_info + configlets_info
+                MODULE_LOGGER.debug("Final configlet list for device  [%s] is: %s", str(device.fqdn), str(configlets_info))
+
                 # get device facts from CV
                 device_facts = dict()
                 if self.__search_by == FIELD_FQDN:
@@ -740,7 +768,8 @@ class CvDeviceTools(object):
                         resp = self.__cv_client.api.apply_configlets_to_device(app_name='CvDeviceTools.apply_configlets',
                                                                                dev=device_facts,
                                                                                new_configlets=configlets_info,
-                                                                               create_task=True)
+                                                                               create_task=True, 
+                                                                               reorder_configlets = True)
                     except CvpApiError:
                         MODULE_LOGGER.error('Error applying configlets to device')
                         self.__ansible.fail_json(msg='Error applying configlets to device')

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -721,7 +721,7 @@ class CvDeviceTools(object):
             for configlet in device.configlets:
                 new_configlet = self.__get_configlet_info(configlet_name=configlet)
                 if new_configlet is None:
-                    error_message = "The configlet \'{}\' defined to be applied on the device \'{}\' does not exist on the CVP server.".format(str(configlet), str(device.fqdn))
+                    error_message = "The configlet \'%s\' defined to be applied on the device \'%s\' does not exist on CVP.", str(configlet), str(device.fqdn)
                     MODULE_LOGGER.error(error_message)
                     self.__ansible.fail_json(msg=error_message)
 
@@ -748,16 +748,16 @@ class CvDeviceTools(object):
             if len(configlets_joined) > 0:
                 try:
                     resp = self.__cv_client.api.apply_configlets_to_device(app_name='CvDeviceTools.apply_configlets',
-                                                                            dev=device_facts,
-                                                                            new_configlets=configlets_joined,
-                                                                            create_task=True,
-                                                                            reorder_configlets=True)
+                                                                           dev=device_facts,
+                                                                           new_configlets=configlets_joined,
+                                                                           create_task=True,
+                                                                           reorder_configlets=True)
                 except TypeError:
-                    MODULE_LOGGER.warning("The function to reorder the configlet is not present. Please check your cvprac version if re-ordering the configlets is needed. Continuing without reordering.")
+                    MODULE_LOGGER.warning('The function to reorder the configlet is not present. Check cvprac version. Continuing without reordering.')
                     resp = self.__cv_client.api.apply_configlets_to_device(app_name='CvDeviceTools.apply_configlets',
-                                                                            dev=device_facts,
-                                                                            new_configlets=new_configlets_list,
-                                                                            create_task=True)
+                                                                           dev=device_facts,
+                                                                           new_configlets=new_configlets_list,
+                                                                           create_task=True)
                 except CvpApiError:
                     MODULE_LOGGER.error('Error applying configlets to device')
                     self.__ansible.fail_json(msg='Error applying configlets to device')

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -366,6 +366,47 @@ class CvDeviceTools(object):
                 return configlet
         return None
 
+    def __get_reordered_configlets_list(self, configlet_applied_to_device_list, configlet_playbook_list):
+        """
+        __get_reordered_configlets_list Provides mechanism to reoder the configlet lists.
+
+        Extract information from CV configlet mapper and save as a cache in instance.
+
+        Parameters
+        ----------
+        configlet_applied_to_device_list : list
+            List of the configlet currently attached to the device
+        configlet_playbook_list: list   
+            List of the configlet specified in the playbook in the correct order
+        Returns
+        -------
+        list
+            List of configlet in the correct order
+        """
+        new_configlets_list = list()
+        for configlet in configlet_playbook_list:
+            new_configlet = self.__get_configlet_info(configlet_name=configlet)
+            if new_configlet is None:
+                error_message = "The configlet \'%s\' defined to be applied on the device does not exist on CVP.", str(configlet)
+                MODULE_LOGGER.error(error_message)
+                self.__ansible.fail_json(msg=error_message)
+
+            # If the configlet is not applied, add it to the new list
+            if configlet not in [x.name for x in configlet_applied_to_device_list]:
+                new_configlets_list.append(new_configlet)
+
+            # If the confilet is already applied, remove it from the main list and add it to the end of the new list
+            else:
+                MODULE_LOGGER.debug("Removing the configlet %s from the current configlet list and adding it to the new list.", str(configlet))
+                for x in configlet_applied_to_device_list:
+                    if x.name == configlet:
+                        configlet_applied_to_device_list.remove(x)
+                        new_configlets_list.append(new_configlet)
+        configlets_attached_get_configlet_info = [self.__get_configlet_info(configlet_name=x.name) for x in configlet_applied_to_device_list]
+        # Joining the 2 new list (configlets already present + new configlet in right order)
+        return configlets_attached_get_configlet_info + new_configlets_list
+
+
     # ------------------------------------------ #
     # Get CV data functions
     # ------------------------------------------ #
@@ -708,55 +749,35 @@ class CvDeviceTools(object):
         """
         results = list()
         for device in user_inventory.devices:
+            MODULE_LOGGER.debug("Applying configlet for device: %s", str(device.fqdn))
             result_data = CvApiResult(action_name=device.fqdn + '_configlet_attached')
             current_container_info = self.get_container_current(device_mac=device.system_mac)
             if (device.configlets is None or current_container_info['name'] == UNDEFINED_CONTAINER):
                 continue
             # get configlet information from CV
-            new_configlets_list = list()
             configlets_attached = self.get_device_configlets(device_lookup=device.fqdn)
             configlets_attached_before_changes = [x.name for x in configlets_attached]
 
-            for configlet in device.configlets:
-                new_configlet = self.__get_configlet_info(configlet_name=configlet)
-                if new_configlet is None:
-                    error_message = "The configlet \'%s\' defined to be applied on the device \'%s\' does not exist on CVP.", str(configlet), str(device.fqdn)
-                    MODULE_LOGGER.error(error_message)
-                    self.__ansible.fail_json(msg=error_message)
-
-                # If the configlet is not applied, add it to the new list
-                if configlet not in [x.name for x in configlets_attached]:
-                    new_configlets_list.append(new_configlet)
-
-                # If the confilet is already applied, remove it from the main list and add it to the end of the new list
-                else:
-                    MODULE_LOGGER.debug("Removing the configlet %s from the current configlet list and adding it to the new list.", str(configlet))
-                    for x in configlets_attached:
-                        if x.name == configlet:
-                            configlets_attached.remove(x)
-                            new_configlets_list.append(new_configlet)
-            configlets_attached_get_configlet_info = [self.__get_configlet_info(configlet_name=x.name) for x in configlets_attached]
-            # Joining the 2 new list (configlets already present + new configlet in right order)
-            configlets_joined = configlets_attached_get_configlet_info + new_configlets_list
+            configlets_reordered_list = self.__get_reordered_configlets_list(configlets_attached, device.configlets)
 
             # Check if changes have been made
             MODULE_LOGGER.debug("[%s] - Old configlet list: %s", str(device.fqdn), str(configlets_attached_before_changes))
-            MODULE_LOGGER.debug("[%s] - New configlet list: %s", str(device.fqdn), str([x['name'] for x in configlets_joined]))
-            if str(configlets_attached_before_changes) == str([x['name'] for x in configlets_joined]):
-                MODULE_LOGGER.info("There was no changes detected in the configlets list, skipping task creation for  device %s.", str(device.fqdn))
+            MODULE_LOGGER.debug("[%s] - New configlet list: %s", str(device.fqdn), str([x['name'] for x in configlets_reordered_list]))
+            if str(configlets_attached_before_changes) == str([x['name'] for x in configlets_reordered_list]):
+                MODULE_LOGGER.info("[%s] - There was no changes detected in the configlets list, skipping task creation for the device.", str(device.fqdn))
                 continue
 
-            MODULE_LOGGER.info("Creating task for device [%s] configlet list is: %s", str(device.fqdn), str([x['name'] for x in configlets_joined]))
+            MODULE_LOGGER.info("Creating task for device [%s] configlet list is: %s", str(device.fqdn), str([x['name'] for x in configlets_reordered_list]))
             # get device facts from CV
             device_facts = dict()
             if self.__search_by == FIELD_FQDN:
                 device_facts = self.__cv_client.api.get_device_by_name(fqdn=device.fqdn)
             # Attach configlets to device
-            if len(configlets_joined) > 0:
+            if len(configlets_reordered_list) > 0:
                 try:
                     resp = self.__cv_client.api.apply_configlets_to_device(app_name='CvDeviceTools.apply_configlets',
                                                                            dev=device_facts,
-                                                                           new_configlets=configlets_joined,
+                                                                           new_configlets=configlets_reordered_list,
                                                                            create_task=True,
                                                                            reorder_configlets=True)
                 except TypeError:
@@ -771,8 +792,7 @@ class CvDeviceTools(object):
                         result_data.changed = True
                         result_data.success = True
                         result_data.taskIds = resp['data']['taskIds']
-                        result_data.add_entry('{} adds {}'.format(
-                            device.fqdn, *device.configlets))
+                        result_data.add_entry('{} adds {}'.format(device.fqdn, *device.configlets))
                 result_data.add_entry('{} to {}'.format(device.fqdn, *device.container))
             else:
                 result_data.name = result_data.name + ' - nothing attached'

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -713,77 +713,68 @@ class CvDeviceTools(object):
                 action_name=device.fqdn + '_configlet_attached')
             current_container_info = self.get_container_current(
                 device_mac=device.system_mac)
-            if (device.configlets is not None and current_container_info['name'] != UNDEFINED_CONTAINER):
-                # get configlet information from CV
-                configlets_info = list()
-                configlets_attached = self.get_device_configlets(
-                    device_lookup=device.fqdn)
-                MODULE_LOGGER.debug('Attached configlets for device %s : %s', str(device.fqdn), str(configlets_attached))
+            if (device.configlets is None or current_container_info['name'] == UNDEFINED_CONTAINER):
+                continue
+            # get configlet information from CV
+            configlets_info = list()
+            configlets_attached = self.get_device_configlets(device_lookup=device.fqdn)
+            MODULE_LOGGER.debug('Attached configlets for device %s : %s', str(device.fqdn), str([x.name for x in configlets_attached ]))
+            
+            for configlet in device.configlets:
+                new_configlet = self.__get_configlet_info(configlet_name=configlet)
+                if new_configlet is None:
+                    error_message = "The configlet \'{}\' defined to be applied on the device \'{}\' does not exist on the CVP server.".format(str(configlet), str(device.fqdn))
+                    MODULE_LOGGER.error(error_message)
+                    self.__ansible.fail_json(msg=error_message)
                 
-                for configlet in device.configlets:
-                    new_configlet = self.__get_configlet_info(configlet_name=configlet)
-                    if new_configlet is None:
-                        error_message = "The configlet \'{}\' defined to be applied on the device \'{}\' does not exist on the CVP server.".format(str(configlet), str(device.fqdn))
-                        MODULE_LOGGER.error(error_message)
-                        self.__ansible.fail_json(msg=error_message)
-                    
-                    MODULE_LOGGER.debug("Configlets attached: %s", str(configlets_attached))
+                # If the configlet is not applied, add it to the list
+                if configlet not in [x.name for x in configlets_attached]:
+                    configlets_info.append(new_configlet)
 
+                # If the confilet is already applied, remove it from the main list and add it to the end of the new list
+                else: 
+                    MODULE_LOGGER.warning("Removing the configlet %s from the current configlet list and adding it to the new list.", str(configlet))
+                    for x in configlets_attached:
+                        if x.name == configlet:
+                            configlets_attached.remove(x)
+                            configlets_info.append(new_configlet)
 
+            configlets_attached_get_configlet_info =  [ self.__get_configlet_info(configlet_name=x.name) for x in configlets_attached ]
+            
+            MODULE_LOGGER.debug("configlets_attached_get_configlet_info: %s", str(configlets_attached_get_configlet_info))
+            MODULE_LOGGER.debug("configlets_info: %s", str(configlets_info))
 
-                    ### TODO: TO DEBUG
-                    configlets_attached_only_names =  [x.name for x in configlets_attached ]
-                    MODULE_LOGGER.debug("configlets_attached_only_names: %s", str(configlets_attached_only_names))
+            # Joining the 2 new list (configlets already present + new configlet in right order)
+            configlets_info = configlets_attached_get_configlet_info + configlets_info
+            MODULE_LOGGER.debug("Final configlet list for device  [%s] is: %s", str(device.fqdn), str( [ x['name'] for x in configlets_info ] ))
 
-                    # If the configlet is not applied, add it to the list
-                    if configlet not in [x.name for x in configlets_attached]:
-                        configlets_info.append(new_configlet)
-
-                    # If the confilet is already applied, remove it from the main list and add it to the end of the new list
-                    else: 
-                        MODULE_LOGGER.warning("Removing the configlet %s from the main list", str(configlet))
-                        for x in configlets_attached:
-                            if x.name == configlet:
-                                configlets_attached.remove(x)
-                                configlets_info.append(new_configlet)
-
-                configlets_attached_get_configlet_info =  [ self.__get_configlet_info(configlet_name=x.name) for x in configlets_attached ]
-                
-                MODULE_LOGGER.debug("configlets_attached: %s", str(configlets_attached))
-                MODULE_LOGGER.debug("configlets_attached_get_configlet_info: %s", str(configlets_attached_get_configlet_info))
-                MODULE_LOGGER.debug("configlets_info: %s", str(configlets_info))
-
-                # Joining the 2 new list (configlets already present + new configlet in right order)
-                configlets_info = configlets_attached_get_configlet_info + configlets_info
-                MODULE_LOGGER.debug("Final configlet list for device  [%s] is: %s", str(device.fqdn), str(configlets_info))
-
-                # get device facts from CV
-                device_facts = dict()
-                if self.__search_by == FIELD_FQDN:
-                    device_facts = self.__cv_client.api.get_device_by_name(
-                        fqdn=device.fqdn)
-                # Attach configlets to device
-                if len(configlets_info) > 0:
-                    try:
-                        resp = self.__cv_client.api.apply_configlets_to_device(app_name='CvDeviceTools.apply_configlets',
-                                                                               dev=device_facts,
-                                                                               new_configlets=configlets_info,
-                                                                               create_task=True, 
-                                                                               reorder_configlets = True)
-                    except CvpApiError:
-                        MODULE_LOGGER.error('Error applying configlets to device')
-                        self.__ansible.fail_json(msg='Error applying configlets to device')
-                    else:
-                        if resp['data']['status'] == 'success':
-                            result_data.changed = True
-                            result_data.success = True
-                            result_data.taskIds = resp['data']['taskIds']
-                            result_data.add_entry('{} adds {}'.format(
-                                device.fqdn, *device.configlets))
-                    result_data.add_entry('{} to {}'.format(device.fqdn, *device.container))
+            # get device facts from CV
+            device_facts = dict()
+            if self.__search_by == FIELD_FQDN:
+                device_facts = self.__cv_client.api.get_device_by_name(
+                    fqdn=device.fqdn)
+            # Attach configlets to device
+            if len(configlets_info) > 0:
+                try:
+                    resp = self.__cv_client.api.apply_configlets_to_device(app_name='CvDeviceTools.apply_configlets',
+                                                                            dev=device_facts,
+                                                                            new_configlets=configlets_info,
+                                                                            create_task=True, 
+                                                                            reorder_configlets = True)
+                except CvpApiError:
+                    MODULE_LOGGER.error('Error applying configlets to device')
+                    self.__ansible.fail_json(msg='Error applying configlets to device')
                 else:
-                    result_data.name = result_data.name + ' - nothing attached'
-                results.append(result_data)
+                    if resp['data']['status'] == 'success':
+                        result_data.changed = True
+                        result_data.success = True
+                        result_data.taskIds = resp['data']['taskIds']
+                        result_data.add_entry('{} adds {}'.format(
+                            device.fqdn, *device.configlets))
+                result_data.add_entry('{} to {}'.format(device.fqdn, *device.container))
+            else:
+                result_data.name = result_data.name + ' - nothing attached'
+            results.append(result_data)
         return results
 
     def detach_configlets(self, user_inventory: DeviceInventory):

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -376,7 +376,7 @@ class CvDeviceTools(object):
         ----------
         configlet_applied_to_device_list : list
             List of the configlet currently attached to the device
-        configlet_playbook_list: list   
+        configlet_playbook_list: list
             List of the configlet specified in the playbook in the correct order
         Returns
         -------

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -716,30 +716,30 @@ class CvDeviceTools(object):
             # get configlet information from CV
             new_configlets_list = list()
             configlets_attached = self.get_device_configlets(device_lookup=device.fqdn)
-            MODULE_LOGGER.debug('Attached configlets for device %s : %s', str(device.fqdn), str([x.name for x in configlets_attached ]))
-            
+            MODULE_LOGGER.debug('Attached configlets for device %s : %s', str(device.fqdn), str([x.name for x in configlets_attached]))
+
             for configlet in device.configlets:
                 new_configlet = self.__get_configlet_info(configlet_name=configlet)
                 if new_configlet is None:
                     error_message = "The configlet \'{}\' defined to be applied on the device \'{}\' does not exist on the CVP server.".format(str(configlet), str(device.fqdn))
                     MODULE_LOGGER.error(error_message)
                     self.__ansible.fail_json(msg=error_message)
-                
+
                 # If the configlet is not applied, add it to the list
                 if configlet not in [x.name for x in configlets_attached]:
                     new_configlets_list.append(new_configlet)
 
                 # If the confilet is already applied, remove it from the main list and add it to the end of the new list
-                else: 
+                else:
                     MODULE_LOGGER.debug("Removing the configlet %s from the current configlet list and adding it to the new list.", str(configlet))
                     for x in configlets_attached:
                         if x.name == configlet:
                             configlets_attached.remove(x)
                             new_configlets_list.append(new_configlet)
-            configlets_attached_get_configlet_info =  [ self.__get_configlet_info(configlet_name=x.name) for x in configlets_attached ]
+            configlets_attached_get_configlet_info = [self.__get_configlet_info(configlet_name=x.name) for x in configlets_attached]
             # Joining the 2 new list (configlets already present + new configlet in right order)
             configlets_joined = configlets_attached_get_configlet_info + new_configlets_list
-            MODULE_LOGGER.debug("Final configlet list for device  [%s] is: %s", str(device.fqdn), str( [ x['name'] for x in configlets_joined ] ))
+            MODULE_LOGGER.debug("Final configlet list for device  [%s] is: %s", str(device.fqdn), str([x['name'] for x in configlets_joined]))
             # get device facts from CV
             device_facts = dict()
             if self.__search_by == FIELD_FQDN:
@@ -750,14 +750,14 @@ class CvDeviceTools(object):
                     resp = self.__cv_client.api.apply_configlets_to_device(app_name='CvDeviceTools.apply_configlets',
                                                                             dev=device_facts,
                                                                             new_configlets=configlets_joined,
-                                                                            create_task=True, 
-                                                                            reorder_configlets = True) 
-                except TypeError as e:
+                                                                            create_task=True,
+                                                                            reorder_configlets=True)
+                except TypeError:
                     MODULE_LOGGER.warning("The function to reorder the configlet is not present. Please check your cvprac version if re-ordering the configlets is needed. Continuing without reordering.")
                     resp = self.__cv_client.api.apply_configlets_to_device(app_name='CvDeviceTools.apply_configlets',
                                                                             dev=device_facts,
                                                                             new_configlets=new_configlets_list,
-                                                                            create_task=True) 
+                                                                            create_task=True)
                 except CvpApiError:
                     MODULE_LOGGER.error('Error applying configlets to device')
                     self.__ansible.fail_json(msg='Error applying configlets to device')


### PR DESCRIPTION
## Change Summary
This PR adds the functionnality to be able to reorder configlets applied to devices in the cv_device_v3 module. 
Example: 
If the following configlets are applied to a device in that order: 

- A
- B 
- C 

The following playbook can be used in order to change the order to (C - B - A) : 
```
- hosts: cv_server
  vars:
    devices: 
      - fqdn: DC1-SPINE1
        parentContainerName: DC1_SPINES
        configlets:
          - C
          - B
          - A
  tasks:
    - name: "Re-order configlet device"
      arista.cvp.cv_device_v3:
        devices: "{{devices}}"
        state: present          
 ```

A few point to keep in mind while using this: 
* This is a beta feature, please report here if any misbehavior is noticed
* The re-order configlets will be added to the end of the list of configlets. 

Example: If the following configlets are applied to the device: 
```
- A
- B 
- Base_configlet
- C
```
And if the above playbook is used (note that the configlet `Base_configlet` is missing from the playbook), the resulting order will be: 
```
- Base_configlet
- C 
- B
- A
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #362

## Component(s) name

`arista.cvp.cv_device_v3`

## Proposed changes
This PR adds the functionnality to reorder configlets in the cv_device_v3 module. 
The order defined in the playbook will be the one applied to the device. 


## How to test
There is no new syntax for this change however, this requires a change being made in the cvprac package (as of today). 
In order to test this functionality, please do the following:
Step 1: Git clone the cvprac github repo
```
git clone https://github.com/aristanetworks/cvprac
```

Step 2: Load the cvprac package - recommended using this inside a virtual environment or a container.
```
pip install -e cvprac
```

Step 3: Verification - the cvprac package used should have the version `develop`
```
pip list
[...]
cvprac              develop   /projects/cvprac
[...]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
