### PR TITLE
Performance improvements in configlet tools compare functions

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/configlet_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/configlet_tools.py
@@ -46,6 +46,11 @@ try:
     HAS_DIFFLIB = True
 except ImportError:
     HAS_DIFFLIB = False
+try:
+    import hashlib
+    HAS_HASHLIB = True
+except ImportError:
+    HAS_HASHLIB = False
 
 MODULE_LOGGER = logging.getLogger('arista.cvp.configlet_tools_v3')
 MODULE_LOGGER.info('Start cv_container_v3 module execution')
@@ -106,10 +111,9 @@ class CvConfigletTools(object):
     def _compare(self, fromText: List[str], toText: List[str], fromName: str = 'CVP', toName: str = 'Ansible', lines: int = 10):
         """
         _compare - Compare text string in 'fromText' with 'toText' and produce
-            diffRatio - a score as a float in the range [0, 1] 2.0*M / T
-            T is the total number of elements in both sequences,
-            M is the number of matches.
-            Score - 1.0 if the sequences are identical, and 0.0 if they have nothing in common.
+            a boolean to indicate if there is a diff between them, along with
+            a unified diff list.
+            Boolean - False if the sequences are identical, True if they are not.
             unified diff list
             Code	Meaning
             '- '	line unique to sequence 1
@@ -121,9 +125,14 @@ class CvConfigletTools(object):
         tolines = self._str_cleanup_line_ending(content=toText).splitlines(1)
         diff = list(difflib.unified_diff(
             fromlines, tolines, fromName, toName, n=lines))
-        textComp = difflib.SequenceMatcher(None, fromText, toText)
-        diffRatio = textComp.ratio()
-        return [diffRatio, diff]
+        # Calculate and compare hash values to produce the boolean.
+        fromHash = hashlib.sha1(fromText.encode()).hexdigest()
+        toHash = hashlib.sha1(toText.encode()).hexdigest()
+        if fromHash == toHash:
+            cfglet_changed = False
+        else:
+            cfglet_changed = True
+        return [cfglet_changed, diff]
 
     def is_present(self, configlet_name: str):
         """
@@ -326,10 +335,12 @@ class CvConfigletTools(object):
                         # Save configlet diff
                         change_response.add_entry('configlet updated')
                         if 'diff' in configlet:
-                            # Change changed flag if diff is not 1.0
-                            if configlet['diff'] is not None and configlet['diff'][0] < 1.0:
+                            # Change changed flag if diff is True
+                            if configlet['diff'] is not None and configlet['diff'][0] == True:
                                 change_response.diff = configlet['diff']
                                 change_response.changed = True
+                                MODULE_LOGGER.info(
+                                    'Found diff in configlet {}.'.format(str(configlet['name'])))
                         # Collect generated tasks
                         if 'taskIds' in update_resp and len(update_resp['taskIds']) > 0:
                             change_response.taskIds = update_resp['taskIds']

--- a/ansible_collections/arista/cvp/plugins/module_utils/configlet_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/configlet_tools.py
@@ -204,7 +204,8 @@ class CvConfigletTools(object):
                     configlet['key'] = cv_data['key']
                     configlet['diff'] = self._compare(
                         fromText=cv_data['config'], toText=configlet['config'], fromName='CVP', toName='Ansible')
-                    to_update.append(configlet)
+                    if configlet['diff'][0] == True:
+                        to_update.append(configlet)
                 else:
                     to_create.append(configlet)
         elif present is False:

--- a/ansible_collections/arista/cvp/plugins/module_utils/configlet_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/configlet_tools.py
@@ -340,7 +340,7 @@ class CvConfigletTools(object):
                                 change_response.diff = configlet['diff']
                                 change_response.changed = True
                                 MODULE_LOGGER.info(
-                                    'Found diff in configlet {}.'.format(str(configlet['name'])))
+                                    'Found diff in configlet %s.', str(configlet['name']))
                         # Collect generated tasks
                         if 'taskIds' in update_resp and len(update_resp['taskIds']) > 0:
                             change_response.taskIds = update_resp['taskIds']

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools.py
@@ -34,6 +34,7 @@ try:
 except ImportError:
     HAS_HASHLIB = False
 
+
 LOGGER = logging.getLogger('arista.cvp.tools')
 # replacement strings
 WINDOWS_LINE_ENDING = '\r\n'

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools.py
@@ -28,11 +28,16 @@ try:
 except ImportError:
     HAS_DIFFLIB = False
 
+try:
+    import hashlib
+    HAS_HASHLIB = True
+except ImportError:
+    HAS_HASHLIB = False
+
 LOGGER = logging.getLogger('arista.cvp.tools')
 # replacement strings
 WINDOWS_LINE_ENDING = '\r\n'
 UNIX_LINE_ENDING = '\n'
-
 
 def str_cleanup_line_ending(content):
     """
@@ -57,11 +62,10 @@ def str_cleanup_line_ending(content):
 
 def compare(fromText, toText, fromName='', toName='', lines=10):
     """ Compare text string in 'fromText' with 'toText' and produce
-        diffRatio - a score as a float in the range [0, 1] 2.0*M / T
-          T is the total number of elements in both sequences,
-          M is the number of matches.
-          Score - 1.0 if the sequences are identical, and 0.0 if they have nothing in common.
-          unified diff list
+          a boolean to indicate if there is a diff between them, along
+          with a unified diff list.
+          Boolean - False if the sequences are identical, True if they are not.
+          Unified diff list:
           Code    Meaning
           '- '    line unique to sequence 1
           '+ '    line unique to sequence 2
@@ -72,9 +76,14 @@ def compare(fromText, toText, fromName='', toName='', lines=10):
     tolines = str_cleanup_line_ending(content=toText).splitlines(1)
     diff = list(difflib.unified_diff(
         fromlines, tolines, fromName, toName, n=lines))
-    textComp = difflib.SequenceMatcher(None, fromText, toText)
-    diffRatio = textComp.ratio()
-    return [diffRatio, diff]
+    # Calculate and compare hash values to produce the boolean.
+    fromHash = hashlib.sha1(fromText.encode()).hexdigest()
+    toHash = hashlib.sha1(toText.encode()).hexdigest()
+    if fromHash == toHash:
+        cfglet_changed = False
+    else:
+        cfglet_changed = True
+    return [cfglet_changed, diff]
 
 
 def isIterable(testing_object=None):

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
@@ -32,18 +32,6 @@ except ImportError:
     HAS_CVPRAC = False
     CVPRAC_IMP_ERR = traceback.format_exc()
 
-try:
-    import hashlib
-    HAS_HASHLIB = True
-except ImportError:
-    HAS_HASHLIB = False
-
-try:
-    import difflib
-    HAS_DIFFLIB = True
-except ImportError:
-    HAS_DIFFLIB = False
-
 LOGGER = logging.getLogger('arista.cvp.cv_tools')
 
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
@@ -32,6 +32,17 @@ except ImportError:
     HAS_CVPRAC = False
     CVPRAC_IMP_ERR = traceback.format_exc()
 
+try:
+    import hashlib
+    HAS_HASHLIB = True
+except ImportError:
+    HAS_HASHLIB = False
+
+try:
+    import difflib
+    HAS_DIFFLIB = True
+except ImportError:
+    HAS_DIFFLIB = False
 
 LOGGER = logging.getLogger('arista.cvp.cv_tools')
 

--- a/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
@@ -228,9 +228,9 @@ def build_configlets_list(module):
                         # Compare function returns a list containing a boolean and a unified diff list.
                         if configlet_compare[0] == False:
                             intend['keep'].append({'data': configlet})
-                            MODULE_LOGGER.debug("No change was detected in configlet {}.".format(configlet['name']))
+                            MODULE_LOGGER.debug("No change was detected in configlet %s.", str(configlet['name']))
                         else:
-                            MODULE_LOGGER.debug("Updating configlet {} due to a detected change.".format(configlet['name']))
+                            MODULE_LOGGER.debug("Updating configlet %s due to a detected change.", str(configlet['name']))
                             intend['update'].append(
                                 {'data': configlet, 'config': ansible_configlet, 'diff': ''.join(configlet_compare[1])})
                     # Mark configlet to be removed as module mode is absent.

--- a/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
@@ -225,20 +225,22 @@ def build_configlets_list(module):
                         ansible_configlet = module.params['configlets'][configlet['name']]
                         configlet_compare = tools.compare(
                             configlet['config'], ansible_configlet, 'CVP', 'Ansible')
-                        # compare function returns a floating point number
-                        if configlet_compare[0] == 1.0:
+                        # Compare function returns a list containing a boolean and a unified diff list.
+                        if configlet_compare[0] == False:
                             intend['keep'].append({'data': configlet})
+                            MODULE_LOGGER.debug("No change was detected in configlet {}.".format(configlet['name']))
                         else:
+                            MODULE_LOGGER.debug("Updating configlet {} due to a detected change.".format(configlet['name']))
                             intend['update'].append(
                                 {'data': configlet, 'config': ansible_configlet, 'diff': ''.join(configlet_compare[1])})
-                    # Mark configlet to be removed as module mode is absent
+                    # Mark configlet to be removed as module mode is absent.
                     elif module.params['state'] == 'absent':
                         intend['delete'].append({'data': configlet})
                 # Configlet is not in expected topology and match filter.
                 else:
                     intend['delete'].append({'data': configlet})
 
-    # Look for new configlets, if a configlet is not CVP assume it has to be created
+    # Look for new configlets, if a configlet is not CVP assume it has to be created.
     for ansible_configlet in module.params['configlets']:
         found = False
         for cvp_configlet in module.params['cvp_facts']['configlets']:
@@ -682,6 +684,9 @@ def main():
 
     if not tools.HAS_DIFFLIB:
         module.fail_json(msg='difflib required for this module')
+
+    if not tools.HAS_HASHLIB:
+        module.fail_json(msg='hashlib required for this module')
 
     if not tools_cv.HAS_CVPRAC:
         module.fail_json(

--- a/ansible_collections/arista/cvp/plugins/modules/cv_configlet_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_configlet_v3.py
@@ -110,6 +110,14 @@ def check_import(ansible_module: AnsibleModule):
         ansible_module.fail_json(
             msg='cvprac required for this module. Please install using pip install cvprac')
 
+    if not tools_cv.HAS_HASHLIB:
+        ansible_module.fail_json(
+            msg='hashlib required for this module. Please install using pip install hashlib')
+
+    if not tools_cv.HAS_DIFFLIB:
+        ansible_module.fail_json(
+            msg='difflib required for this module. Please install using pip install difflib')
+
     if not schema.HAS_JSONSCHEMA:
         ansible_module.fail_json(
             msg="JSONSCHEMA is required. Please install using pip install jsonschema")

--- a/ansible_collections/arista/cvp/plugins/modules/cv_configlet_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_configlet_v3.py
@@ -88,7 +88,7 @@ import ansible_collections.arista.cvp.plugins.module_utils.logger   # noqa # pyl
 from ansible_collections.arista.cvp.plugins.module_utils.response import CvAnsibleResponse
 import ansible_collections.arista.cvp.plugins.module_utils.tools_cv as tools_cv
 import ansible_collections.arista.cvp.plugins.module_utils.schema_v3 as schema
-from ansible_collections.arista.cvp.plugins.module_utils.configlet_tools import ConfigletInput, CvConfigletTools
+from ansible_collections.arista.cvp.plugins.module_utils.configlet_tools import ConfigletInput, CvConfigletTools, HAS_HASHLIB, HAS_DIFFLIB
 try:
     from cvprac.cvp_client_errors import CvpClientError, CvpApiError, CvpRequestError  # noqa # pylint: disable=unused-import
     HAS_CVPRAC = True
@@ -110,11 +110,11 @@ def check_import(ansible_module: AnsibleModule):
         ansible_module.fail_json(
             msg='cvprac required for this module. Please install using pip install cvprac')
 
-    if not tools_cv.HAS_HASHLIB:
+    if not HAS_HASHLIB:
         ansible_module.fail_json(
             msg='hashlib required for this module. Please install using pip install hashlib')
 
-    if not tools_cv.HAS_DIFFLIB:
+    if not HAS_DIFFLIB:
         ansible_module.fail_json(
             msg='difflib required for this module. Please install using pip install difflib')
 


### PR DESCRIPTION
## Change Summary
Substitutes use of difflib ratio() with high-speed hash checksumming in tools.py and configlet_tools.py for cv_configlet and cv_configlet_v3 respectively.

This aims to improve performance in configlet compare operations, as ratio() has proven to be slow and compute-intensive on large files.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Component(s) name

`arista.cvp.plugins.modules.cv_configlet.py`
`arista.cvp.plugins.module_utils.tools.py`
`arista.cvp.plugins.module_utils.configlet_tools.py`

## How to test
Did multiple test playbook runs with input changes to ensure configurations are updated in CVP, also did runs without changes to ensure task "changed" status reporting is ok.

## Checklist:
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
