### PR TITLE
cv_configlet_v3: update configlet note when the config content is not…

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/configlet_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/configlet_tools.py
@@ -204,8 +204,12 @@ class CvConfigletTools(object):
                     configlet['key'] = cv_data['key']
                     configlet['diff'] = self._compare(
                         fromText=cv_data['config'], toText=configlet['config'], fromName='CVP', toName='Ansible')
-                    if configlet['diff'][0] == True:
+                    configlet['notediff'] = self._compare(
+                        fromText=cv_data['note'], toText=note, fromName='CVP', toName='Ansible')
+                    MODULE_LOGGER.debug("configlet note diff: %s", str(configlet['notediff']))
+                    if (configlet['diff'][0]) == True or (configlet['notediff'][0] == True):
                         to_update.append(configlet)
+
                 else:
                     to_create.append(configlet)
         elif present is False:
@@ -247,7 +251,7 @@ class CvConfigletTools(object):
         response.add_manager(created_configlets)
         response.add_manager(updated_configlets)
         response.add_manager(deleted_configlets)
-        MODULE_LOGGER.info('Configlet change result is: %s', str(response))
+        MODULE_LOGGER.info('Configlet change result is: %s', str(response.content))
         return response
 
     def update(self, to_update: list, note: str = 'Managed by Ansible AVD'):
@@ -342,6 +346,12 @@ class CvConfigletTools(object):
                                 change_response.changed = True
                                 MODULE_LOGGER.info(
                                     'Found diff in configlet %s.', str(configlet['name']))
+                        if 'notediff' in configlet:
+                            if configlet['notediff'] is not None and configlet['notediff'][0] == True:
+                                change_response.diff = configlet['notediff']
+                                change_response.changed = True
+                                MODULE_LOGGER.info(
+                                    'Found diff in configlet note of configlet %s.', str(configlet['name']))
                         # Collect generated tasks
                         if 'taskIds' in update_resp and len(update_resp['taskIds']) > 0:
                             change_response.taskIds = update_resp['taskIds']


### PR DESCRIPTION
… updated but the note is changed

## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #371 

## Component(s) name

`arista.cvp.cv_configlet_v3`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Update the configlet note even if the configlet itself is not updated

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

```yaml
---
- name: cv_configlet unit testing
  hosts: cv_server
  connection: local
  gather_facts: false
  collections:
    - arista.avd
    - arista.cvp
  vars:
    CVP_CONFIGLETS:
      01TRAINING-alias: "alias a101 show version"
      01DEMO-alias: "alias a111 show version"
  tasks:
    - name: "Configure configlet on {{inventory_hostname}}"
      tags: create
      arista.cvp.cv_configlet_v3:
        configlets: "{{CVP_CONFIGLETS}}"
        state: present
        configlets_notes: "TEST ANSIBLE NOTES - 371"
      register: CVP_CONFIGLET_RESULT

    - name: "Print logs"
      tags: create
      debug:
        msg: "{{ CVP_CONFIGLET_RESULT }}"
```

This also prints if there's a note diff

```
TASK [Print logs] ********************************************************************************
Friday 02 July 2021  00:18:02 +0100 (0:00:06.025)       0:00:06.099 ***********
Friday 02 July 2021  00:18:02 +0100 (0:00:06.025)       0:00:06.098 ***********
ok: [CloudVision] =>
  msg:
    changed: true
    configlets_created:
      changed: false
      configlets_created_count: 0
      configlets_created_list: []
      diff: {}
      success: false
      taskIds: []
    configlets_deleted:
      changed: false
      configlets_deleted_count: 0
      configlets_deleted_list: []
      diff: {}
      success: false
      taskIds: []
    configlets_updated:
      changed: true
      configlets_updated_count: 2
      configlets_updated_list:
      - 01TRAINING-alias
      - 01DEMO-alias
      diff:
        01DEMO-alias:
        - true
        - - |-
            --- CVP
          - |-
            +++ Ansible
          - |-
            @@ -1 +1 @@
          - -TEST1251 desc Test ansible tamas
          - +TEST1251 371
        01TRAINING-alias:
        - true
        - - |-
            --- CVP
          - |-
            +++ Ansible
          - |-
            @@ -1 +1 @@
          - -TEST1251 desc Test ansible tamas
          - +TEST1251 371
      success: true
      taskIds: []
    failed: false
    success: true
    taskIds: []

PLAY RECAP ***************************************************************************************
CloudVision                : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
