### PR TITLE
Reformat: Apply python linting warning in import

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -12,6 +12,7 @@ jobs:
       code_v3: ${{ steps.filter.outputs.code_v3 }}
       dhcp_module: ${{ steps.filter.outputs.dhcp_module }}
       docs: ${{ steps.filter.outputs.docs }}
+      python: ${{ steps.filter.outputs.python }}
     steps:
       - uses: actions/checkout@v2
       - uses: dorny/paths-filter@v2
@@ -56,6 +57,8 @@ jobs:
               - 'ansible_collections/arista/cvp/roles/**/README.md'
               - '.github/workflows/documentation-check.yml'
               - '.github/workflows/documentation-build.yml'
+            python:
+              - 'ansible_collections/arista/cvp/plugins/**/*.py'
 
   pre_commit:
     name: Run pre-commit validation hooks
@@ -219,8 +222,8 @@ jobs:
     name: Test galaxy-importer
     runs-on: ubuntu-latest
     container: avdteam/base:3.6-v2.0
-    needs: [molecule_dhcp, pytest]
-    # if: startsWith(github.ref, 'refs/heads/release') || startsWith(github.base_ref, 'refs/heads/release')
+    needs: [pre_commit]
+    if: needs.file-changes.outputs.python == 'true' || startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/release')
     env:
       PY_COLORS: 1 # allows molecule colors to be passed to GitHub Actions
       ANSIBLE_FORCE_COLOR: 1 # allows ansible colors to be passed to GitHub Actions

--- a/ansible_collections/arista/cvp/plugins/module_utils/configlet_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/configlet_tools.py
@@ -207,7 +207,7 @@ class CvConfigletTools(object):
                     configlet['notediff'] = self._compare(
                         fromText=cv_data['note'], toText=note, fromName='CVP', toName='Ansible')
                     MODULE_LOGGER.debug("configlet note diff: %s", str(configlet['notediff']))
-                    if (configlet['diff'][0]) == True or (configlet['notediff'][0] == True):
+                    if (configlet['diff'][0]) is True or (configlet['notediff'][0] is True):
                         to_update.append(configlet)
 
                 else:
@@ -341,13 +341,13 @@ class CvConfigletTools(object):
                         change_response.add_entry('configlet updated')
                         if 'diff' in configlet:
                             # Change changed flag if diff is True
-                            if configlet['diff'] is not None and configlet['diff'][0] == True:
+                            if configlet['diff'] is not None and configlet['diff'][0] is True:
                                 change_response.diff = configlet['diff']
                                 change_response.changed = True
                                 MODULE_LOGGER.info(
                                     'Found diff in configlet %s.', str(configlet['name']))
                         if 'notediff' in configlet:
-                            if configlet['notediff'] is not None and configlet['notediff'][0] == True:
+                            if configlet['notediff'] is not None and configlet['notediff'][0] is True:
                                 change_response.diff = configlet['notediff']
                                 change_response.changed = True
                                 MODULE_LOGGER.info(

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -411,7 +411,6 @@ class CvDeviceTools(object):
         # Joining the 2 new list (configlets already present + new configlet in right order)
         return configlets_attached_get_configlet_info + new_configlets_list
 
-
     # ------------------------------------------ #
     # Get CV data functions
     # ------------------------------------------ #

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools.py
@@ -40,6 +40,7 @@ LOGGER = logging.getLogger('arista.cvp.tools')
 WINDOWS_LINE_ENDING = '\r\n'
 UNIX_LINE_ENDING = '\n'
 
+
 def str_cleanup_line_ending(content):
     """
     str_cleanup_line_ending Cleanup line ending to use UNIX style and not Windows style

--- a/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
@@ -226,7 +226,7 @@ def build_configlets_list(module):
                         configlet_compare = tools.compare(
                             configlet['config'], ansible_configlet, 'CVP', 'Ansible')
                         # Compare function returns a list containing a boolean and a unified diff list.
-                        if configlet_compare[0] == False:
+                        if configlet_compare[0] is False:
                             intend['keep'].append({'data': configlet})
                             MODULE_LOGGER.debug("No change was detected in configlet %s.", str(configlet['name']))
                         else:


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Proposed changes

ERROR: Found 5 pylint issue(s) which need to be resolved:
ERROR: plugins/module_utils/configlet_tools.py:210:23: singleton-comparison: Comparison to True should be just 'expr'
ERROR: plugins/module_utils/configlet_tools.py:210:58: singleton-comparison: Comparison to True should be just 'expr'
ERROR: plugins/module_utils/configlet_tools.py:344:65: singleton-comparison: Comparison to True should be just 'expr'
ERROR: plugins/module_utils/configlet_tools.py:350:69: singleton-comparison: Comparison to True should be just 'expr'
ERROR: plugins/modules/cv_configlet.py:229:27: singleton-comparison: Comparison to False should be 'not expr'

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
