### PR TITLE
Make(collection): Remove Molecule from collection build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,9 @@ help: ## Display help message (*: main entry points / []: part of an entry point
 #########################################
 .PHONY: collection-build
 collection-build: ## Build arista.cvp collection locally
-	ansible-galaxy collection build --force ansible_collections/arista/cvp
+	rm -rf ansible_collections/arista/cvp/molecule/ ; \
+	ansible-galaxy collection build --force ansible_collections/arista/cvp ; \
+	git checkout ansible_collections/arista/cvp/molecule/
 
 .PHONY: collection-install
 collection-install: ## Install arista.cvp collection to default location (~/.ansible/collections/ansible_collections)

--- a/ansible_collections/arista/cvp/galaxy.yml
+++ b/ansible_collections/arista/cvp/galaxy.yml
@@ -7,7 +7,7 @@ namespace: arista
 name: cvp
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.1.1
+version: 3.1.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
## Change Summary

Remove molecule folder from the collection package.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [x] Other (please describe): Make

## Proposed changes

Remove molecule folder with following process:

- rm Molecule folder
- Build package
- Restore molecule folder

## How to test

```bash
❯ make collection-build
rm -rf ansible_collections/arista/cvp/molecule/ ; \
        ansible-galaxy collection build --force ansible_collections/arista/cvp ; \
        git checkout ansible_collections/arista/cvp/molecule/
Created collection for arista.cvp at /Users/tgrimonet/Projects/arista-ansible/ansible-cvp/arista-cvp-3.1.1.tar.gz
Updated 38 paths from the index

❯ ls G tar.gz
arista-cvp-3.1.1.tar.gz
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
