### PR TITLE
Fix(cv_device_v3): Correct format ID in str raising an error

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -1110,7 +1110,7 @@ class CvDeviceTools(object):
                                 result_data.success = True
                                 result_data.taskIds = resp['data']['taskIds']
 
-                    result_data.add_entry('{1} deployed to {2}'.format(
+                    result_data.add_entry('{0} deployed to {1}'.format(
                         device.info[self.__search_by], device.container))
             results.append(result_data)
         return results


### PR DESCRIPTION
## Change Summary

Change format ID in str `{1}` from `{1}..{2}` to `{0}..{1}`

## Related Issue(s)

Related to #396 

## Component(s) name

`arista.cvp.cv_device_v3`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test

Run cv_device with multiple devices in the list

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
