### PR TITLE
Feat(dhcp_configuration): Allow networks with an empty range in dhcpd.conf in arista.avd.dhcp_configuration

### DIFF
--- a/.github/workflows/pull-request-triage.yml
+++ b/.github/workflows/pull-request-triage.yml
@@ -82,6 +82,7 @@ jobs:
             cv_container
             cv_configlet
             cv_task
+            dhcp_configuration
             mkdoc
             contribution
             how-to

--- a/ansible_collections/arista/cvp/roles/dhcp_configuration/templates/dhcpd.conf.j2
+++ b/ansible_collections/arista/cvp/roles/dhcp_configuration/templates/dhcpd.conf.j2
@@ -3,7 +3,9 @@
 # Subnet of ZTP interface
 {% for subnet in ztp.general.subnets %}
 subnet {{ subnet.network }} netmask {{ subnet.netmask }} {
+{%     if subnet.start is defined and subnet.end is defined %}
     range {{ subnet.start }} {{ subnet.end }};
+{%     endif %}
 {%     if subnet.gateway is defined %}
     option routers {{ subnet.gateway }};
 {%     endif %}


### PR DESCRIPTION
This is to allow dhcpd to listen to relayed queries in a network without actually offering leases in that network.
This kind of setup is needed when dhcpd is not directly connected to the clients and a DHCP relay is in the middle.

## Change Summary

Update to `dhcpd.conf.j2` template 

## Related Issue(s)

N/A

## Component(s) name

`arista.cvp.dhcp_configuration`

## Proposed changes

The `start` and `end` keys are made optional for each subnet to be added to dhcpd configuration.

## How to test

Use the following variables:
```
---
ztp:
  default:
    registration: 'http://10.83.30.236/ztp/bootstrap'
    gateway: 10.79.254.254
    nameservers:
      - '10.83.28.52'
  general:
    subnets:
      - network: 10.83.28.0
        netmask: 255.255.252.0
      - network: 10.79.254.0
        netmask: 255.255.255.0
        gateway: 10.79.254.254
        nameservers:
          - 9.9.9.9
        start: 10.79.254.200
        end: 10.79.254.250
        lease_time: 300
  clients:
    - name: dc1-spine1
      mac: '0c:1d:c0:11:62:01'
      ip4: 10.79.254.11
    - name: dc1-spine2
      mac: '0c:1d:c0:12:62:01'
      ip4: 10.79.254.12
```

Use this playbook:
```
---
- name: Configure ZTP/DHCP service on CloudVision
  hosts: ztp
  gather_facts: true
  tasks:
  - name: 'Execute ZTP configuration role'
    import_role:
      name: arista.cvp.dhcp_configuration
```


## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
