### PR TITLE
Doc: Update CSS for better dark mode rendering

### DIFF
--- a/ansible_collections/arista/cvp/docs/stylesheets/extra.material.css
+++ b/ansible_collections/arista/cvp/docs/stylesheets/extra.material.css
@@ -1,3 +1,7 @@
+[data-md-color-scheme="slate"] {
+  --md-hue: 210;
+}
+
 :root {
   /* Color schema based on Arista Color Schema */
   /* Default color shades */
@@ -22,11 +26,38 @@
   --md-accent-bg-color:                #27569B;
   --md-accent-bg-color--light:         #27569B;
 
+  /* Link color */
+  --md-typeset-a-color:                #27569B;
+  --md-typeset-a-color-fg:             #FFFFFF;
+  --md-typeset-a-color-bg:             #27569B;
+
   /* Code block color shades */
   --md-code-bg-color:                  #E6E6E6;
-  --md-code-border-color:              #5487b74f;
+  --md-code-border-color:              #0000004f;
   --block-code-bg-color:               #e4e4e4;
   /* --md-code-fg-color:                  ...; */
+
+  font-size: 1rem;
+  /* min-height: 100%;
+  position: relative;
+  width: 100%; */
+  font-feature-settings: "kern","liga";
+  font-family: var(--md-text-font-family,_),-apple-system,BlinkMacSystemFont,Helvetica,Arial,sans-serif;
+  -webkit-font-smoothing: antialiased;
+
+}
+
+[data-md-color-scheme="slate"] {
+
+  /* Link color */
+  --md-typeset-a-color:                #75aaf8;
+  --md-typeset-a-color-fg:             #FFFFFF;
+  --md-typeset-a-color-bg:             #27569B;
+
+  /* Code block color shades */
+  /* --md-code-bg-color:                  #E6E6E6; */
+  --md-code-border-color:              #aec6db4f;
+  /* --block-code-bg-color:               #e4e4e4; */
 }
 
 @media only screen and (min-width: 76.25em) {
@@ -45,6 +76,10 @@
 }
 
 @media only screen {
+  .md-typeset a:hover {
+    background-color: var(--md-typeset-a-color-bg);
+    color: var(--md-typeset-a-color-fg);
+  }
   .md-footer-nav {
       background-color: var(--md-default-bg-color--light);
       color: var(--md-accent-fg-color--transparent)
@@ -63,17 +98,34 @@
   }
   .md-footer-nav__title {
     font-size: .9rem;
-    line-height: 2.4rem;
+    line-height: 10rem;
     color: var(--md-default-fg-color--light);
   }
+
+  .md-typeset h4 h5 h6 {
+      font-size: 1.5rem;
+      margin: 1em 0;
+      /* font-weight: 700; */
+      letter-spacing: -.01em;
+      line-height: 3em;
+  }
+
   .md-typeset table:not([class]) th {
     min-width: 5rem;
     padding: .6rem .8rem;
     color: var(--md-default-fg-color--lighter);
     vertical-align: top;
     background-color: var(--md-accent-bg-color);
+    text-align: left;
     /* min-width: 100%; */
     /* display: table; */
+  }
+  .md-typeset table:not([class]) td {
+    /* padding: .9375em 1.25em; */
+    border-collapse: collapse;
+    vertical-align: center;
+    text-align: left;
+    border-bottom: 1px solid var(--md-default-fg-color--light);
   }
   .md-typeset code {
     padding: 0 .2941176471em;
@@ -104,14 +156,13 @@
     color: var(--md-default-fg-color--lighter)
   } */
 }
-
   .md-typeset__table {
     min-width: 100%;
   }
-
   .md-typeset table:not([class]) {
       display: table;
   }
+
 .mdx-content__footer {
     margin-top: 20px;
     text-align: center;
@@ -122,4 +173,10 @@
 }
 .mdx-content__footer a:focus, .mdx-content__footer a:hover {
     transform: scale(1.2);
+}
+
+.md-typeset table:not([class]) th {
+    min-width: 5rem;
+    padding: .6rem .8rem;
+    color: var(--md-primary-fg-color--light);
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,12 +34,12 @@ theme:
     - media: "(prefers-color-scheme: light)"
       scheme: default
       toggle:
-        icon: material/toggle-switch-off-outline
+        icon: material/weather-sunny
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
       toggle:
-        icon: material/toggle-switch
+        icon: material/weather-night
         name: Switch to light mode
 
 extra_css:


### PR DESCRIPTION
## Change Summary

Update mkdocs theme to be more readable

## Related Issue(s)

Related to https://github.com/aristanetworks/ansible-avd/pull/1337

## Component(s) name

Mkdocs

## Proposed changes

- Update link rendering to be more visible
	- Color code for brighter blue in dark mode: `#75aaf8` instead of `#27569B` for light mode
	- Implement `a:hover` rendering
- Update fonts and font size
- Add better logo for light/dark switcher
- Increase font size for title `h4` to `h6`

## How to test

In your development stack:

```bash
$ make start

# Wait for mkdocs to come up
# Open http://127.0.0.1:8001
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
