### PR TITLE
Refactor: Removing repeated entry from the makefile in pytest refactoring code

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,7 +3,7 @@ CURRENT_DIR = $(shell pwd)
 TAG ?=
 TEST_OPT = -v --cov-report term:skip-covered
 REPORT = -v --cov-report term:skip-covered --html=report.html --self-contained-html --cov-report=html --color yes
-COVERAGE = --cov=ansible_collections.arista.cvp.plugins.module_utils.container_tools --cov=ansible_collections.arista.cvp.plugins.module_utils.configlet_tools --cov=ansible_collections.arista.cvp.plugins.module_utils.generic_tools  --cov=ansible_collections.arista.cvp.plugins.module_utils.device_tools  --cov=ansible_collections.arista.cvp.plugins.module_utils.response  --cov=ansible_collections.arista.cvp.plugins.module_utils.schema_v3  --cov=ansible_collections.arista.cvp.plugins.module_utils.schema_v3
+COVERAGE = --cov=ansible_collections.arista.cvp.plugins.module_utils.container_tools --cov=ansible_collections.arista.cvp.plugins.module_utils.configlet_tools --cov=ansible_collections.arista.cvp.plugins.module_utils.generic_tools  --cov=ansible_collections.arista.cvp.plugins.module_utils.device_tools  --cov=ansible_collections.arista.cvp.plugins.module_utils.response  --cov=ansible_collections.arista.cvp.plugins.module_utils.schema_v3
 
 AUTH_CONFIG_FILE = lib/config.py
 


### PR DESCRIPTION
## Change Summary

Removing repeated entry from the makefile in pytest refactoring code

## Related Issue(s)

Fixes #N/A

## Component(s) name

Pytest

## Proposed changes
Changed the tests/Makefile by removing the repeated entry from the COVERAGE constants. 

## How to test

```bash
# Go to test folder
$ cd tests/

# Run Pytest
$ make ci
$ make test
$make test-api
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
