### PR TITLE
Fix(cv_device_v3): Fix strict mode not inheriting configlets from containers

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -518,7 +518,6 @@ class CvDeviceTools(object):
                 MODULE_LOGGER.debug("[API call] Get configlet associated with container: {}".format(current_container['name']))
                 current_container_configlets_info = self.__cv_client.api.get_configlets_by_container_id(current_container['key'])
                 configletList = [x['name'] for x in current_container_configlets_info['configletList']]
-                MODULE_LOGGER.debug("Configlet list to add: {}".format(configletList))
                 inherited_configlet_list += configletList
                 
                 # Get parent container name
@@ -527,8 +526,6 @@ class CvDeviceTools(object):
 
                 # Adding current container to cache
                 cache_new_entry = {"name_parent": parent_container_name, "configlets": configletList}
-                MODULE_LOGGER.debug("cache_new_entry: {}".format(cache_new_entry))
-                MODULE_LOGGER.debug("name_container cache: {}".format(name_container))
                 self.__containers_configlet_list_cache[name_container] = cache_new_entry
                 MODULE_LOGGER.debug("Cache updated: {}".format(self.__containers_configlet_list_cache))
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -1026,16 +1026,16 @@ class CvDeviceTools(object):
                 elif self.__search_by == FIELD_SERIAL:
                     device_facts = self.__cv_client.api.get_device_by_serial(
                         device_serial=device.serial_number)
-            
+
                 # List of expected configlet applied to the device, taking into account the configlets inherited from parent containers
                 expected_device_configlet_list = self.__get_configlet_list_inherited_from_container(device) + device.configlets
-                
+
                 configlets_to_remove = list()
-                
+
                 # get list of configured configlets
                 configlets_attached = self.get_device_configlets(device_lookup=device.info[self.__search_by])
                 MODULE_LOGGER.debug('Current configlet attached {}'.format(configlets_attached))
-                
+
                 # For each configlet not in the list, add to list of configlets to remove
                 for configlet in configlets_attached:
                     if configlet.name not in expected_device_configlet_list:

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -493,13 +493,13 @@ class CvDeviceTools(object):
             List of configlet
         """
         MODULE_LOGGER.debug("Getting list of inherited configlet for device {}".format(device.hostname))
-        
+
         # List of inherited configlet from all the parent containers
         inherited_configlet_list = list()
-        
+
         parent_container_name = device.container
-        
-        # While loop in order to retrieve the lists of configlets applied to all the parents container
+
+        # While loop to retrieve the lists of configlets applied to all the parents container
         # Loop continue until the parent_container is empty
         # Cache variable is self.__containers_configlet_list_cache - format {<container_name>: {"name_parent": "<>", "configlets": ['', '']}
         while parent_container_name != '':
@@ -511,7 +511,7 @@ class CvDeviceTools(object):
                 parent_container_name = self.__containers_configlet_list_cache[name_container]['name_parent']
 
             # If the container is not in cache
-            else:             
+            else:
                 # Get list of configlet for current container and add them to the list
                 MODULE_LOGGER.debug("[API call] to get info for new container: {}".format(name_container))
                 current_container = self.get_container_info(name_container)
@@ -519,7 +519,7 @@ class CvDeviceTools(object):
                 current_container_configlets_info = self.__cv_client.api.get_configlets_by_container_id(current_container['key'])
                 configletList = [x['name'] for x in current_container_configlets_info['configletList']]
                 inherited_configlet_list += configletList
-                
+
                 # Get parent container name
                 MODULE_LOGGER.debug("[API call] to get parent container name {}".format(current_container['name']))
                 parent_container_name = self.__cv_client.api.get_container_by_id(current_container['key'])['parentName']

--- a/tests/system/test_cv_device_tools.py
+++ b/tests/system/test_cv_device_tools.py
@@ -328,3 +328,4 @@ class TestCvDeviceTools():
         for device in user_inventory.devices:
             logging.info("Testing __get_configlet_list_inherited_from_container for device {}".format(device.fqdn))
             assert(self.inventory._CvDeviceTools__get_configlet_list_inherited_from_container(device) == container_configlet)
+            

--- a/tests/system/test_cv_device_tools.py
+++ b/tests/system/test_cv_device_tools.py
@@ -316,3 +316,15 @@ class TestCvDeviceTools():
             else:
                 pytest.skip("Skipped as device {} has no {} field".format(
                     device.fqdn, FIELD_SYSMAC))
+                
+    @pytest.mark.api
+    @pytest.mark.dependency(depends=["authentication"], scope='class')
+    @pytest.mark.parametrize("CV_DEVICE", get_devices())
+    def test__get_configlet_list_inherited_from_container(self, CV_DEVICE):
+        requests.packages.urllib3.disable_warnings()
+        container_configlet = ['container-configlet-1']
+        user_inventory = DeviceInventory(data=[CV_DEVICE])
+        
+        for device in user_inventory.devices:
+            logging.info("Testing __get_configlet_list_inherited_from_container for device {}".format(device.fqdn))
+            assert(self.inventory._CvDeviceTools__get_configlet_list_inherited_from_container(device) == container_configlet)

--- a/tests/system/test_cv_device_tools.py
+++ b/tests/system/test_cv_device_tools.py
@@ -316,7 +316,7 @@ class TestCvDeviceTools():
             else:
                 pytest.skip("Skipped as device {} has no {} field".format(
                     device.fqdn, FIELD_SYSMAC))
-                
+
     @pytest.mark.api
     @pytest.mark.dependency(depends=["authentication"], scope='class')
     @pytest.mark.parametrize("CV_DEVICE", get_devices())
@@ -328,4 +328,3 @@ class TestCvDeviceTools():
         for device in user_inventory.devices:
             logging.info("Testing __get_configlet_list_inherited_from_container for device {}".format(device.fqdn))
             assert(self.inventory._CvDeviceTools__get_configlet_list_inherited_from_container(device) == container_configlet)
-            

--- a/tests/system/test_cv_device_tools.py
+++ b/tests/system/test_cv_device_tools.py
@@ -322,6 +322,7 @@ class TestCvDeviceTools():
     @pytest.mark.parametrize("CV_DEVICE", get_devices())
     def test__get_configlet_list_inherited_from_container(self, CV_DEVICE):
         requests.packages.urllib3.disable_warnings()
+        # TODO: The container configlet should be defined at the constats_data.py level
         container_configlet = ['container-configlet-1']
         user_inventory = DeviceInventory(data=[CV_DEVICE])
 

--- a/tests/system/test_cv_device_tools.py
+++ b/tests/system/test_cv_device_tools.py
@@ -324,7 +324,7 @@ class TestCvDeviceTools():
         requests.packages.urllib3.disable_warnings()
         container_configlet = ['container-configlet-1']
         user_inventory = DeviceInventory(data=[CV_DEVICE])
-        
+
         for device in user_inventory.devices:
             logging.info("Testing __get_configlet_list_inherited_from_container for device {}".format(device.fqdn))
             assert(self.inventory._CvDeviceTools__get_configlet_list_inherited_from_container(device) == container_configlet)


### PR DESCRIPTION
## Change Summary

Fix device_v3 module strict mode not getting configlets from parent containers. 

## Related Issue(s)

Fixes #353
Fixes #400
## Component(s) name

`arista.cvp.cv_device_v3`

## Proposed changes
The way I implemented the fix is by constructing a list of configlets applied to the container's parent of the devices. 
This is implemented in the function `device_tools.py:__get_configlet_list_inherited_from_container`. 

1. API call to get topology information: `__cv_client.api.filter_topology()`
2. For each parent container we are doing 1 API call to get the list of configlets attached with: 
`__cv_client.api.get_configlets_by_container_id(container_id)`

The number of API calls made is (1 + n) where n is the number of containers to explore. 

All the API informations are cached in the attribute `self.__containers_configlet_list_cache` to avoid any unnecessary API call to the CVP server. 

## How to test
Apply some configlets to devices and remove them with the strict state enabled. 
Example (The configlets `TO_DETACH` and `TO_DETACH2` are applied at the device level, some configlets need also to be applied at the containers level): 
```
- hosts: cv_server
  vars:
    devices: 
      - fqdn: gigi-DC1-LEAF1A
        parentContainerName: LEAFS
        configlets:
          - AVD-gigi_gigi-DC1-LEAF1A
          # - TO_DETACH
          # - TO_DETACH2
  tasks:
    - name: "configlet device test"
      arista.cvp.cv_device_v3:
        devices: "{{devices}}"
        state: present
        apply_mode: strict
      register: CV_DEVICE_OUTPUT
```
The expected output is to have the configlets `TO_DETACH` and `TO_DETACH2` removed. The configlets applied at container level must be kept. 

## Checklist

* A test has been written
* The previous tests all passed

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
