### PR TITLE
Doc: Announce deprecation of arista.cvp v1 modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ build-docker3: ## [DEPRECATED] visit https://github.com/arista-netdevops-communi
 webdoc: ## Build documentation to publish static content
 	( cd $(WEBDOC_BUILD) ; \
 	python ansible2rst.py ; \
-	find . -name 'cv_*.rst' -exec pandoc {} --from rst --to gfm -o ../modules/{}.md \;)
+	find . -name 'cv_*_v3.rst' -exec pandoc {} --from rst --to gfm -o ../modules/{}.md \;)
 	cp $(CURRENT_DIR)/contributing.md $(WEBDOC_BUILD)/.. ;\
 
 .PHONY: check-cvp-404

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   - [Collection overview](#collection-overview)
     - [List of available modules](#list-of-available-modules)
     - [List of available roles](#list-of-available-roles)
+  - [Deprecated modules](#deprecated-modules)
   - [Example](#example)
   - [Installation](#installation)
     - [Dependencies](#dependencies)
@@ -61,18 +62,19 @@ __Version 3:__
 - [__arista.cvp.cv_device_v3__](https://cvp.avd.sh/en/latest/docs/modules/cv_device_v3.rst/) - Manage devices configured on CVP
 - [__arista.cvp.cv_task_v3__](https://cvp.avd.sh/en/latest/docs/modules/cv_task_v3.rst/) - Run tasks created on CVP.
 
-__Legacy / Version 1:__
+### List of available roles
+
+- [__arista.cvp.dhcp_configuration__](https://cvp.avd.sh/en/latest/roles/dhcp_configuration/) - Configure DHCPD service on a Cloudvision server or any dhcpd service.
+- [__arista.cvp.configlet_sync__](https://cvp.avd.sh/en/latest/roles/configlets_sync/) - Synchronize configlets between multiple Cloudvision servers.
+
+
+## Deprecated modules
 
 - [__arista.cvp.cv_facts__](https://cvp.avd.sh/en/latest/docs/modules/cv_facts.rst/) - Collect CVP facts from server like list of containers, devices, configlet and tasks.
 - [__arista.cvp.cv_configlet__](https://cvp.avd.sh/en/latest/docs/modules/cv_configlet.rst/) -  Manage configlet configured on CVP.
 - [__arista.cvp.cv_container__](https://cvp.avd.sh/en/latest/docs/modules/cv_container.rst/) -  Manage container topology and attach configlet and devices to containers.
 - [__arista.cvp.cv_device__](https://cvp.avd.sh/en/latest/docs/modules/cv_device.rst/) - Manage devices configured on CVP
 - [__arista.cvp.cv_task__](https://cvp.avd.sh/en/latest/docs/modules/cv_task.rst/) - Run tasks created on CVP.
-
-### List of available roles
-
-- [__arista.cvp.dhcp_configuration__](https://cvp.avd.sh/en/latest/roles/dhcp_configuration/) - Configure DHCPD service on a Cloudvision server or any dhcpd service.
-- [__arista.cvp.configlet_sync__](https://cvp.avd.sh/en/latest/roles/configlets_sync/) - Synchronize configlets between multiple Cloudvision servers.
 
 ## Example
 

--- a/ansible_collections/arista/cvp/README.md
+++ b/ansible_collections/arista/cvp/README.md
@@ -80,18 +80,18 @@ __Version 3:__
 - [__arista.cvp.cv_device_v3__](docs/modules/cv_device_v3.rst/) - Manage devices configured on CVP
 - [__arista.cvp.cv_task_v3__](docs/modules/cv_task_v3.rst/) - Run tasks created on CVP.
 
-__Legacy / Version 1:__
+### List of available roles
+
+- [__arista.cvp.dhcp_configuration__](roles/dhcp_configuration/) - Configure DHCPD service on a Cloudvision server or any dhcpd service.
+- [__arista.cvp.configlet_sync__](roles/configlets_sync/) - Synchronize configlets between multiple Cloudvision servers.
+
+### Deprecated modules
 
 - [__arista.cvp.cv_facts__](docs/modules/cv_facts.rst/) - Collect CVP facts from server like list of containers, devices, configlet and tasks.
 - [__arista.cvp.cv_configlet__](docs/modules/cv_configlet.rst/) -  Manage configlet configured on CVP.
 - [__arista.cvp.cv_container__](docs/modules/cv_container.rst/) -  Manage container topology and attach configlet and devices to containers.
 - [__arista.cvp.cv_device__](docs/modules/cv_device.rst/) - Manage devices configured on CVP
 - [__arista.cvp.cv_task__](docs/modules/cv_task.rst/) - Run tasks created on CVP.
-
-### List of available roles
-
-- [__arista.cvp.dhcp_configuration__](roles/dhcp_configuration/) - Configure DHCPD service on a Cloudvision server or any dhcpd service.
-- [__arista.cvp.configlet_sync__](roles/configlets_sync/) - Synchronize configlets between multiple Cloudvision servers.
 
 ## Example
 

--- a/ansible_collections/arista/cvp/docs/_build/cv_configlet.rst
+++ b/ansible_collections/arista/cvp/docs/_build/cv_configlet.rst
@@ -9,6 +9,14 @@ Create, Delete, or Update CloudVision Portal Configlets.
    :local:
    :depth: 2
 
+DEPRECATED
+----------
+
+:In: version:
+:Why: Updated modules released with increased functionality
+:Alternative: Use :ref:`arista.cvp.cv_configlet_v3 <arista.cvp.cv_configlet_v3>` instead.
+
+
 
 Synopsis
 --------

--- a/ansible_collections/arista/cvp/docs/_build/cv_container.rst
+++ b/ansible_collections/arista/cvp/docs/_build/cv_container.rst
@@ -9,6 +9,14 @@ Manage Provisioning topology.
    :local:
    :depth: 2
 
+DEPRECATED
+----------
+
+:In: version:
+:Why: Updated modules released with increased functionality
+:Alternative: Use :ref:`arista.cvp.cv_container_v3 <arista.cvp.cv_container_v3>` instead.
+
+
 
 Synopsis
 --------

--- a/ansible_collections/arista/cvp/docs/_build/cv_device.rst
+++ b/ansible_collections/arista/cvp/docs/_build/cv_device.rst
@@ -9,6 +9,14 @@ Provision, Reset, or Update CloudVision Portal Devices.
    :local:
    :depth: 2
 
+DEPRECATED
+----------
+
+:In: version:
+:Why: Updated modules released with increased functionality
+:Alternative: Use :ref:`arista.cvp.cv_device_v3 <arista.cvp.cv_device_v3>` instead.
+
+
 
 Synopsis
 --------

--- a/ansible_collections/arista/cvp/docs/_build/cv_device_v3.rst
+++ b/ansible_collections/arista/cvp/docs/_build/cv_device_v3.rst
@@ -95,7 +95,6 @@ Examples:
 ::
 
     # task in loose mode using fqdn (default)
-    ---
     - name: Device Management in Cloudvision
       hosts: cv_server
       connection: local
@@ -116,7 +115,6 @@ Examples:
             search_key: fqdn
 
     # task in loose mode using serial
-    ---
     - name: Device Management in Cloudvision
       hosts: cv_server
       connection: local
@@ -137,7 +135,6 @@ Examples:
             search_key: serialNumber
 
     # task in strict mode
-    ---
     - name: Device Management in Cloudvision
       hosts: cv_server
       connection: local

--- a/ansible_collections/arista/cvp/docs/_build/cv_facts.rst
+++ b/ansible_collections/arista/cvp/docs/_build/cv_facts.rst
@@ -9,6 +9,14 @@ Collect facts from CloudVision Portal.
    :local:
    :depth: 2
 
+DEPRECATED
+----------
+
+:In: version:
+:Why: Features are now part of every single v3 modules.
+:Alternative:
+
+
 
 Synopsis
 --------

--- a/ansible_collections/arista/cvp/docs/_build/cv_task.rst
+++ b/ansible_collections/arista/cvp/docs/_build/cv_task.rst
@@ -9,6 +9,14 @@ Execute or Cancel CVP Tasks.
    :local:
    :depth: 2
 
+DEPRECATED
+----------
+
+:In: version:
+:Why: Updated modules released with increased functionality
+:Alternative: Use :ref:`arista.cvp.cv_task_v3 <arista.cvp.cv_task_v3>` instead.
+
+
 
 Synopsis
 --------

--- a/ansible_collections/arista/cvp/docs/modules/cv_configlet.rst.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_configlet.rst.md
@@ -1,19 +1,25 @@
-# cv\_configlet
+# cv_configlet
 
 Create, Delete, or Update CloudVision Portal Configlets.
 
-<div class="contents" data-local="" data-depth="2">
+<div class="contents" local="" depth="2">
 
 </div>
+
+## DEPRECATED
+
+- In version: `4.0`
+- Why : Updated modules released with increased functionality
+- Alternative: Use `arista.cvp.cv_configlet_v3` instead.
 
 ## Synopsis
 
 CloudVison Portal Configlet compares the list of configlets and config
 in configlets against cvp-facts then adds, deletes, or updates them as
-appropriate. If a configlet is in cvp\_facts but not in configlets it
-will be deleted. If a configlet is in configlets but not in cvp\_facts
-it will be created. If a configlet is in both configlets and cvp\_facts
-it configuration will be compared and updated with the version in
+appropriate. If a configlet is in cvp_facts but not in configlets it
+will be deleted. If a configlet is in configlets but not in cvp_facts it
+will be created. If a configlet is in both configlets and cvp_facts it
+configuration will be compared and updated with the version in
 configlets if the two are different.
 
 ## Module-specific Options
@@ -132,4 +138,4 @@ The following options may be specified for this module:
 
 ### Author
 
-  - EMEA AS Team (@aristanetworks)
+-   EMEA AS Team (@aristanetworks)

--- a/ansible_collections/arista/cvp/docs/modules/cv_configlet_v3.rst.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_configlet_v3.rst.md
@@ -1,10 +1,10 @@
-# cv\_configlet\_v3
+# cv_configlet_v3
 
 Create, Delete, or Update CloudVision Portal Configlets.
 
 Module added in version 3.0.0
 
-<div class="contents" data-local="" data-depth="2">
+<div class="contents" local="" depth="2">
 
 </div>
 
@@ -12,10 +12,10 @@ Module added in version 3.0.0
 
 CloudVison Portal Configlet compares the list of configlets and config
 in configlets against cvp-facts then adds, deletes, or updates them as
-appropriate. If a configlet is in cvp\_facts but not in configlets it
-will be deleted. If a configlet is in configlets but not in cvp\_facts
-it will be created. If a configlet is in both configlets and cvp\_facts
-it configuration will be compared and updated with the version in
+appropriate. If a configlet is in cvp_facts but not in configlets it
+will be deleted. If a configlet is in configlets but not in cvp_facts it
+will be created. If a configlet is in both configlets and cvp_facts it
+configuration will be compared and updated with the version in
 configlets if the two are different.
 
 ## Module-specific Options
@@ -93,4 +93,4 @@ The following options may be specified for this module:
 
 ### Author
 
-  - EMEA AS Team (@aristanetworks)
+-   EMEA AS Team (@aristanetworks)

--- a/ansible_collections/arista/cvp/docs/modules/cv_container.rst.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_container.rst.md
@@ -1,10 +1,16 @@
-# cv\_container
+# cv_container
 
 Manage Provisioning topology.
 
-<div class="contents" data-local="" data-depth="2">
+<div class="contents" local="" depth="2">
 
 </div>
+
+## DEPRECATED
+
+- In version: `4.0`
+- Why : Updated modules released with increased functionality
+- Alternative: Use `arista.cvp.cv_container_v3` instead.
 
 ## Synopsis
 
@@ -106,4 +112,4 @@ The following options may be specified for this module:
 
 ### Author
 
-  - EMEA AS Team (@aristanetworks)
+-   EMEA AS Team (@aristanetworks)

--- a/ansible_collections/arista/cvp/docs/modules/cv_container_v3.rst.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_container_v3.rst.md
@@ -1,10 +1,10 @@
-# cv\_container\_v3
+# cv_container_v3
 
 Manage Provisioning topology.
 
 Module added in version 3.0.0
 
-<div class="contents" data-local="" data-depth="2">
+<div class="contents" local="" depth="2">
 
 </div>
 
@@ -109,4 +109,4 @@ The following options may be specified for this module:
 
 ### Author
 
-  - EMEA AS Team (@aristanetworks)
+-   EMEA AS Team (@aristanetworks)

--- a/ansible_collections/arista/cvp/docs/modules/cv_device.rst.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_device.rst.md
@@ -1,21 +1,29 @@
-# cv\_device
+# cv_device
 
 Provision, Reset, or Update CloudVision Portal Devices.
 
-<div class="contents" data-local="" data-depth="2">
+<div class="contents" local="" depth="2">
 
 </div>
+
+## DEPRECATED
+
+## DEPRECATED
+
+- In version: `4.0`
+- Why : Updated modules released with increased functionality
+- Alternative: Use `arista.cvp.cv_device_v3` instead.
 
 ## Synopsis
 
 CloudVison Portal Device compares the list of Devices in devices against
 cvp-facts then adds, resets, or updates them as appropriate. If a device
-is in cvp\_facts but not in devices it will be reset to factory defaults
-in ZTP mode If a device is in devices but not in cvp\_facts it will be
-provisioned If a device is in both devices and cvp\_facts its configlets
+is in cvp_facts but not in devices it will be reset to factory defaults
+in ZTP mode If a device is in devices but not in cvp_facts it will be
+provisioned If a device is in both devices and cvp_facts its configlets
 and imageBundles will be compared and updated with the version in
 devices if the two are different. Warning - reset means devices will be
-erased and will run full ZTP process. Use this function with caution \!
+erased and will run full ZTP process. Use this function with caution !
 
 ## Module-specific Options
 
@@ -143,4 +151,4 @@ The following options may be specified for this module:
 
 ### Author
 
-  - EMEA AS Team (@aristanetworks)
+-   EMEA AS Team (@aristanetworks)

--- a/ansible_collections/arista/cvp/docs/modules/cv_device_v3.rst.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_device_v3.rst.md
@@ -1,10 +1,10 @@
-# cv\_device\_v3
+# cv_device_v3
 
 Manage Provisioning topology.
 
 Module added in version 3.0.0
 
-<div class="contents" data-local="" data-depth="2">
+<div class="contents" local="" depth="2">
 
 </div>
 
@@ -79,7 +79,6 @@ The following options may be specified for this module:
 ## Examples:
 
     # task in loose mode using fqdn (default)
-    ---
     - name: Device Management in Cloudvision
       hosts: cv_server
       connection: local
@@ -100,7 +99,6 @@ The following options may be specified for this module:
             search_key: fqdn
 
     # task in loose mode using serial
-    ---
     - name: Device Management in Cloudvision
       hosts: cv_server
       connection: local
@@ -121,7 +119,6 @@ The following options may be specified for this module:
             search_key: serialNumber
 
     # task in strict mode
-    ---
     - name: Device Management in Cloudvision
       hosts: cv_server
       connection: local
@@ -143,4 +140,4 @@ The following options may be specified for this module:
 
 ### Author
 
-  - EMEA AS Team (@aristanetworks)
+-   EMEA AS Team (@aristanetworks)

--- a/ansible_collections/arista/cvp/docs/modules/cv_facts.rst.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_facts.rst.md
@@ -1,10 +1,16 @@
-# cv\_facts
+# cv_facts
 
 Collect facts from CloudVision Portal.
 
-<div class="contents" data-local="" data-depth="2">
+<div class="contents" local="" depth="2">
 
 </div>
+
+## DEPRECATED
+
+- In version: `4.0`
+- Why : Updated modules released with increased functionality
+- Alternative: All v3 modules are now independents and cv_facts is not required anymore.
 
 ## Synopsis
 
@@ -93,4 +99,4 @@ The following options may be specified for this module:
 
 ### Author
 
-  - EMEA AS Team (@aristanetworks)
+-   EMEA AS Team (@aristanetworks)

--- a/ansible_collections/arista/cvp/docs/modules/cv_task.rst.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_task.rst.md
@@ -1,10 +1,16 @@
-# cv\_task
+# cv_task
 
 Execute or Cancel CVP Tasks.
 
-<div class="contents" data-local="" data-depth="2">
+<div class="contents" local="" depth="2">
 
 </div>
+
+## DEPRECATED
+
+- In version: `4.0`
+- Why : Updated modules released with increased functionality
+- Alternative: Use `arista.cvp.cv_task_v3` instead.
 
 ## Synopsis
 
@@ -86,4 +92,4 @@ The following options may be specified for this module:
 
 ### Author
 
-  - EMEA AS Team (@aristanetworks)
+-   EMEA AS Team (@aristanetworks)

--- a/ansible_collections/arista/cvp/docs/modules/cv_task_v3.rst.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_task_v3.rst.md
@@ -1,10 +1,10 @@
-# cv\_task\_v3
+# cv_task_v3
 
 Execute or Cancel CVP Tasks.
 
 Module added in version 3.0.0
 
-<div class="contents" data-local="" data-depth="2">
+<div class="contents" local="" depth="2">
 
 </div>
 
@@ -66,4 +66,4 @@ The following options may be specified for this module:
 
 ### Author
 
-  - EMEA AS Team (@aristanetworks)
+-   EMEA AS Team (@aristanetworks)

--- a/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
@@ -38,6 +38,10 @@ description:
   - If a configlet is in both configlets and cvp_facts it configuration will
   - be compared and updated with the version in configlets
   - if the two are different.
+deprecated:
+  removed_in: '4.0'
+  why: Updated modules released with increased functionality
+  alternative: Use M(arista.cvp.cv_configlet_v3) instead.
 options:
   configlets:
     description: List of configlets to managed on CVP server.

--- a/ansible_collections/arista/cvp/plugins/modules/cv_container.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_container.py
@@ -34,6 +34,10 @@ description:
   - CloudVision Portal Configlet configuration requires a dictionary of containers with their parent,
     to create and delete containers on CVP side.
   - Returns number of created and/or deleted containers
+deprecated:
+  removed_in: '4.0'
+  why: Updated modules released with increased functionality
+  alternative: Use M(arista.cvp.cv_container_v3) instead.
 options:
   topology:
     description: Yaml dictionary to describe intended containers

--- a/ansible_collections/arista/cvp/plugins/modules/cv_device.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_device.py
@@ -35,6 +35,10 @@ description:
   - If a device is in both devices and cvp_facts its configlets and imageBundles will be compared
   - and updated with the version in devices if the two are different.
   - Warning - reset means devices will be erased and will run full ZTP process. Use this function with caution !
+deprecated:
+  removed_in: '4.0'
+  why: Updated modules released with increased functionality
+  alternative: Use M(arista.cvp.cv_device_v3) instead.
 options:
   devices:
     description: Yaml dictionary to describe intended devices

--- a/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
@@ -30,6 +30,9 @@ author: EMEA AS Team (@aristanetworks)
 short_description: Collect facts from CloudVision Portal.
 description:
   - Returns list of devices, configlets, containers and images
+deprecated:
+  removed_in: '4.0'
+  why: Features are now part of every single v3 modules.
 options:
   gather_subset:
     description:

--- a/ansible_collections/arista/cvp/plugins/modules/cv_task.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_task.py
@@ -30,6 +30,10 @@ author: EMEA AS Team (@aristanetworks)
 short_description: Execute or Cancel CVP Tasks.
 description:
   - CloudVison Portal Task module
+deprecated:
+  removed_in: '4.0'
+  why: Updated modules released with increased functionality
+  alternative: Use M(arista.cvp.cv_task_v3) instead.
 options:
   tasks:
     description: CVP taskIDs to act on


### PR DESCRIPTION
## Change Summary

Announce `arista.cvp.cv_*` v1 deprecation

## Related Issue(s)

N/A

## Component(s) name

- `arista.cvp.cv_facts`
- `arista.cvp.cv_container`
- `arista.cvp.cv_configlet`
- `arista.cvp.cv_device`
- `arista.cvp.cv_task`

## Proposed changes

Mark modules as deprecated in module documentation

## How to test

```bash
$ ansible-doc arista.cvp.cv_container

        CloudVision Portal Configlet configuration requires a dictionary of containers with their parent, to create and delete
        containers on CVP side. Returns number of created and/or deleted containers

ADDED IN: version 1.0.0 of arista.cvp

DEPRECATED: 

        Reason: Updated modules released with increased functionality
        Will be removed in: Ansible 4.0
        Alternatives: Use M(arista.cvp.cv_container_v3) instead.

[...]

```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- [x] Update Makefile to stop regenerate v1 documentation
- [x] Update Readmes
- [x] Mark all modules as deprecated

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
