### PR TITLE
Feat(cv_container_v3): Support for removing all configlets from a container

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
@@ -848,7 +848,7 @@ class CvContainerTools(object):
                             if configlet_to_remove:
                                 resp = self.configlets_detach(container=user_container, configlets=configlet_to_remove)
                                 cv_configlets_detach.add_change(resp)
-                                    # If no configlets are set, remove all configlets if apply_mode is set to strict
+                    # If no configlets are set, remove all configlets if apply_mode is set to strict
                     elif apply_mode == 'strict':
                         configlet_to_remove = self.get_configlets(container_name=user_container)
                         if len(configlet_to_remove) > 0:

--- a/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
@@ -834,7 +834,6 @@ class CvContainerTools(object):
                 # If no configlets are set, remove all configlets if apply_mode is set to strict
                 elif apply_mode == 'strict':
                     configlet_to_remove = self.get_configlets(container_name=user_container)
-                    MODULE_LOGGER.debug("DEBUG: configlet to be removed is {}".format(str(configlet_to_remove)))
                     if len(configlet_to_remove) > 0:
                         resp = self.configlets_detach(container=user_container, configlets=configlet_to_remove)
                         cv_configlets_detach.add_change(resp)

--- a/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
@@ -831,6 +831,13 @@ class CvContainerTools(object):
                         if len(configlet_to_remove) > 0:
                             resp = self.configlets_detach(container=user_container, configlets=configlet_to_remove)
                             cv_configlets_detach.add_change(resp)
+                # If no configlets are set, remove all configlets if apply_mode is set to strict
+                elif apply_mode == 'strict':
+                    configlet_to_remove = self.get_configlets(container_name=user_container)
+                    MODULE_LOGGER.debug("DEBUG: configlet to be removed is {}".format(str(configlet_to_remove)))
+                    if len(configlet_to_remove) > 0:
+                        resp = self.configlets_detach(container=user_container, configlets=configlet_to_remove)
+                        cv_configlets_detach.add_change(resp)
 
         # Remove containers topology from Cloudvision
         else:


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Related Issue(s)

Fixes #443 

## Component(s) name

`arista.cvp.cv_container_v3`

## Proposed changes
Added another condition to check if apply_mode is strict when the configlet list is empty on ansible side, which would mean we want to unassign all configlets from the container


## How to test

Assign configlets to containers:

```yaml
---
- name: lab05 - cv_container_v3 lab
  hosts: CloudVision
  connection: local
  gather_facts: no
  vars:
    CVP_CONFIGLETS:
      01TRAINING-alias: "alias srnz show interfaces counters rates | nz"
      01TRAINING-01: "alias a{{ 999 | random }} show version"

    CVP_CONTAINERS:
      Tenant:
        parentContainerName: Tenant
        configlets:
          - 01TRAINING-alias
          - 01TRAINING-01
      TRAINING:
        parentContainerName: Tenant
        configlets:
          - 01TRAINING-alias
          - 01TRAINING-01
  tasks:
    - name: "Configure containers on {{inventory_hostname}}"
      arista.cvp.cv_container_v3:
        topology: "{{CVP_CONTAINERS}}"
        state: present
        apply_mode: strict
      register: CVP_CONTAINERS_RESULT
```

` ansible-playbook test2.yml`

the above will add `01TRAINING-alias` and `01TRAINING-01` to both `Tenant` and `TRAINING` containers

Unassign one configlet:

```yaml
---
- name: lab05 - cv_container_v3 lab
  hosts: CloudVision
  connection: local
  gather_facts: no
  vars:
    CVP_CONFIGLETS:
      01TRAINING-alias: "alias srnz show interfaces counters rates | nz"
      01TRAINING-01: "alias a{{ 999 | random }} show version"

    CVP_CONTAINERS:
      Tenant:
        parentContainerName: Tenant
        configlets:
          - 01TRAINING-alias
      TRAINING:
        parentContainerName: Tenant
        configlets:
          - 01TRAINING-alias
          - 01TRAINING-01
  tasks:
    - name: "Configure containers on {{inventory_hostname}}"
      arista.cvp.cv_container_v3:
        topology: "{{CVP_CONTAINERS}}"
        state: present
        apply_mode: strict
      register: CVP_CONTAINERS_RESULT
```

The above will unassign configlet `01TRAINING-01` from `Tenant` container


Unassign all configlets:

```yaml
---
- name: lab05 - cv_container_v3 lab
  hosts: CloudVision
  connection: local
  gather_facts: no
  vars:
    CVP_CONFIGLETS:
      01TRAINING-alias: "alias srnz show interfaces counters rates | nz"
      01TRAINING-01: "alias a{{ 999 | random }} show version"

    CVP_CONTAINERS:
      Tenant:
        parentContainerName: Tenant
        configlets: []
      TRAINING:
        parentContainerName: Tenant
  tasks:
    - name: "Configure containers on {{inventory_hostname}}"
      arista.cvp.cv_container_v3:
        topology: "{{CVP_CONTAINERS}}"
        state: present
        apply_mode: strict
      register: CVP_CONTAINERS_RESULT
```

The above will unassign all configlets from both `Tenant` and `TRAINING` container
you can either specify `configlets: []` or not specify configlets at all.

## Checklist


### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
