### PR TITLE
CI(actions): Update 404 action after Arista Website update

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -194,7 +194,13 @@ jobs:
           until docker exec webdoc_cvp curl -s -I http://localhost:8000/ ; do sleep 2; done
       - name: check links for 404
         run: |
-          docker run --network container:webdoc_cvp raviqqe/muffet:1.5.7 http://127.0.0.1:8000 -e ".*fonts.googleapis.com.*" -e ".*fonts.gstatic.com.*" -e ".*edit.*" -f --limit-redirections=3 --timeout=30
+          docker run --network container:webdoc_cvp raviqqe/muffet:1.5.7 http://127.0.0.1:8000 \
+            -e ".*fonts.googleapis.com.*" \
+            -e ".*fonts.gstatic.com.*" \
+            -e ".*edit.*" \
+            -e ".*aristanetworks.force.com.*" \
+            -e ".*https://s3.amazonaws.com/onelogin-sourcemaps/.*" \
+            -f --limit-redirections=3 --timeout=30
       - name: 'stop docker-compose stack'
         run: |
           docker-compose -f docker-compose.yml down

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -194,13 +194,16 @@ jobs:
           until docker exec webdoc_cvp curl -s -I http://localhost:8000/ ; do sleep 2; done
       - name: check links for 404
         run: |
-          docker run --network container:webdoc_cvp raviqqe/muffet:1.5.7 http://127.0.0.1:8000 \
+          docker run --network container:webdoc_cvp raviqqe/muffet:2.4.0 http://127.0.0.1:8000 \
             -e ".*fonts.googleapis.com.*" \
             -e ".*fonts.gstatic.com.*" \
             -e ".*edit.*" \
             -e ".*aristanetworks.force.com.*" \
             -e ".*https://s3.amazonaws.com/onelogin-sourcemaps/.*" \
-            -f --limit-redirections=3 --timeout=30
+            -f --buffer-size=8192 \
+            --color=always \
+            --skip-tls-verification \
+            --timeout=30
       - name: 'stop docker-compose stack'
         run: |
           docker-compose -f docker-compose.yml down

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ webdoc: ## Build documentation to publish static content
 
 .PHONY: check-cvp-404
 check-cvp-404: ## Check local 404 links for AVD documentation
-	docker run --rm --network container:webdoc_cvp raviqqe/muffet:1.5.7 http://127.0.0.1:8000 -e ".*fonts.googleapis.com.*" -e ".*fonts.gstatic.com.*" -e ".*edit.*" -f --limit-redirections=3 --timeout=${MUFFET_TIMEOUT}
+	docker run --rm --network container:webdoc_cvp raviqqe/muffet:1.5.7 http://127.0.0.1:8001 -e ".*fonts.googleapis.com.*" -e ".*fonts.gstatic.com.*" -e ".*edit.*" -f --limit-redirections=3 --timeout=${MUFFET_TIMEOUT}
 
 #########################################
 # Misc Actions 							#


### PR DESCRIPTION
## Change Summary

After release of Arista Community website, 404 links action must be updated to ignore some 403 links

## Related Issue(s)

N/A

## Component(s) name

GH actions

## Proposed changes

- Ignore `https://s3.amazonaws.com/onelogin-sourcemaps/.*`
- Ignore `https://aristanetworks.force.com`

## How to test

Run CI

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
