### PR TITLE
Feat: Implementation of concurrent API calls using asyncio

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/api.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/api.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python
+# coding: utf-8 -*-
+#
+# GNU General Public License v3.0+
+#
+# Copyright 2019 Arista Networks AS-EMEA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import logging
+import asyncio
+import time
+import functools
+from typing import Callable, List
+from cvprac.cvp_client import CvpClient
+from concurrent.futures import ThreadPoolExecutor
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def call(func: Callable[..., dict], args: List[dict]) -> List[dict]:
+    """
+    Query CloudVision using concurrent API calls.
+    Take as argument a function that have one or multiple arbitrary arguments.
+    The function must return a dictionary.
+    This function can be a blocking call since it is run in a separate thread.
+
+    The list args contains the arguments for each concurrent API call and thus defines the number of concurrent calls.
+
+    This is a coroutine and can be used in asynchronous code to query multiple ressources concurently.
+
+    Parameters
+    ----------
+    func : Callable[..., dict]
+        Function to call
+    args : List[dict]
+        The arguments for each concurrent API call
+
+    Returns
+    -------
+    List[dict]
+        Aggregated results of concurrent API calls
+    """
+    now = time.time()
+    loop = asyncio.get_running_loop()
+
+    LOGGER.info('%s: Querying %s items', func.__name__, len(args))
+
+    with ThreadPoolExecutor() as pool:
+        responses = await asyncio.gather(*(loop.run_in_executor(pool,
+                                           functools.partial(func, **kwargs))
+                                           for kwargs in args))
+
+    LOGGER.info('%s: Queried %s items in %ss', func.__name__, len(responses), time.time() - now)
+
+    return responses
+
+
+async def call_batch(func: Callable[[int, int], dict], item_per_call: int = 2) -> dict:
+    """
+    Query CloudVision using concurrent API calls.
+    Take as argument a function that have the following signature: func(start:int, end:int).
+    The function must return the following data structure:
+    {
+        "data": [
+            {},
+            {}
+        ],
+        "total": 2
+    }
+
+    This function can be a blocking call since it is run in a separate thread.
+
+    The optional parameter item_per_call defines the number of item to retrieve per concurrent API call.
+
+    This is a coroutine and can be used in asynchronous code to query multiple ressources concurently.
+
+    Parameters
+    ----------
+    func : Callable[[int, int], dict]
+        Function to call
+    item_per_call : int, optional
+        Number of item to retrieve per concurrent API call, by default 2
+
+    Returns
+    -------
+    dict
+        Aggregated results of concurrent API calls
+    """
+    now = time.time()
+    data = []
+    loop = asyncio.get_running_loop()
+    first = func(start=0, end=1)
+    total = first['total']
+    data.extend(first['data'])
+
+    if total == 1:
+        LOGGER.info('%s: Collected 1 item in %ss', func.__name__, time.time() - now)
+        return {'total': total, 'data': data}
+
+    # Some cvprac calls are broken and ignore the start and end parameters
+    if len(data) == total:
+        LOGGER.info('%s: Collected %s items in %ss', func.__name__, len(data), time.time() - now)
+        return {'total': total, 'data': data}
+
+    LOGGER.info('%s: Collecting %s items, %s items per API call', func.__name__, total, item_per_call)
+
+    with ThreadPoolExecutor() as pool:
+        responses = await asyncio.gather(*(loop.run_in_executor(pool,
+                                           functools.partial(func, start=i, end=i + item_per_call))
+                                           for i in range(1, total, item_per_call)))
+
+    for r in responses:
+        data.extend(r['data'])
+    LOGGER.info('%s: Collected %s items in %ss', func.__name__, len(data), time.time() - now)
+
+    return {'total': total, 'data': data}
+
+
+def get_configlets_by_name(client: CvpClient, names: List[str]) -> List[dict]:
+    return asyncio.run(call(client.api.get_configlet_by_name, [{'name': i} for i in names]))
+
+
+def get_configlets(client: CvpClient, **item_per_call) -> dict:
+    return asyncio.run(call_batch(client.api.get_configlets, **item_per_call))
+
+
+def get_images(client: CvpClient, **item_per_call) -> dict:
+    return asyncio.run(call_batch(client.api.get_images, **item_per_call))
+
+
+def get_containers(client: CvpClient, **item_per_call) -> dict:
+    return asyncio.run(call_batch(client.api.get_containers, **item_per_call))
+
+
+def update_configlets(client: CvpClient, configs: List[dict]) -> dict:
+    """
+    config example:
+       {'name': 'my-configlet',
+        'key': 'configlet_123456',
+        'config': 'hostname EOS',
+        'wait_task_ids': False
+        }
+    """
+    return asyncio.run(call(client.api.update_configlet, configs))
+
+
+def add_notes_to_configlets(client: CvpClient, configs: List[dict]) -> dict:
+    """
+    note example:
+       {'key': 'configlet_123456',
+        'note': 'my note'}
+    """
+    return asyncio.run(call(client.api.add_note_to_configlet, configs))
+
+
+def get_images_and_configlets(client: CvpClient, **item_per_call) -> dict:
+    async def run():
+        r = await asyncio.gather(call_batch(client.api.get_configlets, **item_per_call),
+                                 call_batch(client.api.get_images, **item_per_call))
+        return r
+    return asyncio.run(run())

--- a/ansible_collections/arista/cvp/plugins/module_utils/api.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/api.py
@@ -89,8 +89,8 @@ async def call_batch(func: Callable[[int, int], dict], pagination_coeff: int = 4
     ----------
     func : Callable[[int, int], dict]
         Function to call
-    item_per_call : int, optional
-        Number of item to retrieve per concurrent API call
+    pagination_coeff : int, optional
+        Influence the number of item retrieved per concurrent API call
 
     Returns
     -------
@@ -113,9 +113,8 @@ async def call_batch(func: Callable[[int, int], dict], pagination_coeff: int = 4
         LOGGER.info('%s: Collected %s items in %ss', func.__name__, len(data), time.monotonic() - started_at)
         return {'total': total, 'data': data}
 
-    if not item_per_call:
-        # min(32, os.cpu_count() + 4) is the max_workers value of ThreadPoolExecutor in Python 3.8
-        item_per_call = int(total / min(32, os.cpu_count() + 4) * pagination_coeff)
+    # min(32, os.cpu_count() + 4) is the max_workers value of ThreadPoolExecutor in Python 3.8
+    item_per_call = int(total / min(32, os.cpu_count() + 4) * pagination_coeff)
 
     LOGGER.info('%s: Collecting %s items, %s items per API call', func.__name__, total, item_per_call)
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/api.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/api.py
@@ -1,12 +1,4 @@
-#!/usr/bin/env python
-# coding: utf-8 -*-
-#
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
+#!/usr/bin/python
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
@@ -22,6 +14,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import logging
+import os
 import asyncio
 import time
 import functools
@@ -54,7 +47,7 @@ async def call(func: Callable[..., dict], args: List[dict]) -> List[dict]:
     List[dict]
         Aggregated results of concurrent API calls
     """
-    now = time.time()
+    started_at = time.monotonic()
     loop = asyncio.get_running_loop()
 
     LOGGER.info('%s: Querying %s items', func.__name__, len(args))
@@ -64,12 +57,12 @@ async def call(func: Callable[..., dict], args: List[dict]) -> List[dict]:
                                            functools.partial(func, **kwargs))
                                            for kwargs in args))
 
-    LOGGER.info('%s: Queried %s items in %ss', func.__name__, len(responses), time.time() - now)
+    LOGGER.info('%s: Queried %s items in %ss', func.__name__, len(responses), time.monotonic() - started_at)
 
     return responses
 
 
-async def call_batch(func: Callable[[int, int], dict], item_per_call: int = 2) -> dict:
+async def call_batch(func: Callable[[int, int], dict], pagination_coeff: int = 4) -> dict:
     """
     Query CloudVision using concurrent API calls.
     Take as argument a function that have the following signature: func(start:int, end:int).
@@ -84,7 +77,11 @@ async def call_batch(func: Callable[[int, int], dict], item_per_call: int = 2) -
 
     This function can be a blocking call since it is run in a separate thread.
 
-    The optional parameter item_per_call defines the number of item to retrieve per concurrent API call.
+    The optional parameter pagination_coeff influences the number of item retrieved per concurrent API call.
+    A pagination_coeff value of 1 means the number API calls will be equal equal to the max_workers value on
+    the execution machine. A value of 2 means the number of API calls will be half the max_workers value.
+    In Python 3.8, max_workers value is min(32, os.cpu_count() + 4. This value defines the maximum of running
+    concurrent threads of a ThreadPoolExecutor.
 
     This is a coroutine and can be used in asynchronous code to query multiple ressources concurently.
 
@@ -93,14 +90,14 @@ async def call_batch(func: Callable[[int, int], dict], item_per_call: int = 2) -
     func : Callable[[int, int], dict]
         Function to call
     item_per_call : int, optional
-        Number of item to retrieve per concurrent API call, by default 2
+        Number of item to retrieve per concurrent API call
 
     Returns
     -------
     dict
         Aggregated results of concurrent API calls
     """
-    now = time.time()
+    started_at = time.monotonic()
     data = []
     loop = asyncio.get_running_loop()
     first = func(start=0, end=1)
@@ -108,13 +105,17 @@ async def call_batch(func: Callable[[int, int], dict], item_per_call: int = 2) -
     data.extend(first['data'])
 
     if total == 1:
-        LOGGER.info('%s: Collected 1 item in %ss', func.__name__, time.time() - now)
+        LOGGER.info('%s: Collected 1 item in %ss', func.__name__, time.monotonic() - started_at)
         return {'total': total, 'data': data}
 
     # Some cvprac calls are broken and ignore the start and end parameters
     if len(data) == total:
-        LOGGER.info('%s: Collected %s items in %ss', func.__name__, len(data), time.time() - now)
+        LOGGER.info('%s: Collected %s items in %ss', func.__name__, len(data), time.monotonic() - started_at)
         return {'total': total, 'data': data}
+
+    if not item_per_call:
+        # min(32, os.cpu_count() + 4) is the max_workers value of ThreadPoolExecutor in Python 3.8
+        item_per_call = int(total / min(32, os.cpu_count() + 4) * pagination_coeff)
 
     LOGGER.info('%s: Collecting %s items, %s items per API call', func.__name__, total, item_per_call)
 
@@ -125,7 +126,7 @@ async def call_batch(func: Callable[[int, int], dict], item_per_call: int = 2) -
 
     for r in responses:
         data.extend(r['data'])
-    LOGGER.info('%s: Collected %s items in %ss', func.__name__, len(data), time.time() - now)
+    LOGGER.info('%s: Collected %s items in %ss', func.__name__, len(data), time.monotonic() - started_at)
 
     return {'total': total, 'data': data}
 
@@ -134,16 +135,18 @@ def get_configlets_by_name(client, names: List[str]) -> List[dict]:
     return asyncio.run(call(client.api.get_configlet_by_name, [{'name': i} for i in names]))
 
 
-def get_configlets(client, **item_per_call) -> dict:
-    return asyncio.run(call_batch(client.api.get_configlets, **item_per_call))
 
 
-def get_images(client, **item_per_call) -> dict:
-    return asyncio.run(call_batch(client.api.get_images, **item_per_call))
+def get_configlets(client) -> dict:
+    return asyncio.run(call_batch(client.api.get_configlets))
 
 
-def get_containers(client, **item_per_call) -> dict:
-    return asyncio.run(call_batch(client.api.get_containers, **item_per_call))
+def get_images(client) -> dict:
+    return asyncio.run(call_batch(client.api.get_images))
+
+
+def get_containers(client) -> dict:
+    return asyncio.run(call_batch(client.api.get_containers))
 
 
 def update_configlets(client, configs: List[dict]) -> dict:

--- a/ansible_collections/arista/cvp/plugins/module_utils/api.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/api.py
@@ -26,7 +26,6 @@ import asyncio
 import time
 import functools
 from typing import Callable, List
-from cvprac.cvp_client import CvpClient
 from concurrent.futures import ThreadPoolExecutor
 
 LOGGER = logging.getLogger(__name__)
@@ -131,23 +130,23 @@ async def call_batch(func: Callable[[int, int], dict], item_per_call: int = 2) -
     return {'total': total, 'data': data}
 
 
-def get_configlets_by_name(client: CvpClient, names: List[str]) -> List[dict]:
+def get_configlets_by_name(client, names: List[str]) -> List[dict]:
     return asyncio.run(call(client.api.get_configlet_by_name, [{'name': i} for i in names]))
 
 
-def get_configlets(client: CvpClient, **item_per_call) -> dict:
+def get_configlets(client, **item_per_call) -> dict:
     return asyncio.run(call_batch(client.api.get_configlets, **item_per_call))
 
 
-def get_images(client: CvpClient, **item_per_call) -> dict:
+def get_images(client, **item_per_call) -> dict:
     return asyncio.run(call_batch(client.api.get_images, **item_per_call))
 
 
-def get_containers(client: CvpClient, **item_per_call) -> dict:
+def get_containers(client, **item_per_call) -> dict:
     return asyncio.run(call_batch(client.api.get_containers, **item_per_call))
 
 
-def update_configlets(client: CvpClient, configs: List[dict]) -> dict:
+def update_configlets(client, configs: List[dict]) -> dict:
     """
     config example:
        {'name': 'my-configlet',
@@ -159,7 +158,7 @@ def update_configlets(client: CvpClient, configs: List[dict]) -> dict:
     return asyncio.run(call(client.api.update_configlet, configs))
 
 
-def add_notes_to_configlets(client: CvpClient, configs: List[dict]) -> dict:
+def add_notes_to_configlets(client, configs: List[dict]) -> dict:
     """
     note example:
        {'key': 'configlet_123456',
@@ -168,7 +167,7 @@ def add_notes_to_configlets(client: CvpClient, configs: List[dict]) -> dict:
     return asyncio.run(call(client.api.add_note_to_configlet, configs))
 
 
-def get_images_and_configlets(client: CvpClient, **item_per_call) -> dict:
+def get_images_and_configlets(client, **item_per_call) -> dict:
     async def run():
         r = await asyncio.gather(call_batch(client.api.get_configlets, **item_per_call),
                                  call_batch(client.api.get_images, **item_per_call))

--- a/ansible_collections/arista/cvp/plugins/module_utils/api.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/api.py
@@ -97,6 +97,7 @@ async def call_batch(func: Callable[[int, int], dict], pagination_coeff: int = 4
     dict
         Aggregated results of concurrent API calls
     """
+    LOGGER.debug('%s: Collecting concurrently', func.__name__)
     started_at = time.monotonic()
     data = []
     loop = asyncio.get_running_loop()
@@ -108,7 +109,7 @@ async def call_batch(func: Callable[[int, int], dict], pagination_coeff: int = 4
         LOGGER.info('%s: Collected 1 item in %ss', func.__name__, time.monotonic() - started_at)
         return {'total': total, 'data': data}
 
-    # Some cvprac calls are broken and ignore the start and end parameters
+    # Some cvprac calls ignore the start and end parameters
     if len(data) == total:
         LOGGER.info('%s: Collected %s items in %ss', func.__name__, len(data), time.monotonic() - started_at)
         return {'total': total, 'data': data}
@@ -132,8 +133,6 @@ async def call_batch(func: Callable[[int, int], dict], pagination_coeff: int = 4
 
 def get_configlets_by_name(client, names: List[str]) -> List[dict]:
     return asyncio.run(call(client.api.get_configlet_by_name, [{'name': i} for i in names]))
-
-
 
 
 def get_configlets(client) -> dict:

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -222,6 +222,9 @@ class CvFactsTools():
     def __init__(self, cv_connection):
         self.__cv_client = cv_connection
         self._cache = {Facts.CACHE_CONTAINERS: None, Facts.CACHE_MAPPERS: None}
+        self.__init_facts()
+
+    def __init_facts(self):
         self._facts = {Facts.DEVICE: [], Facts.CONFIGLET: [], Facts.CONTAINER: []}
 
     def _get_configlets_and_mappers(self, ids: List[str] = None, force_refresh: bool = False):

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -505,9 +505,4 @@ class CvFactsTools():
             if re.match(filter, configlet[ApiFields.generic.NAME]):
                 MODULE_LOGGER.debug('Adding configlet %s', str(configlet['name']))
                 facts_builder.add(configlet)
-
-        MODULE_LOGGER.debug(
-            'Final results for configlets: %s',
-            str(facts_builder.get(resource_model='configlet').keys())
-        )
         self._facts[Facts.CONFIGLET] = facts_builder.get(resource_model='configlet')

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -284,7 +284,7 @@ class CvFactsTools():
         dict
             A dictionary of information with all the data from Cloudvision
         """
-        asyncio.run(self.gather(scope, regex_filter=regex_filter))
+        return asyncio.run(self.gather(scope, regex_filter=regex_filter))
 
     def __get_container_name(self, key: str = 'undefined_container'):
         """

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -454,7 +454,7 @@ class CvFactsTools():
             Facts verbosity: full get all data from CV where short get only cv_modules data, by default 'short'
         """
         try:
-            cv_devices = await api.call_batch(self.__cv_client.api.get_inventory)
+            cv_devices = self.__cv_client.api.get_inventory()
         except CvpApiError as error_msg:
             MODULE_LOGGER.error('Error when collecting devices facts: %s', str(error_msg))
         MODULE_LOGGER.info('Extract device data using filter %s', str(filter))
@@ -474,7 +474,7 @@ class CvFactsTools():
         __fact_containers Collect facts related to container structure
         """
         try:
-            cv_containers = await api.call_batch(self.__cv_client.api.get_containers)
+            cv_containers = self.__cv_client.api.get_containers()
         except CvpApiError as error_msg:
             MODULE_LOGGER.error('Error when collecting containers facts: %s', str(error_msg))
         facts_builder = CvFactResource()

--- a/tests/lib/config.py
+++ b/tests/lib/config.py
@@ -6,7 +6,9 @@
 import os
 from distutils.util import strtobool
 
-user_token = os.getenv('ARISTA_AVD_CV_TOKEN', 'unset_token')
-server = os.getenv('ARISTA_AVD_CV_SERVER', '')
+user_token = os.getenv('ARISTA_AVD_CV_TOKEN')
+server = os.getenv('ARISTA_AVD_CV_SERVER')
+username = os.getenv('ARISTA_AVD_CV_USERNAME')
+password = os.getenv('ARISTA_AVD_CV_PASSWORD')
 provision_cv = strtobool(os.getenv('ARISTA_AVD_CV_PROVISION', 'true'))
 cvaas = strtobool(os.getenv('ARISTA_AVD_CVAAS', 'true'))

--- a/tests/lib/utils.py
+++ b/tests/lib/utils.py
@@ -15,6 +15,7 @@ from tests.system.constants_data import USER_CONTAINERS, CV_CONTAINERS_NAME_ID_L
 
 MODULE_LOGGER = logging.getLogger(__name__)
 
+
 def cvp_login():
     """Login cvp devices
 
@@ -27,8 +28,8 @@ def cvp_login():
     try:
         cvp_client.connect(
             nodes=[config.server],
-            username="",
-            password="",
+            username=config.username,
+            password=config.password,
             is_cvaas=config.cvaas,
             api_token=config.user_token
         )

--- a/tests/system/test_cv_api.py
+++ b/tests/system/test_cv_api.py
@@ -9,7 +9,6 @@
 from __future__ import (absolute_import, division, print_function)
 import logging
 import pytest
-from tests.lib.config import user_token
 from tests.lib.utils import cvp_login
 from ansible_collections.arista.cvp.plugins.module_utils import api
 
@@ -33,7 +32,6 @@ def api_client():
 
 @pytest.mark.api
 @pytest.mark.dependency(name='authentication')
-@pytest.mark.skipif(user_token == 'unset_token', reason="Token is not set correctly")
 def test_get_configlets(api_client):
     r = api.get_configlets(api_client)
     assert 'data' in r
@@ -41,7 +39,6 @@ def test_get_configlets(api_client):
 
 @pytest.mark.api
 @pytest.mark.dependency(name='authentication')
-@pytest.mark.skipif(user_token == 'unset_token', reason="Token is not set correctly")
 def test_get_images(api_client):
     r = api.get_images(api_client)
     assert 'data' in r
@@ -49,7 +46,6 @@ def test_get_images(api_client):
 
 @pytest.mark.api
 @pytest.mark.dependency(name='authentication')
-@pytest.mark.skipif(user_token == 'unset_token', reason="Token is not set correctly")
 def test_get_containers(api_client):
     r = api.get_containers(api_client)
     assert 'data' in r
@@ -57,7 +53,6 @@ def test_get_containers(api_client):
 
 @pytest.mark.api
 @pytest.mark.dependency(name='authentication')
-@pytest.mark.skipif(user_token == 'unset_token', reason="Token is not set correctly")
 def test_get_images_and_configlets(api_client):
     r = api.get_images_and_configlets(api_client)
     assert 'data' in r[0] and 'data' in r[1]
@@ -65,7 +60,6 @@ def test_get_images_and_configlets(api_client):
 
 @pytest.mark.api
 @pytest.mark.dependency(name='authentication')
-@pytest.mark.skipif(user_token == 'unset_token', reason="Token is not set correctly")
 def test_get_configlets_by_name(api_client):
     r1 = api.get_configlets(api_client)
     names = []
@@ -77,7 +71,6 @@ def test_get_configlets_by_name(api_client):
 
 @pytest.mark.api
 @pytest.mark.dependency(name='authentication')
-@pytest.mark.skipif(user_token == 'unset_token', reason="Token is not set correctly")
 def test_update_configlets(api_client):
     r1 = api.get_configlets(api_client)
     names = []
@@ -95,7 +88,6 @@ def test_update_configlets(api_client):
 
 @pytest.mark.api
 @pytest.mark.dependency(name='authentication')
-@pytest.mark.skipif(user_token == 'unset_token', reason="Token is not set correctly")
 def test_add_notes_to_configlets(api_client):
     r1 = api.get_configlets(api_client)
     names = []

--- a/tests/system/test_cv_api.py
+++ b/tests/system/test_cv_api.py
@@ -1,0 +1,110 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+# pylint: disable=logging-format-interpolation
+# pylint: disable=dangerous-default-value
+# flake8: noqa: W503
+# flake8: noqa: W1202
+# flake8: noqa: R0801
+
+from __future__ import (absolute_import, division, print_function)
+import logging
+import pytest
+from tests.lib.config import user_token
+from tests.lib.utils import cvp_login
+from ansible_collections.arista.cvp.plugins.module_utils import api
+
+LOGGER = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------- #
+#   FIXTURES Management
+# ---------------------------------------------------------------------------- #
+
+
+@pytest.fixture(scope="module")
+def api_client():
+    client = cvp_login()
+    return client
+
+
+# ---------------------------------------------------------------------------- #
+#   TESTS Management
+# ---------------------------------------------------------------------------- #
+
+
+@pytest.mark.api
+@pytest.mark.dependency(name='authentication')
+@pytest.mark.skipif(user_token == 'unset_token', reason="Token is not set correctly")
+def test_get_configlets(api_client):
+    r = api.get_configlets(api_client)
+    assert 'data' in r
+
+
+@pytest.mark.api
+@pytest.mark.dependency(name='authentication')
+@pytest.mark.skipif(user_token == 'unset_token', reason="Token is not set correctly")
+def test_get_images(api_client):
+    r = api.get_images(api_client)
+    assert 'data' in r
+
+
+@pytest.mark.api
+@pytest.mark.dependency(name='authentication')
+@pytest.mark.skipif(user_token == 'unset_token', reason="Token is not set correctly")
+def test_get_containers(api_client):
+    r = api.get_containers(api_client)
+    assert 'data' in r
+
+
+@pytest.mark.api
+@pytest.mark.dependency(name='authentication')
+@pytest.mark.skipif(user_token == 'unset_token', reason="Token is not set correctly")
+def test_get_images_and_configlets(api_client):
+    r = api.get_images_and_configlets(api_client)
+    assert 'data' in r[0] and 'data' in r[1]
+
+
+@pytest.mark.api
+@pytest.mark.dependency(name='authentication')
+@pytest.mark.skipif(user_token == 'unset_token', reason="Token is not set correctly")
+def test_get_configlets_by_name(api_client):
+    r1 = api.get_configlets(api_client)
+    names = []
+    for c in r1['data']:
+        names.append(c['name'])
+    r2 = api.get_configlets_by_name(api_client, names)
+    assert r1['total'] == len(r2)
+
+
+@pytest.mark.api
+@pytest.mark.dependency(name='authentication')
+@pytest.mark.skipif(user_token == 'unset_token', reason="Token is not set correctly")
+def test_update_configlets(api_client):
+    r1 = api.get_configlets(api_client)
+    names = []
+    for c in r1['data']:
+        names.append(c['name'])
+    r2 = api.get_configlets_by_name(api_client, names)
+    configs = []
+    for c in r2:
+        configs.append({'name': c['name'],
+                        'key': c['key'],
+                        'config': c['config']})
+    r3 = api.update_configlets(api_client, configs)
+    assert r1['total'] == len(r3)
+
+
+@pytest.mark.api
+@pytest.mark.dependency(name='authentication')
+@pytest.mark.skipif(user_token == 'unset_token', reason="Token is not set correctly")
+def test_add_notes_to_configlets(api_client):
+    r1 = api.get_configlets(api_client)
+    names = []
+    for c in r1['data']:
+        names.append(c['name'])
+    r2 = api.get_configlets_by_name(api_client, names)
+    notes = []
+    for c in r2:
+        notes.append({'key': c['key'],
+                      'note': c['note']})
+    r3 = api.add_notes_to_configlets(api_client, notes)
+    assert r1['total'] == len(r3)

--- a/tests/system/test_cv_facts_tools.py
+++ b/tests/system/test_cv_facts_tools.py
@@ -52,13 +52,11 @@ class TestCvContainerToolsContainers():
     @pytest.mark.dependency(depends=["authentication"], scope='class')
     def test_get_container_name(self, test_container):
         result = self.inventory._CvFactsTools__get_container_name(key=test_container['container_id'])
-        logger.debug('Got response from module: {0}'.format(result))
         if test_container['is_present_expected']:
             assert result == test_container['name_expected']
         else:
             assert result is None
         logger.info('Got correct response from module')
-        logger.debug('Got response from module: {0}'.format(result))
 
 
 @pytest.mark.usefixtures("CvFactsTools_Manager")
@@ -75,7 +73,6 @@ class TestCvContainerToolsContainers():
     @pytest.mark.dependency(depends=["authentication"], scope='class')
     def test_facts_containers(self):
         result = self.inventory.facts(scope=['containers'])
-        logger.debug('Got response from module: {0}'.format(result))
         assert Facts.CONTAINER in result
         assert validate_cv_inputs(user_json=result[Facts.CONTAINER], schema=SCHEMA_CV_CONTAINER)
         logger.info('output is valid against collection schema')
@@ -105,7 +102,6 @@ class TestCvContainerToolsDevices():
             assert len(result) == 0
         assert result is not None
         logger.info('Got correct response from Cloudvision')
-        logger.debug('Got response from module: {0}'.format(result))
 
 @pytest.mark.usefixtures("CvFactsTools_Manager")
 @pytest.mark.api
@@ -136,7 +132,6 @@ class TestCvContainerToolsDevicesFacts():
         # Validate data with schema
         assert validate_cv_inputs(user_json=result[Facts.DEVICE], schema=SCHEMA_CV_DEVICE)
         logger.info('output is valid against collection schema')
-        logger.debug('Got response from module: {0}'.format(result))
 
 
 @pytest.mark.usefixtures("CvFactsTools_Manager")
@@ -162,7 +157,6 @@ class TestCvContainerToolsDevicesFilter():
 
         assert validate_cv_inputs(user_json=result[Facts.DEVICE], schema=SCHEMA_CV_DEVICE)
         logger.info('output is valid against collection schema')
-        logger.debug('Got response from module: {0}'.format(result))
 
 
 # -------------------
@@ -187,7 +181,6 @@ class TestCvContainerToolsConfiglets():
         assert 'cvp_configlets' in result
         assert validate_cv_inputs(user_json=result[Facts.CONFIGLET], schema=SCHEMA_CV_CONFIGLET)
         logger.info('output is valid against collection schema')
-        logger.debug('Got response from module: {0}'.format(result['cvp_configlets'].keys()))
 
 
 @pytest.mark.usefixtures("CvFactsTools_Manager")
@@ -213,7 +206,6 @@ class TestCvContainerToolsConfiglets():
 
         assert validate_cv_inputs(user_json=result[Facts.CONFIGLET], schema=SCHEMA_CV_CONFIGLET)
         logger.info('output is valid against collection schema')
-        logger.debug('Got response from module: {0}'.format(result))
 
 
 # -------------------
@@ -238,4 +230,3 @@ class TestCvContainerToolsAllFacts():
         assert Facts.CONFIGLET in result
         assert Facts.CONTAINER in result
         assert Facts.DEVICE in result
-        logger.debug('Got response from module: {0}'.format(result))


### PR DESCRIPTION
## Change Summary

When running playbooks on heavily loaded CloudVision instances (hundreds of configlets and devices), performances can be an issue.
There are most likely 2 scenarios:
- Some GET calls that returns a lot of data takes minutes/tens of seconds.
- Some tasks need to perform a lot (hundreds) of API calls (all HTTP methods). When these are done in series, the playbook execution may become unacceptably long (tens of minutes).

This pull request proposes a concurrent programming design to overcome these 2 situations.

## Related Issue(s)

Fixes #370 

## Component(s) name

`arista.cvp.api`

## Proposed changes

To address the GET calls that returns a lot of data (e.g. /configlet/getConfiglets.do), CloudVision provides a pagination mechanism. On the client side, we can perform parallel API calls to retrieve the different pages at the same time. The size of the pages may be configurable, but empirically (as of now) a size of 2 gives the best performances.

To address the complex playbook tasks that require to perform hundreds of API calls, have the ability to write [asynchronous code](https://realpython.com/async-io-python/) within these tasks would facilitates the concurrent execution of API calls.

One important fact to keep in mind is that the [cvprac](https://github.com/aristanetworks/cvprac) library we use to integrate with CloudVision uses [requests](https://docs.python-requests.org/) which is not an async HTTP client library. Thus, we need to execute all cvprac calls within different thread to achieve concurrency. Using different processes is not relevant here since an HTTP call is a blocking IO call and not CPU bound.
There are official [examples](https://docs.python.org/3/library/asyncio-eventloop.html#executing-code-in-thread-or-process-pools) to write such code and integrate it into asynchronous code. This pull request is inspired from these examples.

There are 2 mains functions implemented in this PR in order to support the different function signatures of cvprac:
- [call(func: Callable[..., dict], args: List[dict]) -> List[dict]](https://github.com/aristanetworks/ansible-cvp/compare/devel...mtache:features/threading?expand=1#diff-e15c5a4657922e6af123a269febcd0a85d1cc4197c9e5b18308b06270505adfaR35)
    Query CloudVision using concurrent API calls.
    Take as argument a function that have one or multiple arbitrary arguments.
    The function must return a dictionary.
    This function can be a blocking call since it is run in a separate thread.
    The list args contains the arguments for each concurrent API call and thus defines the number of concurrent calls.
    This is a coroutine and can be used in asynchronous code to query multiple ressources concurently.
- [call_batch(func: Callable[[int, int], dict], item_per_call: int = 2) -> dict](https://github.com/aristanetworks/ansible-cvp/compare/devel...mtache:features/threading?expand=1#diff-e15c5a4657922e6af123a269febcd0a85d1cc4197c9e5b18308b06270505adfaR73)
    Query CloudVision using concurrent API calls.
    Take as argument a function that have the following signature: func(start:int, end:int).
    The function must return the following data structure:
    ```
    { "data": [ {}, {} ],
        "total": 2 }
    ```
    This function can be a blocking call since it is run in a separate thread.
    The optional parameter item_per_call defines the number of item to retrieve per concurrent API call.
    This is a coroutine and can be used in asynchronous code to query multiple ressources concurrently.

Implemented API calls:
- /configlet/getConfiglets.do
- /configlet/getConfigletByName.do
- /configlet/updateConfiglet.do
- /configlet/addNoteToConfiglet.do
- /image/getImages.do
- /inventory/containers

## How to test

Define appropriate environment variables: ARISTA_AVD_CV_SERVER, ARISTA_AVD_CV_TOKEN and ARISTA_AVD_CVAAS.
Run `make -C tests test TESTS=system/test_cv_api.py`.

## Checklist

### User Checklist

- [x] Implement a first `asyncio` code leveraging `concurrent.futures` for threading
- [ ] Measure performances on heavily loaded CloudVision instances using pytest and tweak/enhance the code
- [ ] Integrate async code into Ansible tasks code
- [ ] Measure performances gain on a full playbook execution

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
