### PR TITLE
Feat: Add support for change controls (#413)

### DIFF
--- a/ansible_collections/arista/cvp/docs/modules/cv_change_control_v3.rst.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_change_control_v3.rst.md
@@ -1,0 +1,112 @@
+# cv_image_v3
+
+EOS Image management with Cloudvision
+
+Module added in version 3.X.0
+
+<div class="contents" local="" depth="2">
+
+</div>
+
+## Synopsis
+
+CloudVision Portal Change Control Module.
+
+
+## Module-specific Options
+
+The following options may be specified for this module:
+
+<table border=1 cellpadding=4>
+
+<tr>
+<th class="head">parameter</th>
+<th class="head">type</th>
+<th class="head">required</th>
+<th class="head">default</th>
+<th class="head">choices</th>
+<th class="head">comments</th>
+</tr>
+
+<tr>
+<td>name<br/><div style="font-size: small;"></div></td>
+<td>str</td>
+<td>no</td>
+<td>blank</td>
+<td></td>
+<td>
+    <div>Name of the change control. If none is provided for state == set, a name will be generated based on time timestamp.</div>
+</td>
+</tr>
+
+<tr>
+<td>change<br/><div style="font-size: small;"></div></td>
+<td>dict</td>
+<td>no (unless state==set)</td>
+<td></td>
+<td></td>
+<td>
+    <div>A dict containing the details of the CC</div>
+</td>
+</tr>
+
+<tr>
+<td>state<br/><div style="font-size: small;"></div></td>
+<td>str</td>
+<td>yes</td>
+<td>get</td>
+<td><ul><li>get</li><li>set</li><li>remove</li></ul></td>
+<td>
+    <div>Set will create a new CC, unless the 'key' identifying the CC is included</div>
+</td>
+</tr>
+
+
+</table>
+</br>
+
+## Examples:
+
+    ---
+    - name: CVP Image Tests
+      hosts: cv_server
+      gather_facts: no
+      vars:
+      tasks:
+        - name: "Gather CVP image information facts {{inventory_hostname}}"
+          arista.cvp.cv_image_v3:
+             mode: image
+             action: get
+          register: image_data
+
+        - name: "Print out facts from {{inventory_hostname}}"
+          debug:
+            msg: "{{image_data}}"
+
+
+        - name: "Get CVP image image bundles {{inventory_hostname}}"
+          arista.cvp.cv_image_v3:
+            mode: bundle
+            action: get
+          register: image_bundle_data
+
+        - name: "Print out images from {{inventory_hostname}}"
+          debug:
+            msg: "{{image_bundle_data}}"
+
+
+        - name: "Update an image bundle {{inventory_hostname}}"
+          vars:
+            ansible_command_timeout: 1200
+            ansible_connect_timeout: 600
+          arista.cvp.cv_image_v3:
+            mode: bundle
+            action: add
+            bundle_name: Test_bundle
+            image_list:
+               - TerminAttr-1.16.4-1.swix
+               - EOS-4.25.4M.swi
+
+### Author
+
+-   EMEA AS Team (@aristanetworks)

--- a/ansible_collections/arista/cvp/docs/modules/cv_change_control_v3.rst.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_change_control_v3.rst.md
@@ -80,11 +80,13 @@ The following options may be specified for this module:
       activities:
         - action: "Switch Healthcheck"
           name: Switch1_healthcheck
-          device: DC1-Leaf1a
+          arguments:
+            - name: DeviceID
+              value: <device serial number>
           stage: Pre-Checks
         - action: "Switch Healthcheck"
-          name: Switch1b_healthcheck
-          device: DC1-Leaf1b
+            - name: DeviceID
+              value: <device serial number>
           stage: Pre-Checks
         - task_id: "20"
           stage: Leaf1a_upgrade
@@ -100,67 +102,44 @@ The following options may be specified for this module:
         - name: Leaf1b_upgrade
           parent: Upgrades
 
-
   tasks:
     - name: "Gather CVP change controls {{inventory_hostname}}"
       arista.cvp.cv_change_control_v3:
         state: show
       register: cv_facts
 
-
     - name: "Print out all change controls from {{inventory_hostname}}"
       debug:
         msg: "{{cv_facts}}"
-
 
     - name: "Check CC structure"
       debug:
         msg: "{{change}}"
 
-
     - name: "Create a change control on {{inventory_hostname}}"
       arista.cvp.cv_change_control_v3:
         state: set
         change: "{{ change }}"
-      register: cv_change
 
-    - name: "The Change created has ID {{inventory_hostname}}"
-      debug:
-        msg: "{{ cv_change }}"
-
-    - name: "Updating Change notes"
-      ansible.utils.update_fact:
-        updates:
-          - path: change.key
-            value: "{{ cv_change.data.id }}"
-          - path: change.notes
-            value: "Change updated"
-      register: updated
-
-
-    - name: "Update the change control on {{inventory_hostname}}"
-      arista.cvp.cv_change_control_v3:
-        state: set
-        change: "{{ updated.change }}"
-      register: cv_change
-
-
-    - name: "Get the updated change control {{inventory_hostname}}"
+    - name: "Get the created change control {{inventory_hostname}}"
       arista.cvp.cv_change_control_v3:
         state: show
-        name: "{{change.name}}"
+        name: change.name
       register: cv_facts
 
     - name: "Show the created CC from {{inventory_hostname}}"
       debug:
         msg: "{{cv_facts}}"
 
-
     - name: "Delete the CC from {{inventory_hostname}}"
       arista.cvp.cv_change_control_v3:
         state: remove
         name: "{{change.name}}"
       register: cv_deleted
+
+    - name: "Show deleted CCs"
+      debug:
+        msg: "{{cv_deleted}}"
 
 ### Author
 

--- a/ansible_collections/arista/cvp/docs/modules/cv_change_control_v3.rst.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_change_control_v3.rst.md
@@ -85,6 +85,7 @@ The following options may be specified for this module:
               value: <device serial number>
           stage: Pre-Checks
         - action: "Switch Healthcheck"
+          arguments:
             - name: DeviceID
               value: <device serial number>
           stage: Pre-Checks

--- a/ansible_collections/arista/cvp/docs/modules/cv_change_control_v3.rst.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_change_control_v3.rst.md
@@ -1,6 +1,6 @@
-# cv_image_v3
+# cv_change_control_v3
 
-EOS Image management with Cloudvision
+Change Control with Arista Cloudvision Portal
 
 Module added in version 3.X.0
 
@@ -54,8 +54,8 @@ The following options may be specified for this module:
 <td>state<br/><div style="font-size: small;"></div></td>
 <td>str</td>
 <td>yes</td>
-<td>get</td>
-<td><ul><li>get</li><li>set</li><li>remove</li></ul></td>
+<td>show</td>
+<td><ul><li>show</li><li>set</li><li>remove</li></ul></td>
 <td>
     <div>Set will create a new CC, unless the 'key' identifying the CC is included</div>
 </td>
@@ -67,45 +67,100 @@ The following options may be specified for this module:
 
 ## Examples:
 
-    ---
-    - name: CVP Image Tests
-      hosts: cv_server
-      gather_facts: no
-      vars:
-      tasks:
-        - name: "Gather CVP image information facts {{inventory_hostname}}"
-          arista.cvp.cv_image_v3:
-             mode: image
-             action: get
-          register: image_data
+---
+- name: CVP Change Control Tests
+  hosts: cv_server
+  gather_facts: no
+  vars:
+    ansible_command_timeout: 1200
+    ansible_connect_timeout: 600
+    change:
+      name: Ansible playbook test change
+      notes: Created via playbook
+      activities:
+        - action: "Switch Healthcheck"
+          name: Switch1_healthcheck
+          device: DC1-Leaf1a
+          stage: Pre-Checks
+        - action: "Switch Healthcheck"
+          name: Switch1b_healthcheck
+          device: DC1-Leaf1b
+          stage: Pre-Checks
+        - task_id: "20"
+          stage: Leaf1a_upgrade
+        - task_id: "22"
+          stage: Leaf1b_upgrade
+      stages:
+        - name: Pre-Checks
+          mode: parallel
+        - name: Upgrades
+          modes: series
+        - name: Leaf1a_upgrade
+          parent: Upgrades
+        - name: Leaf1b_upgrade
+          parent: Upgrades
 
-        - name: "Print out facts from {{inventory_hostname}}"
-          debug:
-            msg: "{{image_data}}"
+
+  tasks:
+    - name: "Gather CVP change controls {{inventory_hostname}}"
+      arista.cvp.cv_change_control_v3:
+        state: show
+      register: cv_facts
 
 
-        - name: "Get CVP image image bundles {{inventory_hostname}}"
-          arista.cvp.cv_image_v3:
-            mode: bundle
-            action: get
-          register: image_bundle_data
-
-        - name: "Print out images from {{inventory_hostname}}"
-          debug:
-            msg: "{{image_bundle_data}}"
+    - name: "Print out all change controls from {{inventory_hostname}}"
+      debug:
+        msg: "{{cv_facts}}"
 
 
-        - name: "Update an image bundle {{inventory_hostname}}"
-          vars:
-            ansible_command_timeout: 1200
-            ansible_connect_timeout: 600
-          arista.cvp.cv_image_v3:
-            mode: bundle
-            action: add
-            bundle_name: Test_bundle
-            image_list:
-               - TerminAttr-1.16.4-1.swix
-               - EOS-4.25.4M.swi
+    - name: "Check CC structure"
+      debug:
+        msg: "{{change}}"
+
+
+    - name: "Create a change control on {{inventory_hostname}}"
+      arista.cvp.cv_change_control_v3:
+        state: set
+        change: "{{ change }}"
+      register: cv_change
+
+    - name: "The Change created has ID {{inventory_hostname}}"
+      debug:
+        msg: "{{ cv_change }}"
+
+    - name: "Updating Change notes"
+      ansible.utils.update_fact:
+        updates:
+          - path: change.key
+            value: "{{ cv_change.data.id }}"
+          - path: change.notes
+            value: "Change updated"
+      register: updated
+
+
+    - name: "Update the change control on {{inventory_hostname}}"
+      arista.cvp.cv_change_control_v3:
+        state: set
+        change: "{{ updated.change }}"
+      register: cv_change
+
+
+    - name: "Get the updated change control {{inventory_hostname}}"
+      arista.cvp.cv_change_control_v3:
+        state: show
+        name: "{{change.name}}"
+      register: cv_facts
+
+    - name: "Show the created CC from {{inventory_hostname}}"
+      debug:
+        msg: "{{cv_facts}}"
+
+
+    - name: "Delete the CC from {{inventory_hostname}}"
+      arista.cvp.cv_change_control_v3:
+        state: remove
+        name: "{{change.name}}"
+      register: cv_deleted
 
 ### Author
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -585,7 +585,6 @@ class CvChangeControlTools():
                 MODULE_LOGGER.error('Change control with id %s not found', cc_id)
                 change = None
 
-
         return change
 
     def module_action(self, change: dict, name: str = None, state: str = "show", change_id: List[str] = None):

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -1,0 +1,671 @@
+#!/usr/bin/env python
+# coding: utf-8 -*-
+#
+# GNU General Public License v3.0+
+#
+# Copyright 2021 Arista Networks AS-EMEA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import (absolute_import, division, print_function)
+import string
+__metaclass__ = type
+
+import traceback
+import logging
+import random
+import string
+from datetime import datetime
+from typing import List
+from ansible.module_utils.basic import AnsibleModule
+import ansible_collections.arista.cvp.plugins.module_utils.logger   # noqa # pylint: disable=unused-import
+from ansible_collections.arista.cvp.plugins.module_utils.response import CvApiResult, CvManagerResult, CvAnsibleResponse  # noqa # pylint: disable=unused-import
+try:
+    from cvprac.cvp_client import CvpClient  # noqa # pylint: disable=unused-import
+    from cvprac.cvp_client_errors import CvpApiError, CvpRequestError  # noqa # pylint: disable=unused-import
+    HAS_CVPRAC = True
+except ImportError:
+    HAS_CVPRAC = False
+    CVPRAC_IMP_ERR = traceback.format_exc()
+
+
+MODULE_LOGGER = logging.getLogger('arista.cvp.change_tools')
+MODULE_LOGGER.info('Start change_tools module execution')
+
+
+
+class CvpChangeControlBuilder:
+    """
+    CvpChangeControlBuilder Class to the generation of a CVP Change control.
+    
+    Methods
+    -------
+    build_cc(data)
+        Returns the Change Control datastructure.
+    add_known_uuid(list(str))
+        Provide a list of UUIDs already in use to the class, to prevent collisions.
+    """
+    def __init__( self ):
+        # Guarantee that the generated IDs are unique, for this session
+        self.__keySize = 12
+        self.__keyStore = []
+        # Track if a stage is meant to be series or parallel
+        self.__stageMode = {}
+        # Map the stage name to the generated IDs
+        self.__stageMapping = {}
+        # The final change control
+        self.ChangeControl = {}
+        
+
+        
+    def build_cc(self, data, name = None):
+        """
+        Build the change control data structure
+
+        Parameters
+        ----------
+        data: dict
+            The dict consists of the following keys and data types;
+            name: str
+               The name of the change control
+            activities: list
+               A list of tasks or actions to be executed. Each entry is a dict consisting of;
+                    action (if performing a Change Control action): str
+                        The name of the Change Control Action e.g. what you select from the drop down menu in the GUI
+                    task_id: int
+                        The Task / Work Order Id for the task to be executed
+                    timeout: int
+                        The timeout value to be used for task completion 
+                    name: str
+                        A name for the card/action - not required or used outside of datastructures
+                    device: str
+                        Name of the device that this action is to be performed on
+                    stage: str
+                        The name of the stage to assign the action to 
+            stages: list
+               A list of stages, with their name, mode and parent stage defined;
+                    name: str
+                        The name of the stage
+                    mode: str (series | parallel)
+                        Defines if tasks/actions within that stage should be performed in series or parallel.
+                        Series is the default
+                    parent: str
+                        The name of the parent stage to assign this stage to
+                        
+        Example data
+        ------------
+        Sample data passed to method::
+          - name: TestCC123
+            notes: Test change 
+            activities:
+              - task_id: 1234
+                name: "task"
+                timeout: 12000
+                stage: Stage2
+              - action: "Switch Healthcheck"
+                name: "Switch1_health"
+                device: DC1-Leaf1a
+                stage: Stage0
+    
+              - action: "Switch Healthcheck"
+                name: "Switch1_health"
+                device: switch1
+                stage: Stage1b
+    
+              - action: "Switch Healthcheck"
+                name: "Spine 1 Health Check"
+                device: DC1-SPINE1
+                stage: Stage1b
+            stages:
+              - name: Stage0
+                mode: parallel
+    
+              - name: Stage1
+                mode: parallel
+    
+              - name: Stage1b
+                mode: parallel
+                parent: Stage1
+    
+              - name: Stage2
+                mode: series  
+        
+
+        Returns
+        -------
+        Str:
+            A random string, of length __keySize, guaranteed to be unique within the class instance.
+        """        
+        data = self._validate_input(data, name)
+        self._create_cc_struct( data['name'], notes=data['notes'] )
+        
+        for stage in data['stages']:
+            if 'parent' in stage.keys():
+                self._create_stage(stage['name'],mode=stage['mode'],parent=stage['parent'])
+            else:
+                self._create_stage(stage['name'],mode=stage['mode'])
+
+
+        for action in data['activities']:
+            if 'task_id' in action:
+                self._create_task(action['name'], action['task_id'], action['stage'])
+            else:
+                self._create_action(action['name'], action['action'], action['stage'], action['device'])
+
+        return self.ChangeControl
+
+
+
+    def add_known_uuid(self, existing_id):
+        """
+        Update our list of UUIDs with other known ones, to prevent ID collussions
+
+        Parameters
+        ----------
+        existing_id: list (str)
+            List of strings, representing UUIDs already in use
+
+        Returns
+        -------
+        None
+        """
+        for entry in existing_id:
+            if entry not in self.__keyStore:
+                self.__keyStore.append(entry)
+
+        return None
+
+    def _validate_input( self, data, name = None ):
+        """
+        Sanitize the incoming data structure
+
+        Parameters
+        ----------
+        data: dict
+            Provided data structure defining the Change
+        name: str
+            The name of the CC, coming from the module call
+
+        Returns
+        -------
+        data: dict
+            Sanitized version of the input
+        """
+        defined_stages = []
+        
+        if 'name' not in data and name is None:
+            name = "Change "
+            timestamp = datetime.now()
+            name += timestamp.strftime("%Y%m%d_%H%M%S")
+            data['name'] = name
+        elif name is not None and len(name) > 0:
+            data['name'] = name
+        
+        
+        if 'notes' not in data:
+            data['notes'] = None
+            
+        if 'stages' not in data:
+            data['stages'] = []
+        
+        if 'activities' not in data:
+            data['activities'] = []
+        
+        # Build a list of all the user defined stages
+        for stage in data['stages']:
+            if 'name' in stage:
+                defined_stages.append(stage['name'])
+            if 'mode' not in stage:
+                stage['mode'] = "series"
+
+        # if a task/action is assigned to a stage that isn't created
+        # assign it to the root stage
+        for task in data['activities']:
+            if 'stage' in task:
+                if task['stage'] not in defined_stages:
+                    task['stage'] = None
+            if 'task_id' in task and 'name' not in task:
+                task['name'] = "task"
+
+        # if the key is provided, we are updating an existing CC
+        if 'key' in data:
+            self.__changeKey = data['key']
+        
+        return data            
+        
+    def __genID__( self ):
+        """
+        Generates a UUID to identify each task/action and stage, and the assignment of the 
+        former to the latter. The UUID should be unique within the Change control.
+
+        Parameters
+        ----------
+        __keySize: int
+            The number of ascii_letters to include in the ID.
+
+        Returns
+        -------
+        Str:
+            A random string, of length __keySize, guaranteed to be unique within the class instance.
+        """
+        while True:
+            id = ''.join( random.choices( string.ascii_letters, k=self.__keySize ) )
+            if id not in self.__keyStore:
+                self.__keyStore.append(id)
+                return(id)
+            else:
+                # Keep looping until we get a unique ID
+                pass
+            
+        
+    def __attachThing( self, ownId, parent=None ):
+        """
+        Assign a task/action to a stage within the Change Control
+
+        Parameters
+        ----------
+        oneId: Str
+            The UUID assigned to this task or action
+        parent: Str
+            The UUID of the stage the task/action is to be assigned to.
+            By default everything will be assigned to the root stage unless otherwise specified
+
+        Returns
+        -------
+        None:
+            The Class ChangeControl is updated to reflect the updated attachment.
+        """
+        # If we don't have a parent, we are attached to the Root Stage
+        if parent == None:
+            parentId = self.ChangeControl['change']['rootStageId']
+        else:
+            parentId = self.__stageMapping[parent]
+        
+        # Depending on if it's a series or parallel stage, we need to populate the structure differently e.g. list of dicts vs list of strings
+        if self.__stageMode[parentId] == 'parallel':
+            if len(self.ChangeControl['change']['stages']['values'][parentId]['rows']['values']) == 0:
+                self.ChangeControl['change']['stages']['values'][parentId]['rows']['values'].append( {'values': [ ownId ] } )
+            else:
+                self.ChangeControl['change']['stages']['values'][parentId]['rows']['values'][0]['values'].append(ownId)
+
+        else:
+            self.ChangeControl['change']['stages']['values'][parentId]['rows']['values'].append( {'values': [ ownId ] } )
+        
+        return None
+            
+
+
+    def _create_cc_struct(self, name, mode='series', notes=None):
+        """
+        Create the Change Control starting structure
+
+        Parameters
+        ----------
+        Name: Str
+            The name of the CC 
+        mode: Str: series/parallel
+            For now, the mode of the root stage is always series - the API does not let a CC to be created
+            with the root stage as parallel, even when it has multiple stages/tasks/actions assigned to it.
+            
+            The GUI allows the root stage to be changed to parallel, but only after it's created.
+            
+            Our workaround is to always have a "hidden" root stage, always series, and we assign the 
+            defined root/Stage 0 to that - the child stages can be series or parallel on creation.
+        notes: Str
+            Any notes to be added to the CC, default is "Created by Ansible-CVP".
+
+        Returns
+        -------
+        None:
+            The Class ChangeControl is updated to reflect the updated attachment
+        """
+        changeControl = {}
+        change = {}
+        change['name'] = name
+        if notes is not None:
+            change['notes'] = notes
+        else:
+            change['notes'] = "Created by Ansible-CVP"
+        change['stages'] = {}
+        change['stages']['values'] = {}
+        change['rootStageId'] = self.__genID__()
+        self.__stageMapping[name] = change['rootStageId']
+        
+        change['stages']['values'][ change['rootStageId'] ] = {}
+        change['stages']['values'][ change['rootStageId'] ]['name'] = " ".join([name, "root stage"])
+        change['stages']['values'][ change['rootStageId'] ]['rows'] = {}
+        change['stages']['values'][ change['rootStageId'] ]['rows']['values'] = []
+        
+        # We could in theory have a collision here, as the key is basically the Change Control ID
+        # and since we don't know all the CC IDs, there is a non-0 possibility of this occurring
+        changeControl['key'] = { 'id': str(self.__genID__()) }
+        changeControl['change'] = change
+        
+        self.__stageMode[ change['rootStageId'] ] = mode
+       
+        self.ChangeControl = changeControl
+        
+        return None
+
+
+    def _create_stage(self, name, mode='series', parent=None):
+        """
+        Create a stage within the Change Control
+
+        Parameters
+        ----------
+        name: Str
+            The name of the stage - this should be unique
+        mode: Str (series | parallel)
+            The mode defines if tasks/actions within the stage will be executed in series
+            or in parallel
+        parent: Str
+            The UUID of the parent stage that this stage is to be assigned to.
+            By default will be assigned to the root stage
+
+        Returns
+        -------
+        None:
+            The Class ChangeControl is updated to include the new stage
+        """
+        stageId = self.__genID__()
+        self.__stageMode[stageId] = mode
+        self.__stageMapping[name] = stageId
+        self.__attachThing(stageId,parent)
+        stage = {}
+        stage['name'] = name
+        stage['rows'] = {}
+        stage['rows']['values'] = []
+        
+        self.ChangeControl['change']['stages']['values'][stageId] = stage
+        
+        return None
+        
+ 
+        
+    def _create_task(self, name, taskID, stage=None, timeout=3000):
+        """
+        Create a task within the Change Control
+
+        Parameters
+        ----------
+        name: Str
+            The name of the task - by default this is "task"
+        taskID: Str 
+            The task/workorderID of the task to be executed
+        stage: Str
+            The name of the stage that this task is to be assigned to
+        timeout: Int
+            The timeout value for task completion in X units
+
+        Returns
+        -------
+        None:
+            The Class ChangeControl is updated to include the new task
+        """
+        task = {}
+        task['action'] = {}
+        task['action']['name'] = 'task'
+        task['action']['args'] = {}
+        task['action']['args']['values'] = {}
+        task['action']['args']['values']['TaskID'] = taskID
+        task['action']['timeout'] = timeout
+        task['name'] = name
+        
+        cardID = self.__genID__()
+        self.ChangeControl['change']['stages']['values'][cardID] = task
+        self.__attachThing(cardID, stage)
+        
+        return None
+        
+
+    def _create_action(self, name, action, stage, deviceID):
+        """
+        Create a task within the Change Control
+
+        Parameters
+        ----------
+        name: Str
+            The name of the action - by default this is "task"
+        taskID: Str 
+            The task/workorderID of the task to be executed
+        stage: Str
+            The name of the stage that this task is to be assigned to
+        timeout: Int
+            The timeout value for task completion in X units
+
+        Returns
+        -------
+        None:
+            The Class ChangeControl is updated to include the new task
+        """
+        
+        task = {}
+        task['action'] = {}
+        task['action']['name'] = action
+        task['action']['args'] = {}
+        task['action']['args']['values'] = {}
+        task['action']['args']['values']['DeviceID'] = deviceID
+        task['name'] = name
+        
+        cardID = self.__genID__()
+        self.ChangeControl['change']['stages']['values'][cardID] = task
+        self.__attachThing(cardID, stage)
+        
+        return None
+
+
+
+
+
+class CvChangeControlTools():
+    """
+    CvImageTools Class to manage Cloudvision Change Controls
+    """
+    def __init__(self, cv_connection, ansible_module: AnsibleModule = None, check_mode: bool = False):
+        self.__cv_client = cv_connection
+        self.__ansible = ansible_module
+        self.__check_mode = check_mode
+        # A list of tuples ("Change Control Name", "Change control ID")
+        self.__cc_index = []
+        self.cvp_version = self.__cv_client.api.get_cvp_info()['version']
+        self.apiversion = self.__cv_client.apiversion
+        
+    def __index_cc__(self):
+        """
+        Index the known Change Controls, creating an internal list of tuples
+        ( Change Control Name, Change Control ID )
+
+        Parameters
+        ----------
+        None: 
+            Provided data structure defining the Change
+            
+        Returns
+        -------
+        None: 
+            
+        """
+        MODULE_LOGGER.debug('Indexing Change Controls')
+        self.__cc_index.clear()
+        
+        for entry in self.change_controls['data']:
+            self.__cc_index.append( (entry['result']['value']['change']['name'], entry['result']['value']['key']['id']) )
+
+        return None
+            
+    def _find_id_by_name(self, name):
+        """
+        Find the ID of a change control, by name
+
+        Parameters
+        ----------
+        name: str
+            The name of the CC
+
+        Returns
+        -------
+        cc_id: list
+            A list of matching change control IDs
+        """
+        cc_id = []
+        cc_id = list( filter(lambda x:name in x, self.__cc_index) )
+        MODULE_LOGGER.debug('%d changes found' % len(cc_id))
+        return cc_id
+    
+     
+            
+        
+    def get_all_change_controls(self):
+        """
+        Get all change controls on CVP
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        None
+
+        """
+        cc_list = []
+        MODULE_LOGGER.debug('Collecting Change controls')
+        
+        if self.apiversion < 3.0:
+            MODULE_LOGGER.debug('Trying legacy API call')
+            cc_list = self.__cv_client.api.get_change_controls()
+        
+        else:
+            # Rewrite on cvprac > 1.0.7
+            MODULE_LOGGER.debug('Using resource API call')
+            cc_list = self.__cv_client.get('/api/resources/changecontrol/v1/ChangeControl/all')
+
+        if len(cc_list) > 0:
+            self.change_controls = cc_list
+            self.__index_cc__()
+            return True
+
+        return None
+
+    
+    def get_change_control(self, cc_id):
+        """
+        Get a specific change control
+
+        Parameters
+        ----------
+        cc_id: str
+            The UUID of the Change Control in question
+
+        Returns
+        -------
+        change: dict
+            A dict describing the request change control
+        """
+        MODULE_LOGGER.debug('Collecting change control: %s' % cc_id)
+        if self.apiversion < 3.0:
+            MODULE_LOGGER.debug('Using legacy API call')
+            change = self.__cv_client.api.get_change_control_info(cc_id)
+        else:
+            # Rewrite on cvprac > 1.0.7
+            params = 'key.id={}'.format(cc_id)
+            cc_url = '/api/resources/changecontrol/v1/ChangeControl?' + params
+            change = self.__cv_client.get(cc_url)
+            
+        return change
+    
+        
+    
+    
+    def module_action(self, change:dict, name:str = None, state:str = "get", change_id:List[str] = None ):
+        
+        changed = False
+        data = dict()
+        warnings = list()
+        
+        MODULE_LOGGER.debug('Collecting all change controls')
+        self.get_all_change_controls()
+        
+        if state == "get":
+
+            if name is None:
+                return changed, {'change_controls': self.change_controls}, warnings
+            else:
+                cc_list = []
+                cc_id_list = self._find_id_by_name(name)
+                for change in cc_id_list:
+                    MODULE_LOGGER.debug('Looking up change: %s with ID: %s' % (change[0],change[1]) )
+                    cc_list.append(self.get_change_control(change[1]) )
+
+                # Revisit this - should be the full CC I guess
+                return changed, {'change_controls:': cc_list  }, warnings
+
+            
+            
+        elif state == "remove":
+            MODULE_LOGGER.debug("Deleting change control")
+            if change_id is not None:
+                if name is not None:
+                    warnings.append("Deleting CC IDs takes precedence over deleting named CCs. Only the provided CCids will be deleted")
+                try:
+                    changes = self.__cv_client.api.delete_change_controls(change_id)
+                    MODULE_LOGGER.debug("Response to delete request was: %s" % changes)
+                    if len(changes) > 0:
+                        changed = True
+                    else:
+                        warnings.append('No changes made in delete request')
+                except Exception as e:
+                    self.__ansible.fail_json(msg="{0}".format(e))
+                    
+                return changed,{'remove':changes}, warnings
+            
+            elif name is not None:
+                cc_list = self._find_id_by_name(name)
+                if len(cc_list) == 0:
+                    warnings.append("No matching change controls found for %s" % name)
+                    return changed, {'search': name}, warnings
+                elif len(cc_list) > 1:
+                    warnings.append("Multiple changes (%d) found matching name: %s" % (len(cc_list),name ) )
+                    # Should we hard fail here?
+                    e = "Deleting multiple CCs by name is not supported at this time"
+                    self.__ansible.fail_json(msg="{0}".format(e))
+                    return changed, {'matches': cc_list}, warnings
+                else:
+                    try:
+                        changes = self.__cv_client.api.delete_change_controls(change_id)
+                        if len(changes) > 0:
+                            changed = True
+                        else:
+                            warnings.append('No changes made in delete request')
+                    except Exception as e:
+                        self.__ansible.fail_json(msg="{0}".format(e))
+            else:
+                e = "Unable to delete change control. Change name or change_id(s) must be specified"
+                self.__ansible.fail_json(msg="{0}".format(e))
+                    
+        elif state == "set":
+            changeControl = CvpChangeControlBuilder()
+            changeControl.add_known_uuid( [ v[1] for v in self.__cc_index ] )
+            cc_structure = changeControl.build_cc(change, name)
+            
+            try:
+                data = self.__cv_client.post('/api/resources/changecontrol/v1/ChangeControlConfig',data=cc_structure )
+                changed = True
+                
+            except Exception as e:
+                self.__ansible.fail_json(msg="{0}".format(e))            
+            
+        
+        return changed, data, warnings

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -573,7 +573,7 @@ class CvChangeControlTools():
             try:
                 change = self.__cv_client.api.get_change_control_info(cc_id)
             except Exception:
-                MODULE_LOGGER.error('Change control with id %s not found' % cc_id)
+                MODULE_LOGGER.error('Change control with id %s not found', cc_id)
                 change = None
         else:
             # Rewrite on cvprac > 1.0.7
@@ -582,7 +582,7 @@ class CvChangeControlTools():
             try:
                 change = self.__cv_client.get(cc_url)
             except Exception:
-                MODULE_LOGGER.error('Change control with id %s not found' % cc_id)
+                MODULE_LOGGER.error('Change control with id %s not found', cc_id)
                 change = None
 
 
@@ -661,12 +661,12 @@ class CvChangeControlTools():
             while True:
                 MODULE_LOGGER.debug("Creating change control structure")
                 cc_structure = changeControl.build_cc(change, name)
-                if self.get_change_control(cc_structure['key']) is None:
-                    MODULE_LOGGER.debug("Change ID: %s was not found, moving to next step", cc_list)
-                    break
-                else:
+                if self.get_change_control(cc_structure['key']) is not None:
                     MODULE_LOGGER.debug("Change ID: %s was already known. Adding to list and running again", cc_list)
                     changeControl.add_known_uuid(cc_structure['key'])
+                else:
+                    MODULE_LOGGER.debug("Change ID: %s was not found, moving to next step", cc_list)
+                    break
 
             try:
                 MODULE_LOGGER.debug("Calling on CVP to create change")

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -163,7 +163,7 @@ class CvpChangeControlBuilder:
             if 'task_id' in action:
                 self._create_task(action['name'], action['task_id'], action['stage'])
             else:
-                self._create_action(action['name'], action['action'], action['stage'], action['arguments'] )
+                self._create_action(action['name'], action['action'], action['stage'], action['arguments'])
 
         return self.ChangeControl
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -605,16 +605,21 @@ class CvChangeControlTools():
         
         if state == "get":
 
-            if name is None:
+            if name is None and change_id is None:
                 return changed, {'change_controls': self.change_controls}, warnings
             else:
                 cc_list = []
-                cc_id_list = self._find_id_by_name(name)
-                for change in cc_id_list:
-                    MODULE_LOGGER.debug('Looking up change: %s with ID: %s' % (change[0],change[1]) )
-                    cc_list.append(self.get_change_control(change[1]) )
+                if change_id is not None:
+                    for change in change_id:
+                        MODULE_LOGGER.debug('Looking up change: %s with ID: %s' % (change[0],change[1]) )
+                        cc_list.append(self.get_change_control(change[1]) )
 
-                # Revisit this - should be the full CC I guess
+                else:
+                    cc_id_list = self._find_id_by_name(name)
+                    for change in cc_id_list:
+                        MODULE_LOGGER.debug('Looking up change: %s with ID: %s' % (change[0],change[1]) )
+                        cc_list.append(self.get_change_control(change[1]) )
+
                 return changed, {'change_controls:': cc_list  }, warnings
 
             

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -631,12 +631,12 @@ class CvChangeControlTools():
                     warnings.append("Deleting CC IDs takes precedence over deleting named CCs. Only the provided CCids will be deleted")
                 try:
                     changes = self.__cv_client.api.delete_change_controls(change_id)
-                    MODULE_LOGGER.debug("Response to delete request was: %s", changes)
+                    MODULE_LOGGER.debug("Successfully deleted: %s", change_id)
                     changed = True
                 except Exception as e:
                     self.__ansible.fail_json(msg="{0}".format(e))
 
-                return changed, {'remove': changes}, warnings
+                return changed, {'remove': []}, warnings
 
             elif name is not None:
                 cc_list = self._find_id_by_name(name)

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -662,10 +662,10 @@ class CvChangeControlTools():
                 MODULE_LOGGER.debug("Creating change control structure")
                 cc_structure = changeControl.build_cc(change, name)
                 if self.get_change_control(cc_structure['key']) is not None:
-                    MODULE_LOGGER.debug("Change ID: %s was already known. Adding to list and running again", cc_list)
+                    MODULE_LOGGER.debug("Change ID: %s was already known. Adding to list and running again", cc_structure['key'])
                     changeControl.add_known_uuid(cc_structure['key'])
                 else:
-                    MODULE_LOGGER.debug("Change ID: %s was not found, moving to next step", cc_list)
+                    MODULE_LOGGER.debug("Change ID: %s was not found, moving to next step", cc_structure['key'])
                     break
 
             try:

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -153,7 +153,6 @@ class CvpChangeControlBuilder:
             else:
                 self._create_stage(stage['name'], mode=stage['mode'])
 
-
         for action in data['activities']:
             if 'task_id' in action:
                 self._create_task(action['name'], action['task_id'], action['stage'])
@@ -206,7 +205,6 @@ class CvpChangeControlBuilder:
             data['name'] = name
         elif name is not None and len(name) > 0:
             data['name'] = name
-
 
         if 'notes' not in data:
             data['notes'] = None

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -655,8 +655,8 @@ class CvChangeControlTools():
                     return changed, {'matches': cc_list}, warnings
                 else:
                     try:
-                        MODULE_LOGGER.debug("Trying to delete: %s", cc_list)
-                        data = self.__cv_client.api.delete_change_controls(cc_list)
+                        MODULE_LOGGER.debug("Trying to delete: %s", list(cc_list.values()))
+                        data = self.__cv_client.api.delete_change_controls(list(cc_list.values()))
                         changed = True
                     except Exception as e:
                         self.__ansible.fail_json(msg="{0}".format(e))

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -26,6 +26,7 @@ import traceback
 import logging
 import random
 import string
+import uuid
 from datetime import datetime
 from typing import List
 from ansible.module_utils.basic import AnsibleModule
@@ -57,7 +58,6 @@ class CvpChangeControlBuilder:
     """
     def __init__(self):
         # Guarantee that the generated IDs are unique, for this session
-        self.__keySize = 12
         self.__keyStore = []
         # Track if a stage is meant to be series or parallel
         self.__stageMode = {}
@@ -251,16 +251,15 @@ class CvpChangeControlBuilder:
 
         Parameters
         ----------
-        __keySize: int
-            The number of ascii_letters to include in the ID.
+        None
 
         Returns
         -------
         Str:
-            A random string, of length __keySize, guaranteed to be unique within the class instance.
+            A str of UUID4.
         """
         while True:
-            id = ''.join(random.choices(string.ascii_letters, k=self.__keySize))
+            id = str(uuid.uuid4())
             if id not in self.__keyStore:
                 self.__keyStore.append(id)
                 return(id)

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -658,8 +658,8 @@ class CvChangeControlTools():
                     return changed, {'matches': cc_list}, warnings
                 else:
                     try:
-                        MODULE_LOGGER.debug("Trying to delete: %s", list(cc_list.values()))
-                        data = self.__cv_client.api.delete_change_controls(list(cc_list.values()))
+                        MODULE_LOGGER.debug("Trying to delete: %s", cc_list)
+                        data = self.__cv_client.api.delete_change_controls(cc_list)
                         changed = True
                     except Exception as e:
                         self.__ansible.fail_json(msg="{0}".format(e))

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -611,8 +611,8 @@ class CvChangeControlTools():
                 cc_list = []
                 if change_id is not None:
                     for change in change_id:
-                        MODULE_LOGGER.debug('Looking up change: %s with ID: %s' % (change[0],change[1]) )
-                        cc_list.append(self.get_change_control(change[1]) )
+                        MODULE_LOGGER.debug('Looking up change: %s with ID: %s' % change )
+                        cc_list.append( self.get_change_control(change ) )
 
                 else:
                     cc_id_list = self._find_id_by_name(name)

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -69,7 +69,7 @@ class CvpChangeControlBuilder:
         
 
         
-    def build_cc(self, data, name = None):
+    def build_cc(self, data, name=None):
         """
         Build the change control data structure
 
@@ -148,7 +148,7 @@ class CvpChangeControlBuilder:
             A random string, of length __keySize, guaranteed to be unique within the class instance.
         """        
         data = self._validate_input(data, name)
-        self._create_cc_struct( data['name'], notes=data['notes'] )
+        self._create_cc_struct(data['name'], notes=data['notes'])
         
         for stage in data['stages']:
             if 'parent' in stage.keys():
@@ -186,7 +186,7 @@ class CvpChangeControlBuilder:
 
         return None
 
-    def _validate_input( self, data, name = None ):
+    def _validate_input(self, data, name = None):
         """
         Sanitize the incoming data structure
 
@@ -249,7 +249,7 @@ class CvpChangeControlBuilder:
         
         return data            
         
-    def __genID__( self ):
+    def __genID__(self):
         """
         Generates a UUID to identify each task/action and stage, and the assignment of the 
         former to the latter. The UUID should be unique within the Change control.
@@ -265,7 +265,7 @@ class CvpChangeControlBuilder:
             A random string, of length __keySize, guaranteed to be unique within the class instance.
         """
         while True:
-            id = ''.join( random.choices( string.ascii_letters, k=self.__keySize ) )
+            id = ''.join(random.choices(string.ascii_letters, k=self.__keySize))
             if id not in self.__keyStore:
                 self.__keyStore.append(id)
                 return(id)
@@ -274,7 +274,7 @@ class CvpChangeControlBuilder:
                 pass
             
         
-    def __attachThing( self, ownId, parent=None ):
+    def __attachThing(self, ownId, parent=None):
         """
         Assign a task/action to a stage within the Change Control
 
@@ -300,12 +300,12 @@ class CvpChangeControlBuilder:
         # Depending on if it's a series or parallel stage, we need to populate the structure differently e.g. list of dicts vs list of strings
         if self.__stageMode[parentId] == 'parallel':
             if len(self.ChangeControl['change']['stages']['values'][parentId]['rows']['values']) == 0:
-                self.ChangeControl['change']['stages']['values'][parentId]['rows']['values'].append( {'values': [ ownId ] } )
+                self.ChangeControl['change']['stages']['values'][parentId]['rows']['values'].append( {'values':[ ownId ]})
             else:
                 self.ChangeControl['change']['stages']['values'][parentId]['rows']['values'][0]['values'].append(ownId)
 
         else:
-            self.ChangeControl['change']['stages']['values'][parentId]['rows']['values'].append( {'values': [ ownId ] } )
+            self.ChangeControl['change']['stages']['values'][parentId]['rows']['values'].append({'values': [ ownId ]})
         
         return None
             
@@ -347,17 +347,17 @@ class CvpChangeControlBuilder:
         change['rootStageId'] = self.__genID__()
         self.__stageMapping[name] = change['rootStageId']
         
-        change['stages']['values'][ change['rootStageId'] ] = {}
-        change['stages']['values'][ change['rootStageId'] ]['name'] = " ".join([name, "root stage"])
-        change['stages']['values'][ change['rootStageId'] ]['rows'] = {}
-        change['stages']['values'][ change['rootStageId'] ]['rows']['values'] = []
+        change['stages']['values'][change['rootStageId']] = {}
+        change['stages']['values'][change['rootStageId']]['name'] = " ".join([name, "root stage"])
+        change['stages']['values'][change['rootStageId']]['rows'] = {}
+        change['stages']['values'][change['rootStageId']]['rows']['values'] = []
         
         # We could in theory have a collision here, as the key is basically the Change Control ID
         # and since we don't know all the CC IDs, there is a non-0 possibility of this occurring
-        changeControl['key'] = { 'id': str(self.__genID__()) }
+        changeControl['key'] = {'id': str(self.__genID__())}
         changeControl['change'] = change
         
-        self.__stageMode[ change['rootStageId'] ] = mode
+        self.__stageMode[change['rootStageId']] = mode
        
         self.ChangeControl = changeControl
         
@@ -594,7 +594,7 @@ class CvChangeControlTools():
         
     
     
-    def module_action(self, change:dict, name:str = None, state:str = "get", change_id:List[str] = None ):
+    def module_action(self, change:dict, name:str = None, state:str = "get", change_id:List[str] = None):
         
         changed = False
         data = dict()

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -83,7 +83,7 @@ class CvpChangeControlBuilder:
                A list of tasks or actions to be executed. Each entry is a dict consisting of;
                     action (if performing a Change Control action): str
                         The name of the Change Control Action e.g. what you select from the drop down menu in the GUI
-                    task_id: int
+                    task_id: str
                         The Task / Work Order Id for the task to be executed
                     timeout: int
                         The timeout value to be used for task completion 
@@ -109,7 +109,7 @@ class CvpChangeControlBuilder:
           - name: TestCC123
             notes: Test change 
             activities:
-              - task_id: 1234
+              - task_id: "1234"
                 name: "task"
                 timeout: 12000
                 stage: Stage2

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -358,7 +358,7 @@ class CvpChangeControlBuilder:
             changeControl['key'] = {'id': str(self.__genID__())}
         else:
             changeControl['key'] = {'id': self.__changeKey}
-            
+
         changeControl['change'] = change
 
         self.__stageMode[change['rootStageId']] = mode
@@ -530,7 +530,7 @@ class CvChangeControlTools():
         """
         cc_id = []
         #cc_id = list(filter(lambda x: name in x, self.__cc_index))
-        for k,v in self.__cc_index:
+        for k, v in self.__cc_index:
             if name in k:
                 cc_id.append(v)
         MODULE_LOGGER.debug('%d changes found', len(cc_id))
@@ -624,7 +624,7 @@ class CvChangeControlTools():
                 else:
                     cc_id_list = self._find_id_by_name(name)
                     for change in cc_id_list:
-                        MODULE_LOGGER.debug('Looking up change: %s with ID: %s', change[0], change[1])
+                        MODULE_LOGGER.debug('Found change for search: %s with ID: %s', name, change)
                         cc_list.append(self.get_change_control(change))
 
                 return changed, {'change_controls:': cc_list}, warnings

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -617,7 +617,7 @@ class CvChangeControlTools():
                 else:
                     cc_id_list = self._find_id_by_name(name)
                     for change in cc_id_list:
-                        MODULE_LOGGER.debug('Looking up change: %s with ID: %s' % (change[0],change[1]))
+                        MODULE_LOGGER.debug('Looking up change: %s with ID: %s' % (change[0], change[1]))
                         cc_list.append(self.get_change_control(change[1]))
 
                 return changed, {'change_controls:': cc_list}, warnings
@@ -639,7 +639,7 @@ class CvChangeControlTools():
                 except Exception as e:
                     self.__ansible.fail_json(msg="{0}".format(e))
                     
-                return changed,{'remove': changes}, warnings
+                return changed, {'remove': changes}, warnings
             
             elif name is not None:
                 cc_list = self._find_id_by_name(name)

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -529,7 +529,10 @@ class CvChangeControlTools():
             A list of matching change control IDs
         """
         cc_id = []
-        cc_id = list(filter(lambda x: name in x, self.__cc_index))
+        #cc_id = list(filter(lambda x: name in x, self.__cc_index))
+        for k,v in self.__cc_index:
+            if name in k:
+                cc_id.append(v)
         MODULE_LOGGER.debug('%d changes found', len(cc_id))
         return cc_id
 
@@ -622,7 +625,7 @@ class CvChangeControlTools():
                     cc_id_list = self._find_id_by_name(name)
                     for change in cc_id_list:
                         MODULE_LOGGER.debug('Looking up change: %s with ID: %s', change[0], change[1])
-                        cc_list.append(self.get_change_control(change[1]))
+                        cc_list.append(self.get_change_control(change))
 
                 return changed, {'change_controls:': cc_list}, warnings
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -446,9 +446,9 @@ class CvpChangeControlBuilder:
         Parameters
         ----------
         name: Str
-            Not used - name associated with the action
+           Only used internally - name associated with the action, not really required
         action: Str
-            The name of the action - the is the internal action name 
+            The name of the action - the is the internal action name
         stage: Str
             The name of the stage that this task is to be assigned to
         deviceId: Str

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -594,7 +594,7 @@ class CvChangeControlTools():
 
 
 
-    def module_action(self, change: dict, name: str = None, state: str = "get", change_id: List[str] = None):
+    def module_action(self, change: dict, name: str = None, state: str = "show", change_id: List[str] = None):
 
         changed = False
         data = dict()
@@ -603,7 +603,7 @@ class CvChangeControlTools():
         MODULE_LOGGER.debug('Collecting all change controls')
         self.get_all_change_controls()
 
-        if state == "get":
+        if state == "show":
 
             if name is None and change_id is None:
                 return changed, {'change_controls': self.change_controls}, warnings
@@ -632,10 +632,7 @@ class CvChangeControlTools():
                 try:
                     changes = self.__cv_client.api.delete_change_controls(change_id)
                     MODULE_LOGGER.debug("Response to delete request was: %s", changes)
-                    if len(changes) > 0:
-                        changed = True
-                    else:
-                        warnings.append('No changes made in delete request')
+                    changed = True
                 except Exception as e:
                     self.__ansible.fail_json(msg="{0}".format(e))
 
@@ -655,10 +652,7 @@ class CvChangeControlTools():
                 else:
                     try:
                         changes = self.__cv_client.api.delete_change_controls(change_id)
-                        if len(changes) > 0:
-                            changed = True
-                        else:
-                            warnings.append('No changes made in delete request')
+                        changed = True
                     except Exception as e:
                         self.__ansible.fail_json(msg="{0}".format(e))
             else:

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -237,6 +237,11 @@ class CvpChangeControlBuilder:
                     task['stage'] = None
             if 'task_id' in task and 'name' not in task:
                 task['name'] = "task"
+            if 'task_id' not in task and 'name' not in task:
+                task['name'] = "action_"
+                task['name'] += task['action']
+                task['name'] += "_"
+                task['name'] += task['device']
 
         # if the key is provided, we are updating an existing CC
         if 'key' in data:

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -44,7 +44,6 @@ MODULE_LOGGER = logging.getLogger('arista.cvp.change_tools')
 MODULE_LOGGER.info('Start change_tools module execution')
 
 
-
 class CvpChangeControlBuilder:
     """
     CvpChangeControlBuilder Class to the generation of a CVP Change control.
@@ -66,8 +65,6 @@ class CvpChangeControlBuilder:
         self.__stageMapping = {}
         # The final change control
         self.ChangeControl = {}
-
-
 
     def build_cc(self, data, name=None):
         """
@@ -164,8 +161,6 @@ class CvpChangeControlBuilder:
                 self._create_action(action['name'], action['action'], action['stage'], action['device'])
 
         return self.ChangeControl
-
-
 
     def add_known_uuid(self, existing_id):
         """
@@ -275,7 +270,6 @@ class CvpChangeControlBuilder:
                 # Keep looping until we get a unique ID
                 pass
 
-
     def __attachThing(self, ownId, parent=None):
         """
         Assign a task/action to a stage within the Change Control
@@ -294,7 +288,7 @@ class CvpChangeControlBuilder:
             The Class ChangeControl is updated to reflect the updated attachment.
         """
         # If we don't have a parent, we are attached to the Root Stage
-        if parent == None:
+        if parent is None:
             parentId = self.ChangeControl['change']['rootStageId']
         else:
             parentId = self.__stageMapping[parent]
@@ -302,7 +296,7 @@ class CvpChangeControlBuilder:
         # Depending on if it's a series or parallel stage, we need to populate the structure differently e.g. list of dicts vs list of strings
         if self.__stageMode[parentId] == 'parallel':
             if len(self.ChangeControl['change']['stages']['values'][parentId]['rows']['values']) == 0:
-                self.ChangeControl['change']['stages']['values'][parentId]['rows']['values'].append({'values':[ownId]})
+                self.ChangeControl['change']['stages']['values'][parentId]['rows']['values'].append({'values': [ownId]})
             else:
                 self.ChangeControl['change']['stages']['values'][parentId]['rows']['values'][0]['values'].append(ownId)
 
@@ -310,8 +304,6 @@ class CvpChangeControlBuilder:
             self.ChangeControl['change']['stages']['values'][parentId]['rows']['values'].append({'values': [ownId]})
 
         return None
-
-
 
     def _create_cc_struct(self, name, mode='series', notes=None):
         """
@@ -367,7 +359,6 @@ class CvpChangeControlBuilder:
 
         return None
 
-
     def _create_stage(self, name, mode='series', parent=None):
         """
         Create a stage within the Change Control
@@ -400,8 +391,6 @@ class CvpChangeControlBuilder:
         self.ChangeControl['change']['stages']['values'][stageId] = stage
 
         return None
-
-
 
     def _create_task(self, name, taskID, stage=None, timeout=3000):
         """
@@ -438,7 +427,6 @@ class CvpChangeControlBuilder:
 
         return None
 
-
     def _create_action(self, name, action, stage, deviceID):
         """
         Create a task within the Change Control
@@ -474,9 +462,6 @@ class CvpChangeControlBuilder:
         self.__attachThing(cardID, stage)
 
         return None
-
-
-
 
 
 class CvChangeControlTools():
@@ -530,15 +515,12 @@ class CvChangeControlTools():
             A list of matching change control IDs
         """
         cc_id = []
-        #cc_id = list(filter(lambda x: name in x, self.__cc_index))
+        # cc_id = list(filter(lambda x: name in x, self.__cc_index))
         for k, v in self.__cc_index:
             if name in k:
                 cc_id.append(v)
         MODULE_LOGGER.debug('%d changes found', len(cc_id))
         return cc_id
-
-
-
 
     def get_all_change_controls(self):
         """
@@ -572,7 +554,6 @@ class CvChangeControlTools():
 
         return None
 
-
     def get_change_control(self, cc_id):
         """
         Get a specific change control
@@ -599,9 +580,6 @@ class CvChangeControlTools():
 
         return change
 
-
-
-
     def module_action(self, change: dict, name: str = None, state: str = "show", change_id: List[str] = None):
 
         changed = False
@@ -612,7 +590,6 @@ class CvChangeControlTools():
         self.get_all_change_controls()
 
         if state == "show":
-
             if name is None and change_id is None:
                 return changed, {'change_controls': self.change_controls}, warnings
             else:
@@ -629,8 +606,6 @@ class CvChangeControlTools():
                         cc_list.append(self.get_change_control(change))
 
                 return changed, {'change_controls:': cc_list}, warnings
-
-
 
         elif state == "remove":
             MODULE_LOGGER.debug("Deleting change control")
@@ -680,6 +655,5 @@ class CvChangeControlTools():
 
             except Exception as e:
                 self.__ansible.fail_json(msg="{0}".format(e))
-
 
         return changed, data, warnings

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -446,18 +446,19 @@ class CvpChangeControlBuilder:
         Parameters
         ----------
         name: Str
-            The name of the action - by default this is "task"
-        taskID: Str
-            The task/workorderID of the task to be executed
+            Not used - name associated with the action
+        action: Str
+            The name of the action - the is the internal action name 
         stage: Str
             The name of the stage that this task is to be assigned to
-        timeout: Int
-            The timeout value for task completion in X units
+        deviceId: Str
+            The name of the device to which the action is to be done
+
 
         Returns
         -------
         None:
-            The Class ChangeControl is updated to include the new task
+            The Class ChangeControl is updated to include the new action
         """
 
         task = {}

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -655,7 +655,8 @@ class CvChangeControlTools():
                     return changed, {'matches': cc_list}, warnings
                 else:
                     try:
-                        changes = self.__cv_client.api.delete_change_controls(change_id)
+                        MODULE_LOGGER.debug("Trying to delete: %s", cc_list)
+                        data = self.__cv_client.api.delete_change_controls(cc_list)
                         changed = True
                     except Exception as e:
                         self.__ansible.fail_json(msg="{0}".format(e))

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -526,7 +526,7 @@ class CvChangeControlTools():
         """
         cc_id = []
         cc_id = list(filter(lambda x: name in x, self.__cc_index))
-        MODULE_LOGGER.debug('%d changes found' % len(cc_id))
+        MODULE_LOGGER.debug('%d changes found', len(cc_id))
         return cc_id
     
      

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -572,7 +572,7 @@ class CvChangeControlTools():
             change = self.__cv_client.api.get_change_control_info(cc_id)
         else:
             # Rewrite on cvprac > 1.0.7
-            params = 'key.id={}'.format(cc_id)
+            params = 'key.id={0}'.format(cc_id)
             cc_url = '/api/resources/changecontrol/v1/ChangeControl?' + params
             change = self.__cv_client.get(cc_url)
 
@@ -605,7 +605,7 @@ class CvChangeControlTools():
 
                 return changed, {'change_controls:': cc_list}, warnings
 
-        elif state == "remove":
+        elif state == "remove" and self.__check_mode == False:
             MODULE_LOGGER.debug("Deleting change control")
             if change_id is not None:
                 if name is not None:
@@ -641,7 +641,7 @@ class CvChangeControlTools():
                 e = "Unable to delete change control. Change name or change_id(s) must be specified"
                 self.__ansible.fail_json(msg="{0}".format(e))
 
-        elif state == "set":
+        elif state == "set" and self.__check_mode == False:
             changeControl = CvpChangeControlBuilder()
             changeControl.add_known_uuid([v[1] for v in self.__cc_index])
             cc_structure = changeControl.build_cc(change, name)

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -56,7 +56,7 @@ class CvpChangeControlBuilder:
     add_known_uuid(list(str))
         Provide a list of UUIDs already in use to the class, to prevent collisions.
     """
-    def __init__( self ):
+    def __init__(self):
         # Guarantee that the generated IDs are unique, for this session
         self.__keySize = 12
         self.__keyStore = []
@@ -152,9 +152,9 @@ class CvpChangeControlBuilder:
         
         for stage in data['stages']:
             if 'parent' in stage.keys():
-                self._create_stage(stage['name'],mode=stage['mode'],parent=stage['parent'])
+                self._create_stage(stage['name'], mode=stage['mode'], parent=stage['parent'])
             else:
-                self._create_stage(stage['name'],mode=stage['mode'])
+                self._create_stage(stage['name'], mode=stage['mode'])
 
 
         for action in data['activities']:
@@ -186,7 +186,7 @@ class CvpChangeControlBuilder:
 
         return None
 
-    def _validate_input(self, data, name = None):
+    def _validate_input(self, data, name=None):
         """
         Sanitize the incoming data structure
 
@@ -300,12 +300,12 @@ class CvpChangeControlBuilder:
         # Depending on if it's a series or parallel stage, we need to populate the structure differently e.g. list of dicts vs list of strings
         if self.__stageMode[parentId] == 'parallel':
             if len(self.ChangeControl['change']['stages']['values'][parentId]['rows']['values']) == 0:
-                self.ChangeControl['change']['stages']['values'][parentId]['rows']['values'].append( {'values':[ ownId ]})
+                self.ChangeControl['change']['stages']['values'][parentId]['rows']['values'].append({'values':[ownId]})
             else:
                 self.ChangeControl['change']['stages']['values'][parentId]['rows']['values'][0]['values'].append(ownId)
 
         else:
-            self.ChangeControl['change']['stages']['values'][parentId]['rows']['values'].append({'values': [ ownId ]})
+            self.ChangeControl['change']['stages']['values'][parentId]['rows']['values'].append({'values': [ownId]})
         
         return None
             
@@ -387,7 +387,7 @@ class CvpChangeControlBuilder:
         stageId = self.__genID__()
         self.__stageMode[stageId] = mode
         self.__stageMapping[name] = stageId
-        self.__attachThing(stageId,parent)
+        self.__attachThing(stageId, parent)
         stage = {}
         stage['name'] = name
         stage['rows'] = {}
@@ -506,7 +506,7 @@ class CvChangeControlTools():
         self.__cc_index.clear()
         
         for entry in self.change_controls['data']:
-            self.__cc_index.append( (entry['result']['value']['change']['name'], entry['result']['value']['key']['id']) )
+            self.__cc_index.append((entry['result']['value']['change']['name'], entry['result']['value']['key']['id']))
 
         return None
             
@@ -525,7 +525,7 @@ class CvChangeControlTools():
             A list of matching change control IDs
         """
         cc_id = []
-        cc_id = list( filter(lambda x:name in x, self.__cc_index) )
+        cc_id = list(filter(lambda x: name in x, self.__cc_index))
         MODULE_LOGGER.debug('%d changes found' % len(cc_id))
         return cc_id
     
@@ -594,7 +594,7 @@ class CvChangeControlTools():
         
     
     
-    def module_action(self, change:dict, name:str = None, state:str = "get", change_id:List[str] = None):
+    def module_action(self, change: dict, name: str = None, state: str = "get", change_id: List[str] = None):
         
         changed = False
         data = dict()
@@ -611,16 +611,16 @@ class CvChangeControlTools():
                 cc_list = []
                 if change_id is not None:
                     for change in change_id:
-                        MODULE_LOGGER.debug('Looking up change: ID: %s' % change )
-                        cc_list.append( self.get_change_control(change ) )
+                        MODULE_LOGGER.debug('Looking up change: ID: %s' % change)
+                        cc_list.append(self.get_change_control(change))
 
                 else:
                     cc_id_list = self._find_id_by_name(name)
                     for change in cc_id_list:
-                        MODULE_LOGGER.debug('Looking up change: %s with ID: %s' % (change[0],change[1]) )
-                        cc_list.append(self.get_change_control(change[1]) )
+                        MODULE_LOGGER.debug('Looking up change: %s with ID: %s' % (change[0],change[1]))
+                        cc_list.append(self.get_change_control(change[1]))
 
-                return changed, {'change_controls:': cc_list  }, warnings
+                return changed, {'change_controls:': cc_list}, warnings
 
             
             
@@ -639,7 +639,7 @@ class CvChangeControlTools():
                 except Exception as e:
                     self.__ansible.fail_json(msg="{0}".format(e))
                     
-                return changed,{'remove':changes}, warnings
+                return changed,{'remove': changes}, warnings
             
             elif name is not None:
                 cc_list = self._find_id_by_name(name)
@@ -647,7 +647,7 @@ class CvChangeControlTools():
                     warnings.append("No matching change controls found for %s" % name)
                     return changed, {'search': name}, warnings
                 elif len(cc_list) > 1:
-                    warnings.append("Multiple changes (%d) found matching name: %s" % (len(cc_list),name ) )
+                    warnings.append("Multiple changes (%d) found matching name: %s" % (len(cc_list), name))
                     # Should we hard fail here?
                     e = "Deleting multiple CCs by name is not supported at this time"
                     self.__ansible.fail_json(msg="{0}".format(e))
@@ -667,11 +667,11 @@ class CvChangeControlTools():
                     
         elif state == "set":
             changeControl = CvpChangeControlBuilder()
-            changeControl.add_known_uuid( [ v[1] for v in self.__cc_index ] )
+            changeControl.add_known_uuid([v[1] for v in self.__cc_index])
             cc_structure = changeControl.build_cc(change, name)
             
             try:
-                data = self.__cv_client.post('/api/resources/changecontrol/v1/ChangeControlConfig',data=cc_structure )
+                data = self.__cv_client.post('/api/resources/changecontrol/v1/ChangeControlConfig', data=cc_structure)
                 changed = True
                 
             except Exception as e:

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -605,7 +605,7 @@ class CvChangeControlTools():
 
                 return changed, {'change_controls:': cc_list}, warnings
 
-        elif state == "remove" and self.__check_mode == False:
+        elif state == "remove" and self.__check_mode is False:
             MODULE_LOGGER.debug("Deleting change control")
             if change_id is not None:
                 if name is not None:
@@ -641,7 +641,7 @@ class CvChangeControlTools():
                 e = "Unable to delete change control. Change name or change_id(s) must be specified"
                 self.__ansible.fail_json(msg="{0}".format(e))
 
-        elif state == "set" and self.__check_mode == False:
+        elif state == "set" and self.__check_mode is False:
             changeControl = CvpChangeControlBuilder()
             changeControl.add_known_uuid([v[1] for v in self.__cc_index])
             cc_structure = changeControl.build_cc(change, name)

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -611,7 +611,7 @@ class CvChangeControlTools():
                 cc_list = []
                 if change_id is not None:
                     for change in change_id:
-                        MODULE_LOGGER.debug('Looking up change: %s with ID: %s' % change )
+                        MODULE_LOGGER.debug('Looking up change: ID: %s' % change )
                         cc_list.append( self.get_change_control(change ) )
 
                 else:

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -19,13 +19,10 @@
 #
 
 from __future__ import (absolute_import, division, print_function)
-import string
 __metaclass__ = type
 
 import traceback
 import logging
-import random
-import string
 import uuid
 from datetime import datetime
 from typing import List

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -637,7 +637,7 @@ class CvChangeControlTools():
                 if name is not None:
                     warnings.append("Deleting CC IDs takes precedence over deleting named CCs. Only the provided CCids will be deleted")
                 try:
-                    changes = self.__cv_client.api.delete_change_controls(change_id)
+                    self.__cv_client.api.delete_change_controls(change_id)
                     MODULE_LOGGER.debug("Successfully deleted: %s", change_id)
                     changed = True
                 except Exception as e:

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -144,7 +144,7 @@ class CvpChangeControlBuilder:
             The Change control.
         """
         self._validate_input(data, name)
-        
+
         self._create_cc_struct(self._data['name'], notes=self._data['notes'])
 
         for stage in self._data['stages']:

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -579,7 +579,7 @@ class CvChangeControlTools():
         change: dict
             A dict describing the request change control
         """
-        MODULE_LOGGER.debug('Collecting change control: %s' % cc_id)
+        MODULE_LOGGER.debug('Collecting change control: %s', cc_id)
         if self.apiversion < 3.0:
             MODULE_LOGGER.debug('Using legacy API call')
             change = self.__cv_client.api.get_change_control_info(cc_id)
@@ -611,13 +611,13 @@ class CvChangeControlTools():
                 cc_list = []
                 if change_id is not None:
                     for change in change_id:
-                        MODULE_LOGGER.debug('Looking up change: ID: %s' % change)
+                        MODULE_LOGGER.debug('Looking up change: ID: %s', change)
                         cc_list.append(self.get_change_control(change))
 
                 else:
                     cc_id_list = self._find_id_by_name(name)
                     for change in cc_id_list:
-                        MODULE_LOGGER.debug('Looking up change: %s with ID: %s' % (change[0], change[1]))
+                        MODULE_LOGGER.debug('Looking up change: %s with ID: %s', change[0], change[1])
                         cc_list.append(self.get_change_control(change[1]))
 
                 return changed, {'change_controls:': cc_list}, warnings
@@ -631,7 +631,7 @@ class CvChangeControlTools():
                     warnings.append("Deleting CC IDs takes precedence over deleting named CCs. Only the provided CCids will be deleted")
                 try:
                     changes = self.__cv_client.api.delete_change_controls(change_id)
-                    MODULE_LOGGER.debug("Response to delete request was: %s" % changes)
+                    MODULE_LOGGER.debug("Response to delete request was: %s", changes)
                     if len(changes) > 0:
                         changed = True
                     else:

--- a/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
@@ -25,7 +25,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: cv_change_control_v3
-version_added: 3.3.4
+version_added: 3.4.0
 author: EMEA AS Team (@aristanetworks)
 short_description: Change Control management with Cloudvision
 description:

--- a/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
@@ -184,8 +184,8 @@ def main():
         ansible_module=ansible_module,
         check_mode=ansible_module.check_mode
     )
-    
-    MODULE_LOGGER.debug("Calling module action")    
+
+    MODULE_LOGGER.debug("Calling module action")
     result['changed'], result['data'], warnings = cv_cc.module_action(**ansible_module.params)
     MODULE_LOGGER.warning(warnings)
 

--- a/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
@@ -40,14 +40,16 @@ options:
     description: A dict containuing the change control to be created/modified
     required: true (if state == set)
     type: dict
-    elements: dict
   state:
     description: Set if we should get, set/update, or remove the change control
     required: false
     default: get
     choices: ['get','set','remove']
     type: str
-
+  change_id:
+    description: List of change IDs to get/remove
+    required: false
+    type: list(str)
 '''
 
 EXAMPLES = r'''
@@ -147,9 +149,9 @@ def main():
     """
     argument_spec = dict(
         name=dict(type='str'),
-        change=dict(type="dict"),
+        change=dict(type='dict'),
         state=dict(default='get', type='str', choices=['get', 'set', 'remove']),
-        change_id=dict(type='list')
+        change_id=dict(type='list', elements='str')
     )
 
     ansible_module = AnsibleModule(

--- a/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
@@ -67,10 +67,13 @@ EXAMPLES = r'''
       activities:
         - action: "Switch Healthcheck"
           name: Switch1_healthcheck
-          device: DC1-Leaf1a
+          arguments:
+            - name: DeviceID
+              value: <device serial number>
           stage: Pre-Checks
         - action: "Switch Healthcheck"
-          device: DC1-Leaf1b
+            - name: DeviceID
+              value: <device serial number>
           stage: Pre-Checks
         - task_id: "20"
           stage: Leaf1a_upgrade
@@ -86,13 +89,11 @@ EXAMPLES = r'''
         - name: Leaf1b_upgrade
           parent: Upgrades
 
-
   tasks:
     - name: "Gather CVP change controls {{inventory_hostname}}"
       arista.cvp.cv_change_control_v3:
         state: show
       register: cv_facts
-
 
     - name: "Print out all change controls from {{inventory_hostname}}"
       debug:

--- a/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
@@ -151,7 +151,7 @@ def main():
     argument_spec = dict(
         name=dict(type='str'),
         change=dict(type='dict'),
-        state=dict(default='show', type='str', choices=['get', 'show', 'remove']),
+        state=dict(default='show', type='str', choices=['show', 'set', 'remove']),
         change_id=dict(type='list', elements='str')
     )
 

--- a/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
@@ -70,7 +70,6 @@ EXAMPLES = r'''
           device: DC1-Leaf1a
           stage: Pre-Checks
         - action: "Switch Healthcheck"
-          name: Switch1b_healthcheck
           device: DC1-Leaf1b
           stage: Pre-Checks
         - task_id: "20"

--- a/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
@@ -38,7 +38,7 @@ options:
     type: str
   change:
     description: A dict containuing the change control to be created/modified
-    required: true (if state == set)
+    required: false
     type: dict
   state:
     description: Set if we should get, set/update, or remove the change control
@@ -49,7 +49,8 @@ options:
   change_id:
     description: List of change IDs to get/remove
     required: false
-    type: list(str)
+    type: list
+    elements: str
 '''
 
 EXAMPLES = r'''
@@ -123,7 +124,7 @@ EXAMPLES = r'''
     - name: "Delete the CC from {{inventory_hostname}}"
       arista.cvp.cv_change_control_v3:
         state: remove
-        name: change.name
+        name: "{{change.name}}"
       register: cv_deleted
 
     - name: "Show deleted CCs"

--- a/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
@@ -149,6 +149,7 @@ def main():
         name=dict(type='str'),
         change=dict(type="dict"),
         state=dict(default='get', type='str', choices=['get', 'set', 'remove']),
+        change_id=dict(type='list')
     )
 
     ansible_module = AnsibleModule(

--- a/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
@@ -25,7 +25,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: cv_change_control_v3
-version_added: TBD
+version_added: 3.3.4
 author: EMEA AS Team (@aristanetworks)
 short_description: Change Control management with Cloudvision
 description:
@@ -43,8 +43,8 @@ options:
   state:
     description: Set if we should get, set/update, or remove the change control
     required: false
-    default: get
-    choices: ['get','set','remove']
+    default: 'show'
+    choices: ['show','set','remove']
     type: str
   change_id:
     description: List of change IDs to get/remove
@@ -91,7 +91,7 @@ EXAMPLES = r'''
   tasks:
     - name: "Gather CVP change controls {{inventory_hostname}}"
       arista.cvp.cv_change_control_v3:
-        state: get
+        state: show
       register: cv_facts
 
 
@@ -112,7 +112,7 @@ EXAMPLES = r'''
 
     - name: "Get the created change control {{inventory_hostname}}"
       arista.cvp.cv_change_control_v3:
-        state: get
+        state: show
         name: change.name
       register: cv_facts
 
@@ -151,7 +151,7 @@ def main():
     argument_spec = dict(
         name=dict(type='str'),
         change=dict(type='dict'),
-        state=dict(default='get', type='str', choices=['get', 'set', 'remove']),
+        state=dict(default='show', type='str', choices=['get', 'show', 'remove']),
         change_id=dict(type='list', elements='str')
     )
 

--- a/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
@@ -1,0 +1,193 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+#
+# GNU General Public License v3.0+
+#
+# Copyright 2019 Arista Networks AS-EMEA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: cv_change_control_v3
+version_added: TBD
+author: EMEA AS Team (@aristanetworks)
+short_description: Change Control management with Cloudvision
+description:
+  - CloudVision Portal Change Control Module.
+  - ''
+options:
+  name:
+    description: The name of the change control. If not provided, one will be generated.
+    required: false
+    type: str
+  change:
+    description: A dict containuing the change control to be created/modified
+    required: true (if state == set)
+    type: dict
+    elements: dict
+  state:
+    description: Set if we should get, set/update, or remove the change control
+    required: false
+    default: get
+    choices: ['get','set','remove']
+    type: str
+
+'''
+
+EXAMPLES = r'''
+---
+- name: CVP Change Control Tests
+  hosts: cv_server
+  gather_facts: no
+  vars:
+    ansible_command_timeout: 1200
+    ansible_connect_timeout: 600
+    change:
+      name: Ansible playbook test change
+      notes: Created via playbook
+      activities:
+        - action: "Switch Healthcheck"
+          name: Switch1_healthcheck
+          device: DC1-Leaf1a
+          stage: Pre-Checks
+        - action: "Switch Healthcheck"
+          name: Switch1b_healthcheck
+          device: DC1-Leaf1b
+          stage: Pre-Checks
+        - task_id: "20"
+          stage: Leaf1a_upgrade
+        - task_id: "22"
+          stage: Leaf1b_upgrade
+      stages:
+        - name: Pre-Checks
+          mode: parallel
+        - name: Upgrades
+          modes: series
+        - name: Leaf1a_upgrade
+          parent: Upgrades
+        - name: Leaf1b_upgrade
+          parent: Upgrades
+
+
+  tasks:
+    - name: "Gather CVP change controls {{inventory_hostname}}"
+      arista.cvp.cv_change_control_v3:
+        state: get
+      register: cv_facts
+
+
+    - name: "Print out all change controls from {{inventory_hostname}}"
+      debug:
+        msg: "{{cv_facts}}"
+
+
+    - name: "Check CC structure"
+      debug:
+        msg: "{{change}}"
+
+
+    - name: "Create a change control on {{inventory_hostname}}"
+      arista.cvp.cv_change_control_v3:
+        state: set
+        change: "{{ change }}"
+
+    - name: "Get the created change control {{inventory_hostname}}"
+      arista.cvp.cv_change_control_v3:
+        state: get
+        name: change.name
+      register: cv_facts
+
+    - name: "Show the created CC from {{inventory_hostname}}"
+      debug:
+        msg: "{{cv_facts}}"
+
+
+    - name: "Delete the CC from {{inventory_hostname}}"
+      arista.cvp.cv_change_control_v3:
+        state: remove
+        name: change.name
+      register: cv_deleted
+
+    - name: "Show deleted CCs"
+      debug:
+        msg: "{{cv_deleted}}"
+
+'''
+
+# Required by Ansible and CVP
+import logging
+from ansible.module_utils.basic import AnsibleModule
+import ansible_collections.arista.cvp.plugins.module_utils.logger   # noqa # pylint: disable=unused-import
+from ansible_collections.arista.cvp.plugins.module_utils import tools_cv
+from ansible_collections.arista.cvp.plugins.module_utils.change_tools import CvChangeControlTools
+
+MODULE_LOGGER = logging.getLogger('arista.cvp.cv_change_control_v3')
+MODULE_LOGGER.info('Start cv_change_control_v3 module execution')
+
+
+def main():
+    """
+    main entry point for module execution.
+    """
+    argument_spec = dict(
+        name=dict(type='str'),
+        change=dict(type="dict"),
+        state=dict(default='get', type='str', choices=['get', 'set', 'remove']),
+    )
+
+    ansible_module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    # Instantiate ansible results
+    result = dict(changed=False, data={}, failed=False)
+    warnings = []
+
+    MODULE_LOGGER.info('starting module cv_change_control_v3')
+    if ansible_module.check_mode:
+        MODULE_LOGGER.warning('! check_mode is enable')
+        # module.exit_json(changed=True)
+
+    if not tools_cv.HAS_CVPRAC:
+        ansible_module.fail_json(
+            msg='cvprac required for this module. Please install using pip install cvprac'
+        )
+
+    # Create CVPRAC client
+    cv_client = tools_cv.cv_connect(ansible_module)
+
+    result = dict(changed=False)
+
+    # Instantiate the image class
+    cv_cc = CvChangeControlTools(
+        cv_connection=cv_client,
+        ansible_module=ansible_module,
+        check_mode=ansible_module.check_mode
+    )
+    
+    MODULE_LOGGER.debug("Calling module action")    
+    result['changed'], result['data'], warnings = cv_cc.module_action(**ansible_module.params)
+    MODULE_LOGGER.warning(warnings)
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
@@ -72,6 +72,7 @@ EXAMPLES = r'''
               value: <device serial number>
           stage: Pre-Checks
         - action: "Switch Healthcheck"
+          arguments:
             - name: DeviceID
               value: <device serial number>
           stage: Pre-Checks


### PR DESCRIPTION
## Change Summary

This PR adds the ability to get, create/update, and delete change controls.

## Related Issue(s)

Fixes #413

## Component(s) name

`arista.cvp.cv_change_control_v3`

## Proposed changes

The `CvChangeControlTools` class provides a simple module to allow for us to get/set/remove change controls,
```yaml
name: <Name of CC - doesn't have to be unique, but should be to make life easier>
state: <show | set | remove >
change: <dict>
change_id: <list>
```
The `CvpChangeControlBuilder` class does most of the heavy lifting in terms of building the CC data structure, to pass to CVP. The way of describing the change control is relatively simple, but allows for arbitrary (nested) multi-stage changes to be created, to any depth and/or level of complexity required.

```yaml
name: <name of change control>
notes: <Any notes that you want to add>
stages:
   - name: <name of stage>
     mode: <series | parallel>
     parent: <name of parent stage>
activities:
   - name: <only used internally, "task" for any tasks>
     task_id: <str - the WorkOrderId of the task to be executed>
     timeout: <int>
     stage: <str - the name of the Stage to assign the task to>
   - name: <only used internally>
     action: <The name of the action to be done e.g. "Switch Healthcheck">
     stage: <The name of the stage to assign the action to> 
     arguments: <list of dicts, each consisting of a name, and value key>
        - name: <argument name>
          value: <argument value>
```
An example here:
```yaml
name: Ansible playbook test change
notes: Created via playbook
activities:
  - action: "Switch Healthcheck"
    name: Switch1_healthcheck
    arguments:
       - name: DeviceID
         value: SERIAL_NUMBER
    stage: Pre-Checks
  - action: "Switch Healthcheck"
    name: Switch1b_healthcheck
    arguments:
       - name: DeviceID
         value: SERIAL_NUMBER
    stage: Pre-Checks
  - task_id: "20"
    stage: Leaf1a_upgrade
  - task_id: "22"
    stage: Leaf1b_upgrade
stages:
  - name: Pre-Checks
    mode: parallel
  - name: Upgrades
    modes: series
  - name: Leaf1a_upgrade
    parent: Upgrades
  - name: Leaf1b_upgrade
    parent: Upgrades
```
![image](https://user-images.githubusercontent.com/43743234/157035360-95019440-9f4a-4dd5-91cc-3ffc0740d217.png)


## How to test
An ansible test run:
```yaml
---
- name: CVP Change Control Tests
  hosts: cv_server
  gather_facts: no
  vars:
    ansible_command_timeout: 1200
    ansible_connect_timeout: 600
    change:
      name: Ansible playbook test change
      notes: Created via playbook
      activities:
        - action: "Switch Healthcheck"
          name: Switch1_healthcheck
          arguments:
            - name: DeviceID
              value: C13DB880A7DF8A7A5FEB7445C476255C
          stage: Pre-Checks
        - action: "Switch Healthcheck"
          name: Switch1b_healthcheck
          arguments:
            - name: DeviceID
              value: 1FA1BEEE0B875693FE5125374F882EE4
          stage: Pre-Checks
        - task_id: "20"
          stage: Leaf1a_upgrade
        - task_id: "22"
          stage: Leaf1b_upgrade
      stages:
        - name: Pre-Checks
          mode: parallel
        - name: Upgrades
          modes: series
        - name: Leaf1a_upgrade
          parent: Upgrades
        - name: Leaf1b_upgrade
          parent: Upgrades


  tasks:
    - name: "Gather CVP change controls {{inventory_hostname}}"
      arista.cvp.cv_change_control_v3:
        state: show
      register: cv_facts


    - name: "Print out all change controls from {{inventory_hostname}}"
      debug:
        msg: "{{cv_facts}}"


    - name: "Check CC structure"
      debug:
        msg: "{{change}}"


    - name: "Create a change control on {{inventory_hostname}}"
      arista.cvp.cv_change_control_v3:
        state: set
        change: "{{ change }}"
      register: cv_change

    - name: "The Change created has ID {{inventory_hostname}}"
      debug:
        msg: "{{ cv_change }}"

    - name: "Updating Change notes"
      ansible.utils.update_fact:
        updates:
          - path: change.key
            value: "{{ cv_change.data.id }}"
          - path: change.notes
            value: "Change updated"
      register: updated


    - name: "Update the change control on {{inventory_hostname}}"
      arista.cvp.cv_change_control_v3:
        state: set
        change: "{{ updated.change }}"
      register: cv_change


    - name: "Get the updated change control {{inventory_hostname}}"
      arista.cvp.cv_change_control_v3:
        state: show
        name: "{{change.name}}"
      register: cv_facts

    - name: "Show the created CC from {{inventory_hostname}}"
      debug:
        msg: "{{cv_facts}}"


    - name: "Delete the CC from {{inventory_hostname}}"
      arista.cvp.cv_change_control_v3:
        state: remove
        name: "{{change.name}}"
      register: cv_deleted

```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
