### PR TITLE
Feat: Facts update

### DIFF
--- a/ansible_collections/arista/cvp/docs/how-to/v3/cv_facts_v3.md
+++ b/ansible_collections/arista/cvp/docs/how-to/v3/cv_facts_v3.md
@@ -59,12 +59,12 @@ ok: [CloudVision] =>
              exec /usr/bin/TerminAttr -cvaddr=apiserver.cv-staging.corp.arista.io:443 -cvcompression=gzip -taillogs -cvauth=token-secure,/tmp/cv-onboarding-token -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -disableaaa
              no shutdown
           hostname spine-2-unit-test
-          ip name-server vrf default 172.22.22.40
+          ip name-server vrf default 192.0.2.40
           dns domain ire.aristanetworks.com
           interface Management1
              mtu 1380
-             ip address 10.83.13.165/24
-          ip route 0.0.0.0/0 10.83.13.1
+             ip address 192.0.2.165/24
+          ip route 0.0.0.0/0 192.0.2.1
           ntp server ntp.aristanetworks.com
       cvp_containers:
         CVPRACTEST:
@@ -80,11 +80,13 @@ ok: [CloudVision] =>
         fqdn: leaf-1-unit-test.ire.aristanetworks.com
         hostname: leaf-1-unit-test
         parentContainerName: ansible-tests
+        ipAddress: 192.0.2.165
         serialNumber: A2BC886CB9408A0453A3CFDD9C251999
         systemMacAddress: 50:00:00:d5:5d:c0
       - configlets: []
         fqdn: leaf-2-unit-test.ire.aristanetworks.com
         hostname: leaf-2-unit-test
+        ipAddress: 192.0.2.166
         parentContainerName: ansible-tests
         serialNumber: 08A7E527AF711F688A6AD7D78BB5AD0A
         systemMacAddress: 50:00:00:cb:38:c2
@@ -92,6 +94,7 @@ ok: [CloudVision] =>
         - test_configlet
         fqdn: leaf-2-unit-test.ire.aristanetworks.com
         hostname: leaf-2-unit-test
+        ipAddress: 192.0.2.167
         parentContainerName: ansible-tests
         serialNumber: 24666013EF2271599935B4A894F356E1
         systemMacAddress: 50:00:00:03:37:66

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -60,6 +60,7 @@ class DeviceElement(object):
         self.__fqdn = self.__data.get(Api.device.FQDN)
         self.__sysmac = self.__data.get(Api.device.SYSMAC)
         self.__serial = self.__data.get(Api.device.SERIAL)
+        self.__mgmtip = self.__data.get(Api.device.MGMTIP)
         self.__container = self.__data[Api.generic.PARENT_CONTAINER_NAME]
         # self.__image_bundle = []  # noqa # pylint: disable=unused-variable
         self.__current_parent_container_id = None
@@ -71,6 +72,8 @@ class DeviceElement(object):
             self.__serial = data[Api.device.SERIAL]
         if Api.device.HOSTNAME in data:
             self.__hostname = data[Api.device.HOSTNAME]
+        if Api.device.MGMTIP in data:
+            self.__mgmtip = data[Api.device.MGMTIP]
         elif Api.device.FQDN in data:
             self.__hostname = data[Api.device.FQDN].split('.')[0]
         else:
@@ -147,6 +150,30 @@ class DeviceElement(object):
             systemMac address to configure on device
         """
         self.__sysmac = mac
+
+    @property
+    def mgmt_ip(self):
+        """
+        system_mac Getter for SystemMac value
+
+        Returns
+        -------
+        str
+            mgmtIp address for the device
+        """
+        return self.__mgmtip
+
+    @mgmt_ip.setter
+    def mgmt_ip(self, mgmtip: str):
+        """
+        mgmt_ip Setter for MgmtIp address
+
+        Parameters
+        ----------
+        ip : str
+            mgmtIp address to configure on device
+        """
+        self.__mgmtip = mgmtip
 
     @property
     def serial_number(self):

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -83,6 +83,7 @@ class CvFactResource():
                 Api.device.SERIAL,
                 Api.device.SYSMAC,
                 Api.generic.CONFIGLETS,
+                Api.device.MGMTIP,
             ]
         }
         fact[Api.generic.PARENT_CONTAINER_NAME] = device_fact[Api.device.CONTAINER_NAME]

--- a/ansible_collections/arista/cvp/plugins/module_utils/resources/api/fields.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/resources/api/fields.py
@@ -77,6 +77,7 @@ class ApiDevice():
     SERIAL: str = 'serialNumber'
     SYSMAC: str = 'systemMacAddress'
     PARENT_CONTAINER_KEY: str = 'parentContainerKey'
+    MGMTIP: str = 'ipAddress'
 
 
 # @dataclass

--- a/ansible_collections/arista/cvp/plugins/module_utils/resources/schemas/v3.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/resources/schemas/v3.py
@@ -59,6 +59,7 @@ SCHEMA_CV_DEVICE = {
         [
             {
                 "fqdn": "CV-ANSIBLE-EOS01",
+                "ipAddress": "192.0.2.100",
                 "serialNumber": "79AEA53101E7340AEC9AA4819D5E1F5B",
                 "systemMacAddress": "50:8d:00:e3:78:aa",
                 "parentContainerName": "ANSIBLE2",
@@ -82,6 +83,7 @@ SCHEMA_CV_DEVICE = {
                 "examples": [
                     {
                         "fqdn": "CV-ANSIBLE-EOS01",
+                        "ipAddress": "192.0.2.100",
                         "serialNumber": "79AEA53101E7340AEC9AA4819D5E1F5B",
                         "systemMacAddress": "50:8d:00:e3:78:aa",
                         "parentContainerName": "ANSIBLE2",
@@ -108,6 +110,16 @@ SCHEMA_CV_DEVICE = {
                 ],
                 "additionalProperties": True,
                 "properties": {
+                    "ipAddress": {
+                        "$id": "#/items/anyOf/0/properties/ipAddress",
+                        "type": "string",
+                        "title": "The ipAddress schema",
+                        "description": "An explanation about the purpose of this instance.",
+                        "default": "",
+                        "examples": [
+                            "192.0.2.5"
+                        ]
+                    },
                     "fqdn": {
                         "$id": "#/items/anyOf/0/properties/fqdn",
                         "type": "string",


### PR DESCRIPTION
## Change Summary

Added the `mgmt_ip` to the `DeviceElement` class and expanded `fact_tools` to also populated the IP of the device

## Related Issue(s)

Fixes #468 

## Component(s) name

`arista.cvp.cv_facts_v3`

## Proposed changes
added a new key for `ipAddress` to the existing schema similarly to how we had it for hostname,fqdn, SN and MAC address

## How to test

example playbook: 

```yaml
- name: get facts
  hosts: cv_server
  connection: local
  gather_facts: no
  tasks:
  - name: '#01 - Collect devices facts from {{inventory_hostname}}'
    tags: [facts]
    arista.cvp.cv_facts_v3:
      facts:
        - devices
    register: facts_devices
 - name: "Printing facts from {{inventory_hostname}}"
    tags: [facts]
    debug:
      msg: "{{ facts_devices.data.cvp_devices }}"
    delegate_to: localhost
```

output should contain something like below:

```yaml
  - configlets:
    - vlangen
    - tp-avd_tp-avd-leaf2
    - vlan144
    fqdn: tp-avd-leaf2
    hostname: tp-avd-leaf2
    ipAddress: 10.83.13.215
    parentContainerName: TP_LEAF1
    serialNumber: 0123F2E4462997EB155B7C50EC148767
    systemMacAddress: 50:08:00:b1:5b:0b
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
