### PR TITLE
Change from fail to warning

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/image_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/image_tools.py
@@ -214,7 +214,7 @@ class CvImageTools():
                         except Exception as e:
                             self.__ansible.fail_json(msg="{0}".format(e))
                     else:
-                        self.__ansible.fail_json(msg="Unable to add image {0}. Image already present on server".format(image))
+                        warnings.append("Unable to add image {0}. Image already present on server".format(image))
                 else:
                     self.__ansible.fail_json(msg="Specified file ({0}) does not exist".format(image))
             else:


### PR DESCRIPTION
## Change Summary

The original feedback on the module indicated that we [shouldn't fail](https://github.com/aristanetworks/ansible-cvp/pull/428/files#diff-f3756c9ec43d5287ee538abada8a577a241d07639746c703ffd06615036fdd46R222) if the software image was already present on the server. It looks like that got reverted somewhere in the process.

## Related Issue(s)

Didn't open an issue

## Component(s) name

`arista.cvp.image_tools`

## Proposed changes
Warn rather then fail if the software image is already present on the CVP server

## How to test
Add an image twice - it should not fail
```yaml
    - name: "Add new EOS lab image {{inventory_hostname}}"
      vars:
        ansible_command_timeout: 1200
        ansible_connect_timeout: 600
      arista.cvp.cv_image_v3:
        mode: image
        action: add
        image: /home/colin/automated-upgrades/images/vEOS-lab-4.27.3F.swi

    - name: "Add existing EOS lab image {{inventory_hostname}}"
      vars:
        ansible_command_timeout: 1200
        ansible_connect_timeout: 600
      arista.cvp.cv_image_v3:
        mode: image
        action: add
        image: /home/colin/automated-upgrades/images/vEOS-lab-4.27.3F.swi
```


## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
