### PR TITLE
Refactor(pytest): remove distutils import to anticipate deprecation

### DIFF
--- a/ansible_collections/arista/cvp/docs/_build/ansible2rst.py
+++ b/ansible_collections/arista/cvp/docs/_build/ansible2rst.py
@@ -20,12 +20,9 @@ __metaclass__ = type
 
 import os
 import re
-import sys
 import datetime
 import cgi
 import yaml
-import logging
-from distutils.version import LooseVersion
 from jinja2 import Environment, FileSystemLoader
 from ansible.module_utils.six import print_
 from ansible.module_utils.common._collections_compat import MutableMapping, MutableSet, MutableSequence

--- a/tests/lib/config.py
+++ b/tests/lib/config.py
@@ -4,9 +4,28 @@
     config.py - Declares the credential of the specified server
 """
 import os
-from distutils.util import strtobool
 
-user_token = os.getenv('ARISTA_AVD_CV_TOKEN', 'unset_token')
-server = os.getenv('ARISTA_AVD_CV_SERVER', '')
-provision_cv = strtobool(os.getenv('ARISTA_AVD_CV_PROVISION', 'true'))
-cvaas = strtobool(os.getenv('ARISTA_AVD_CVAAS', 'true'))
+
+def strtobool(val):
+    """
+    Convert a string representation of truth to true (1) or false (0).
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+
+    Port of distutils.util.strtobool as per PEP 0632 recommendation
+    https://peps.python.org/pep-0632/#migration-advice
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return 1
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))
+
+
+user_token = os.getenv("ARISTA_AVD_CV_TOKEN", "unset_token")
+server = os.getenv("ARISTA_AVD_CV_SERVER", "")
+provision_cv = strtobool(os.getenv("ARISTA_AVD_CV_PROVISION", "true"))
+cvaas = strtobool(os.getenv("ARISTA_AVD_CVAAS", "true"))


### PR DESCRIPTION
## Change Summary

Refactor(ansible-cvp): remove distutils import to anticipate deprecation

* also removed unused imports sys and logging in  ansible_collections/arista/cvp/docs/_build/ansible2rst.py

## Related Issue(s)

Fixes #477

## Component(s) name

* `tests`
* `arista.cvp.docs`
*
## Proposed changes

### `tests`
* reimplementing the function as it is in distutils today as per PEP recommendation

### `arista.cvp.docs`
the LooseVersion was actually not used so just removed the import - note that the migration advice would have been to use the `packaging` package if required: https://peps.python.org/pep-0632/#migration-advice

## How to test

run pytest and verify the warning is gone

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
