### PR TITLE
Feat(module_utils): raise NotImplementedError if encrypted Vault password…

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
@@ -68,6 +68,12 @@ def cv_connect(module):
     ansible_connect_timeout = connection.get_option(
         "persistent_connect_timeout")
 
+    if not isinstance(user_authentication, str):
+        LOGGER.error('Cannot connect to CVP, password is encrypted')
+        raise NotImplementedError("Vault encrypted variables are not supported "
+                                  "as password yet. Use ansible vault file instead."
+                                  "https://docs.ansible.com/ansible/latest/user_guide/vault.html#encrypting-files-with-ansible-vault")
+
     if cert_validation:
         LOGGER.debug("  Module will check CV certificate")
     if user == 'cvaas':
@@ -91,8 +97,8 @@ def cv_connect(module):
                        connect_timeout=ansible_connect_timeout
                        )
     except CvpLoginError as e:
-        module.fail_json(msg=str(e))
         LOGGER.error('Cannot connect to CVP: %s', str(e))
+        module.fail_json(msg=str(e))
 
     LOGGER.info('Connected to CVP')
 
@@ -112,7 +118,7 @@ def isIterable(testing_object=None):
 
     """
     try:
-        some_object_iterator = iter(testing_object)  # noqa # pylint: disable=unused-variable
+        iter(testing_object)  # noqa
         return True
     except TypeError as te:  # noqa # pylint: disable=unused-variable
         return False

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
@@ -118,7 +118,7 @@ def isIterable(testing_object=None):
 
     """
     try:
-        iter(testing_object)  # noqa
+        iter(testing_object)
         return True
     except TypeError as te:  # noqa # pylint: disable=unused-variable
         return False

--- a/tests/lib/mock_ansible.py
+++ b/tests/lib/mock_ansible.py
@@ -6,6 +6,7 @@ import pprint
 import logging
 from cvprac.cvp_client import CvpClient, CvpApi
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
 from ansible_collections.arista.cvp.plugins.module_utils.resources.api.fields import Api
 from tests.data import facts_unit
 
@@ -29,9 +30,25 @@ def get_ansible_module(check_mode: bool = False):
     Returns
     -------
     MagicMock
-        The mock cpvrac.cvp_client.CvpClient instance.
+        The mock AnsibleModule instance
     """
     mock_module = create_autospec(AnsibleModule)
     mock_module.fail_json.side_effect = fail_json
     mock_module.check_mode = check_mode
     return mock_module
+
+
+def get_ansible_connection():
+    """
+    Return a mock ansible.module_utils.connection.Connection instance.
+
+    Returns
+    -------
+    MagicMock
+        The mock Connection instance
+    """
+    # The issue with create_autospec is that Connection relies on
+    # __getattr__ method to automatically generate a call to __rpc__
+    # for any method applied to it. Hence using a generic MagicMock
+    mock_connection = MagicMock(spec=Connection)
+    return mock_connection

--- a/tests/unit/test_tools_cv.py
+++ b/tests/unit/test_tools_cv.py
@@ -1,0 +1,116 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+# pylint: disable=logging-format-interpolation
+# pylint: disable=dangerous-default-value
+# flake8: noqa: W503
+# flake8: noqa: W1202
+
+from __future__ import absolute_import, division, print_function
+from tests.lib.parametrize import generate_flat_data
+from ansible_collections.arista.cvp.plugins.module_utils.tools_cv import cv_connect
+import logging
+import pytest
+from unittest import mock
+
+from tests.lib.mock_ansible import (
+    get_ansible_module,
+    get_ansible_connection,
+    AnsibleFailJson,
+)
+from contextlib import contextmanager
+from cvprac.cvp_client_errors import CvpLoginError
+
+# pytest - -html = report.html - -self-contained-html - -cov = . --cov-report = html - -color yes containerInputs.py - v
+
+# ---------------------------------------------------------------------------- #
+#   FIXTURES
+# ---------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def module():
+    module = get_ansible_module()
+    module._socket_path = __file__
+    return module
+
+
+@pytest.fixture
+def connection(request):
+    def get_option(key):
+        return request.param[key]
+
+    connection = get_ansible_connection()
+    connection.get_option = get_option
+    return connection
+
+
+def module_values(
+    host="42.42.42.42",
+    port=443,
+    validate_certs=True,
+    remote_user="cvpadmin",
+    password="ansible",
+    persistent_command_timeout=30,
+    persistent_connect_timeout=30,
+):
+    """
+    Default dict to be used to fake module parameters
+    """
+    return {
+        "host": host,
+        "port": port,
+        "validate_certs": validate_certs,
+        "remote_user": remote_user,
+        "password": password,
+        "persistent_command_timeout": persistent_command_timeout,
+        "persistent_connect_timeout": persistent_connect_timeout,
+    }
+
+
+# As per https://docs.pytest.org/en/6.2.x/example/parametrize.html#parametrizing-conditional-raising
+@contextmanager
+def does_not_raise():
+    yield
+
+
+# ---------------------------------------------------------------------------- #
+#   PYTEST
+# ---------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "connection, connect_side_effect, expectation",
+    [
+        (module_values(), None, does_not_raise()),
+        (
+            module_values(password={"__ansible_vault": "DUMMY VAULT"}),
+            None,
+            pytest.raises(NotImplementedError),
+        ),
+        (
+            module_values(),
+            CvpLoginError("Test Exception"),
+            pytest.raises(AnsibleFailJson),
+        ),
+    ],
+    indirect=["connection"],
+)
+def test_cv_connect(module, connection, connect_side_effect, expectation):
+    """
+    this test is using indirect parametrization to pass arguments to the connection
+    fixture.
+    Note that implicit fixture parametrization is also possible but it then looks like
+    a lot of magic
+    https://stackoverflow.com/questions/18011902/pass-a-parameter-to-a-fixture-function
+    hmmm
+    """
+    # Patch the Connection class to return the connection fixture
+    with mock.patch(
+        "ansible_collections.arista.cvp.plugins.module_utils.tools_cv.Connection",
+        return_value=connection,
+    ), mock.patch(
+        "ansible_collections.arista.cvp.plugins.module_utils.tools_cv.CvpClient.connect",
+        side_effect=connect_side_effect,
+    ):
+        with expectation:
+            cv_connect(module)


### PR DESCRIPTION
## Change Summary

Raise NotImplementedError if the ansible_password received for the CvpClient is a dictionary encoding of an `__ansible_vault` value rather than a string.

## Related Issue(s)

The issue is not fixed but it relates to #475 - this is a temporary measure to raise a meaningful error.

## Component(s) name

* `ansible_cvp.module_utils.tools_cv.py
 
## Proposed changes

In the meantime of finding a good solution to retrieve a propre password via `get_option` or other method, this PR suggest to raise a `NonImplementedError` if the received password via `connection.get_option` is not a string.

## How to test

Additional tests for pytest to verify this issue

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
