### PR TITLE
Feat: (dhcp_configuration) add a name to the dhcp record

### DIFF
--- a/ansible_collections/arista/cvp/molecule/dhcp_management_offline/inventory/group_vars/TOOLS.yml
+++ b/ansible_collections/arista/cvp/molecule/dhcp_management_offline/inventory/group_vars/TOOLS.yml
@@ -11,7 +11,8 @@ ztp:
         netmask: 255.255.0.0
         start: 172.17.255.200
         end: 172.17.255.200
-      - network: 10.255.0.0
+      - name: Remote Subnet
+        network: 10.255.0.0
         netmask: 255.255.255.0
         gateway: 10.255.0.3
         nameservers:

--- a/ansible_collections/arista/cvp/roles/dhcp_configuration/README.md
+++ b/ansible_collections/arista/cvp/roles/dhcp_configuration/README.md
@@ -46,7 +46,8 @@ ztp:
     use_system_mac:   < true | false Configure DHCP for system-mac-address provided in show version (default false) >
   general:            < Section to define subnets parameters >
     subnets:
-      - network:      < * Subnet where DHCP will listen for request >
+      - name:         < Descriptive name, added as a comment in config file >
+        network:      < * Subnet where DHCP will listen for request >
         netmask:      < * Netmask of given subnet >
         gateway:      < Gateway to configure for given subnet >
         nameservers:  < List of name-servers to configure for given subnet >

--- a/ansible_collections/arista/cvp/roles/dhcp_configuration/templates/dhcpd.conf.j2
+++ b/ansible_collections/arista/cvp/roles/dhcp_configuration/templates/dhcpd.conf.j2
@@ -2,6 +2,10 @@
 # {{ ansible_managed }} - {{ inventory_hostname }}
 # Subnet of ZTP interface
 {% for subnet in ztp.general.subnets %}
+{% if subnet.name is defined %}
+
+# {{ subnet.name }}
+{% endif %}
 subnet {{ subnet.network }} netmask {{ subnet.netmask }} {
 {%     if subnet.start is defined and subnet.end is defined %}
     range {{ subnet.start }} {{ subnet.end }};


### PR DESCRIPTION
## Change Summary

Add a descriptive name to a subnet and render the name as a comment.

## Related Issue(s)

Fixes #480

## Component(s) name

`arista.cvp.dhcp_configuration`

## Proposed changes
Add a new key: 
```yaml
ztp:
  general:            < Section to define subnets parameters >
    subnets:
      - name:         < Descriptive name, added as a comment in config file >

```

## How to test
Added to molecule but not rendering intended config

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
