### PR TITLE
CI(actions): Add autopep8 to pre-commit hooks

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,0 +1,3 @@
+[pycodestyle]
+max_line_length = 160
+ignore = ["E402" , "E741" , "W503" , "W504"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: check-added-large-files
       - id: check-merge-conflict
   - repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: 898691a48e7dbdbbac32f44f9336ef944d74cf82
+    rev: v1.6.0
     hooks:
       - id: autopep8
   - repo: https://github.com/pre-commit/mirrors-pylint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,10 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
       - id: check-merge-conflict
+  - repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: 898691a48e7dbdbbac32f44f9336ef944d74cf82
+    hooks:
+      - id: autopep8
   - repo: https://github.com/pre-commit/mirrors-pylint
     rev: 'v2.5.0'
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,16 @@ check-cvp-404: ## Check local 404 links for AVD documentation
 #########################################
 
 .PHONY: linting
-linting: ## Run pre-commit script for python code linting using pylint
-	sh .github/pre-commit
+linting: ## Run pre-commit script for code linting check
+	pre-commit run --all-files pylint
+	pre-commit run --all-files yamllint
+	pre-commit run --all-files ansible-lint
+
+.PHONY: sanitize
+sanitize: ## Run pre-commit script for code linting check
+	pre-commit run --all-files trailing-whitespace
+	pre-commit run --all-files end-of-file-fixer
+	pre-commit run --all-files autopep8
 
 .PHONY: pre-commit
 pre-commit: ## Execute pre-commit validation for staged files

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -54,6 +54,7 @@ class CvpChangeControlBuilder:
     add_known_uuid(list(str))
         Provide a list of UUIDs already in use to the class, to prevent collisions.
     """
+
     def __init__(self):
         # Guarantee that the generated IDs are unique, for this session
         self.__keyStore = []
@@ -479,6 +480,7 @@ class CvChangeControlTools():
     """
     CvImageTools Class to manage Cloudvision Change Controls
     """
+
     def __init__(self, cv_connection, ansible_module: AnsibleModule = None, check_mode: bool = False):
         self.__cv_client = cv_connection
         self.__ansible = ansible_module

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -307,6 +307,7 @@ class CvDeviceTools(object):
     CvDeviceTools Object to operate Device operation on Cloudvision
     """
     # Updated as per issue #365 to set default search with hostname field
+
     def __init__(self, cv_connection, ansible_module: AnsibleModule = None, search_by: str = Api.device.HOSTNAME, check_mode: bool = False):
         self.__cv_client = cv_connection
         self.__ansible = ansible_module

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -57,6 +57,7 @@ class CvFactResource():
     """
     CvFactResource Helper to render facts based on resource type
     """
+
     def __init__(self, facts_type: str = 'list'):
         if facts_type == 'list':
             self._cache = []

--- a/ansible_collections/arista/cvp/plugins/module_utils/resources/exceptions.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/resources/exceptions.py
@@ -43,6 +43,7 @@ class AnsibleCVPError(Exception):
 
 class AnsibleCVPApiError(Exception):
     """Exception raised when an API-related error occurs"""
+
     def __init__(self, cvprac_method: Callable, message: str) -> None:
         """
         Constructor for the AnsibleCVPApiError class
@@ -64,6 +65,7 @@ class AnsibleCVPApiError(Exception):
 
 class AnsibleCVPNotFoundError(Exception):
     """Raised when the ressource is not found in CloudVision instance."""
+
     def __init__(self, name: str, type: CVPRessource, message: str = None) -> None:
         """
         Constructor for the AnsibleCVPNotFoundError class

--- a/ansible_collections/arista/cvp/plugins/module_utils/response.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/response.py
@@ -301,6 +301,7 @@ class CvManagerResult():
     }
 
     """
+
     def __init__(self, builder_name: str, default_success: bool = False):
         self.__name = builder_name
         self.__success = default_success
@@ -451,6 +452,7 @@ class CvAnsibleResponse():
           success: false
           failed: false
     """
+
     def __init__(self):
         self.success = False
         self.changed = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
-[pycodestyle]
+[tool.autopep8]
 max_line_length = 160
 ignore = ["E402" , "E741" , "W503" , "W504"]

--- a/tests/data/image_unit.py
+++ b/tests/data/image_unit.py
@@ -20,7 +20,7 @@
 
 
 CV_IMAGES_PAYLOADS = [
-    {   'name': '0 image, 1 bundle',
+    {'name': '0 image, 1 bundle',
         'images': {
             "total": 0,
             "data": []
@@ -35,7 +35,7 @@ CV_IMAGES_PAYLOADS = [
                     "isCertifiedImageBundle": "true",
                     "updatedDateInLongFormat": 1643897984608,
                     "imageIds": [
-                    "EOS-4.26.1F.swi"
+                        "EOS-4.26.1F.swi"
                     ],
                     "appliedContainersCount": 0,
                     "appliedDevicesCount": 0
@@ -45,8 +45,8 @@ CV_IMAGES_PAYLOADS = [
             "imageBundleMapper": {},
             "assignedImageBundleId": ""
         }
-    },
-    {   'name': '0 image fake number, 1 bundle',
+     },
+    {'name': '0 image fake number, 1 bundle',
         'images': {
             "total": 100,
             "data": []
@@ -61,7 +61,7 @@ CV_IMAGES_PAYLOADS = [
                     "isCertifiedImageBundle": "true",
                     "updatedDateInLongFormat": 1643897984608,
                     "imageIds": [
-                    "EOS-4.26.1F.swi"
+                        "EOS-4.26.1F.swi"
                     ],
                     "appliedContainersCount": 0,
                     "appliedDevicesCount": 0
@@ -71,7 +71,7 @@ CV_IMAGES_PAYLOADS = [
             "imageBundleMapper": {},
             "assignedImageBundleId": ""
         }
-    },
+     },
     {
         'name': '1 image, 1 bundle',
         'images': {
@@ -89,7 +89,7 @@ CV_IMAGES_PAYLOADS = [
                     "uploadedDateinLongFormat": 1643897952009,
                     "isHotFix": "false",
                     "imageBundleKeys": [
-                    "imagebundle_1643897984608204097"
+                        "imagebundle_1643897984608204097"
                     ],
                     "key": "EOS-4.26.1F.swi",
                     "imageId": "EOS-4.26.1F.swi",
@@ -109,7 +109,7 @@ CV_IMAGES_PAYLOADS = [
                     "isCertifiedImageBundle": "true",
                     "updatedDateInLongFormat": 1643897984608,
                     "imageIds": [
-                    "EOS-4.26.1F.swi"
+                        "EOS-4.26.1F.swi"
                     ],
                     "appliedContainersCount": 0,
                     "appliedDevicesCount": 0

--- a/tests/lib/helpers.py
+++ b/tests/lib/helpers.py
@@ -63,7 +63,7 @@ def setup_custom_logger(name):
     """
     formatter = logging.Formatter(
         fmt='%(asctime)s %(levelname)-8s File: %(filename)s  - Function: %(funcName)s - Line: %(lineno)d - %(message)s',
-        )
+    )
     # Handler for logfile
     handler = logging.FileHandler('pytest.log', mode='w')
     handler.setFormatter(formatter)
@@ -101,6 +101,7 @@ def to_nice_json(data, ident: int = 4):
     """
     return pprint.pformat(data, indent=ident)
 
+
 @dataclass
 class AnsibleModuleMock():
     """
@@ -113,6 +114,7 @@ class AnsibleModuleMock():
 
     def fail_json(self, msg: str):
         logging.error("AnsibleModule.fail_json: {}".format(msg))
+
 
 def strtobool(input):
     """

--- a/tests/lib/json_data.py
+++ b/tests/lib/json_data.py
@@ -279,8 +279,8 @@ mook_data["invalid"]["device"] = [
         "systemMacAddress": "ccccccc",
         "parentContainerName": "DC1_SPINES",
         "configlets": [
-                "AVD_DC1-SPINE1",
-                "01TRAINING-01"
+            "AVD_DC1-SPINE1",
+            "01TRAINING-01"
         ],
         "imageBundle": []
     }]
@@ -291,16 +291,16 @@ mook_data["invalid"]["device"] = [
 #######################################
 
 mook_data["valid"]["configlet"] = [
-        {"configlet_device01": "alias sib show version"},
-        {"configlet-device01": "alias sib show version"},
-        {"configlet-device_01": CONFIGLET_CONTENT},
+    {"configlet_device01": "alias sib show version"},
+    {"configlet-device01": "alias sib show version"},
+    {"configlet-device_01": CONFIGLET_CONTENT},
 ]
 
 mook_data["invalid"]["configlet"] = [
-        {"configlet_device01": 100},
-        {"configlet_device02": True},
-        {"configlet_device02": False},
-        {"configlet-device_01": "alias sib show version", 'version': 1},
+    {"configlet_device01": 100},
+    {"configlet_device02": True},
+    {"configlet_device02": False},
+    {"configlet-device_01": "alias sib show version", 'version': 1},
 ]
 
 #######################################
@@ -397,9 +397,9 @@ CVP_DATA_CONTAINERS = {
 # CVP data used to play with Facts           #
 ##############################################
 
-mook_data['valid']['facts']= {
+mook_data['valid']['facts'] = {
     'device_ids': ['50:01:00:1e:cf:92']
 }
-mook_data['invalid']['facts']= {
+mook_data['invalid']['facts'] = {
     'device_ids': ['00:00:00:00:00:00']
 }

--- a/tests/lib/utils.py
+++ b/tests/lib/utils.py
@@ -15,6 +15,7 @@ from tests.system.constants_data import USER_CONTAINERS, CV_CONTAINERS_NAME_ID_L
 
 MODULE_LOGGER = logging.getLogger(__name__)
 
+
 def cvp_login():
     """Login cvp devices
 
@@ -130,6 +131,7 @@ def get_cvp_devices_after_move():
     """
     return CVP_DEVICES_1
 
+
 def get_devices_to_move():
     """Returns list of devices to move
 
@@ -142,6 +144,7 @@ def get_devices_to_move():
             entry[Api.generic.PARENT_CONTAINER_NAME] = CONTAINER_DESTINATION
         to_move.append(entry)
     return to_move
+
 
 def generate_container_ids():
     """Returns the container ids

--- a/tests/system/test_cv_configlet.py
+++ b/tests/system/test_cv_configlet.py
@@ -16,7 +16,7 @@ from ansible_collections.arista.cvp.plugins.module_utils.response import CvApiRe
 from tests.lib.helpers import time_log, AnsibleModuleMock, setup_custom_logger, to_nice_json
 from tests.lib.parametrize import generate_CvConfigletTools_content
 from tests.lib.config import user_token, provision_cv
-from tests.lib.cvaas_configlet import  SYSTEM_CONFIGLETS_TESTS
+from tests.lib.cvaas_configlet import SYSTEM_CONFIGLETS_TESTS
 from tests.lib.utils import cvp_login, generate_test_ids_dict
 from tests.lib.provisioner import CloudvisionProvisioner
 
@@ -120,7 +120,7 @@ class Test_CvConfiglet_Unit():
         diff_data = self.cv_configlet._compare(
             fromText=test_configlet['config'],
             toText=test_configlet['config_expected']
-            )
+        )
         logger.debug('Diff result is: {}'.format(diff_data))
         # Tests
         assert python_str_not_equal is diff_data[0]
@@ -162,7 +162,7 @@ class Test_CvConfiglet_Unit():
         configlet_key = self.cv_configlet.get_configlet_data_cv(configlet_name=test_configlet['name'])['key']
         logger.info('Got CV result')
         #   API Call 2
-        configlet = {'name':test_configlet['name'], 'key':configlet_key, 'config': test_configlet['config']}
+        configlet = {'name': test_configlet['name'], 'key': configlet_key, 'config': test_configlet['config']}
         logger.info('Start to update configlet data')
         api_call = self.cv_configlet.update(to_update=[configlet], note='Updated by pytest - {}'.format(time_log()))
         logger.info('Got CV result')
@@ -172,7 +172,7 @@ class Test_CvConfiglet_Unit():
         assert api_call[0].results['success'] is True
         # Revert content only if check_mode is False
         if check_mode is False:
-            configlet = {'name':test_configlet['name'], 'key':configlet_key, 'config': test_configlet['config_expected']}
+            configlet = {'name': test_configlet['name'], 'key': configlet_key, 'config': test_configlet['config_expected']}
             api_call = self.cv_configlet.update(to_update=[configlet], note='Updated by pytest - {}'.format(time_log()))
             logger.debug('Revert to expected - API result is: {}'.format(to_nice_json(data=api_call[0].results)))
 
@@ -186,7 +186,7 @@ class Test_CvConfiglet_Unit():
         self.cv_configlet._ansible.check_mode = check_mode
         # Work with API
         configlet_key = self.cv_configlet.get_configlet_data_cv(configlet_name=test_configlet['name'])['key']
-        configlet = {'name':test_configlet['name'], 'key':configlet_key}
+        configlet = {'name': test_configlet['name'], 'key': configlet_key}
         logger.info('Start to delete configlet on CV')
         api_call = self.cv_configlet.delete(to_delete=[configlet])
         logger.info('Got CV result')
@@ -200,6 +200,7 @@ class Test_CvConfiglet_Unit():
         requests.packages.urllib3.disable_warnings()
         logger.info("Object has been deleted {}".format(time_log()))
         assert True
+
 
 @pytest.mark.api
 @pytest.mark.configlet

--- a/tests/system/test_cv_container_tools.py
+++ b/tests/system/test_cv_container_tools.py
@@ -194,7 +194,7 @@ class TestCvContainerTools():
         assert len(configlets) > 0
         for configlet in configlets:
             assert configlet["name"] in [
-               "cvaas-unit-test-01", "cvaas-unit-test-02", "leaf-1-unit-test"]
+                "cvaas-unit-test-01", "cvaas-unit-test-02", "leaf-1-unit-test"]
             logging.info(
                 "CVP returned {} and it is in the expected list".format(configlet["name"]))
         logging.info("All returned configlets are in expected list")

--- a/tests/system/test_cv_facts_tools.py
+++ b/tests/system/test_cv_facts_tools.py
@@ -85,6 +85,7 @@ class TestCvContainerToolsContainers():
 # -------------------
 # Test Devices
 
+
 @pytest.mark.usefixtures("CvFactsTools_Manager")
 @pytest.mark.parametrize("test_device", FACT_DEVICE_TEST, ids=generate_test_ids_dict)
 @pytest.mark.api
@@ -109,11 +110,11 @@ class TestCvContainerToolsDevices():
         logger.info('Got correct response from Cloudvision')
         logger.debug('Got response from module: {0}'.format(result))
 
+
 @pytest.mark.usefixtures("CvFactsTools_Manager")
 @pytest.mark.api
 @pytest.mark.facts
 class TestCvContainerToolsDevicesFacts():
-
 
     @pytest.mark.dependency(name='authentication')
     @pytest.mark.skipif(user_token == 'unset_token', reason="Token is not set correctly")
@@ -181,7 +182,6 @@ class TestCvContainerToolsConfiglets():
         requests.packages.urllib3.disable_warnings()
         logger.debug(str("Class is connected to CV"))
         assert True
-
 
     @pytest.mark.dependency(depends=["authentication"], scope='class')
     def test_facts_configlets(self):

--- a/tests/unit/test_cv_container_tools.py
+++ b/tests/unit/test_cv_container_tools.py
@@ -23,6 +23,7 @@ CVP_DATA_CONTAINERS_INIT = {
 #   FIXTURES
 # ---------------------------------------------------------------------------- #
 
+
 @pytest.fixture
 def cvp_database(request):
     database = mock.MockCVPDatabase()

--- a/tests/unit/test_cv_facts_tools.py
+++ b/tests/unit/test_cv_facts_tools.py
@@ -17,6 +17,7 @@ LOGGER = setup_custom_logger(__name__)
 #   FIXTURES
 # ---------------------------------------------------------------------------- #
 
+
 @pytest.fixture
 def cvp_database():
     database = mock.MockCVPDatabase(
@@ -57,6 +58,7 @@ def test_CvFactsTools__get_container_name(fact_unit_tools, container_def):
 
 # CvFactsTools.__configletIds_to_configletName
 
+
 @pytest.mark.generic
 @pytest.mark.facts
 @pytest.mark.usefixtures("fact_unit_tools")
@@ -68,6 +70,7 @@ def test_CvFactsTools__configletIds_to_configletName(fact_unit_tools, configlet_
     LOGGER.info('** facts_tool response: %s', str(result))
     assert configlet_def['name'] in result
     LOGGER.info('Configlet name for id %s is %s', str(configlet_def[mock.MockCVPDatabase.FIELD_KEY]), str(result))
+
 
 @pytest.mark.generic
 @pytest.mark.facts
@@ -81,6 +84,7 @@ def test_CvFactsTools__configletIds_to_configletName_empty(fact_unit_tools):
     LOGGER.info('Configlet name for id [] is %s', str(result))
 
 # CvFactsTools.__device_get_configlets
+
 
 @pytest.mark.generic
 @pytest.mark.facts
@@ -96,6 +100,7 @@ def test_CvFactsTools__device_get_configlets_with_configlets(fact_unit_tools, de
         LOGGER.info('Device name %s has configlets %s attached', str(device_def['hostname']), str(result))
     else:
         pytest.skip("skipping DEVICES with no configlet")
+
 
 @pytest.mark.generic
 @pytest.mark.facts
@@ -114,6 +119,7 @@ def test_CvFactsTools__device_get_configlets_no_configlet(fact_unit_tools, devic
 
 # CvFactsTools.__device_get_configlets
 
+
 @pytest.mark.generic
 @pytest.mark.facts
 @pytest.mark.usefixtures("fact_unit_tools")
@@ -128,6 +134,7 @@ def test_CvFactsTools__device_get_configlets_with_configlets(fact_unit_tools, co
         LOGGER.info('Container name for id %s has configlets %s attached', str(container_def[mock.MockCVPDatabase.FIELD_NAME]), str(result))
     else:
         pytest.skip("skipping CONTAINER with no configlet")
+
 
 @pytest.mark.generic
 @pytest.mark.facts

--- a/tests/unit/test_cv_image_tools.py
+++ b/tests/unit/test_cv_image_tools.py
@@ -2,7 +2,8 @@
 # coding: utf-8 -*-
 
 import logging
-import os, tempfile
+import os
+import tempfile
 from pathlib import Path
 from ansible_collections.arista.cvp.plugins.module_utils.image_tools import CvImageTools
 import pytest
@@ -15,6 +16,7 @@ from tests.lib.utils import generate_test_ids_dict
 
 LOGGER = logging.getLogger(__name__)
 
+
 @pytest.fixture
 def cvp_database(request):
     database = mock.MockCVPDatabase()
@@ -26,12 +28,13 @@ def cvp_database(request):
         database.image_bundles.update(request.param.get('image_bundles', []))
     else:
         database = mock.MockCVPDatabase(
-            images = data.CV_IMAGES_PAYLOAD['images'] if 'images' in data.data.CV_IMAGES_PAYLOADS else {},
-            image_bundles = data.CV_IMAGES_PAYLOAD['image_bundles'] if 'image_bundles' in data.data.CV_IMAGES_PAYLOADS else {}
+            images=data.CV_IMAGES_PAYLOAD['images'] if 'images' in data.data.CV_IMAGES_PAYLOADS else {},
+            image_bundles=data.CV_IMAGES_PAYLOAD['image_bundles'] if 'image_bundles' in data.data.CV_IMAGES_PAYLOADS else {}
         )
     LOGGER.info('Initial CVP state: %s', database)
     yield database
     LOGGER.info('Final CVP state: %s', database)
+
 
 @pytest.fixture()
 def image_unit_tool(request, cvp_database):
@@ -50,7 +53,7 @@ def image_unit_tool(request, cvp_database):
 def test_CvImageTools__get_images(image_unit_tool, cvp_database):
     result = image_unit_tool._CvImageTools__get_images()
     LOGGER.info('__get_images response: %s', str(result))
-    if 'data' in cvp_database.images and  len(cvp_database.images['data']) > 0:
+    if 'data' in cvp_database.images and len(cvp_database.images['data']) > 0:
         LOGGER.info('Size of DB is: %s', str(len(cvp_database.images['data'])))
         assert result is True
     else:
@@ -65,7 +68,7 @@ def test_CvImageTools__get_images(image_unit_tool, cvp_database):
 def test_CvImageTools__get_image_bundles(image_unit_tool, cvp_database):
     result = image_unit_tool._CvImageTools__get_image_bundles()
     LOGGER.info('__get_image_bundles response: %s', str(result))
-    if 'data' in cvp_database.images and  len(cvp_database.image_bundles['data']) > 0:
+    if 'data' in cvp_database.images and len(cvp_database.image_bundles['data']) > 0:
         LOGGER.info('Size of DB is: %s', str(len(cvp_database.image_bundles['data'])))
         assert result is True
     else:
@@ -81,7 +84,7 @@ def test_CvImageTools_is_image_present(image_unit_tool, cvp_database):
     if 'data' not in cvp_database.images or len(cvp_database.images['data']) == 0:
         pytest.skip('Not concerned by this test as no image is in DB')
     for image in cvp_database.images['data']:
-        fake_path_file = '/fake/path/to/'+image['imageFileName']
+        fake_path_file = '/fake/path/to/' + image['imageFileName']
         is_filename_found = image_unit_tool.is_image_present(fake_path_file)
         assert is_filename_found is True
         LOGGER.info('Filename (%s) exists on CVP', str(image['imageFileName']))
@@ -99,6 +102,7 @@ def test_CvImageTools_does_bundle_exist(image_unit_tool, cvp_database):
         is_bundle_found = image_unit_tool.does_bundle_exist(bundle['name'])
         assert is_bundle_found is True
         LOGGER.info('Filename (%s) exists on CVP', str(bundle['name']))
+
 
 @pytest.mark.generic
 @pytest.mark.image
@@ -188,8 +192,8 @@ def test_CvImageTools_module_action_get_mode_unsupported(image_unit_tool, cvp_da
     try:
         image_unit_tool.module_action(mode='FAKE', image='', image_list=[], bundle_name=[])
     except mock_ansible.AnsibleFailJson as expected_error:
-            LOGGER.info('received exception: %s', str(expected_error))
-            assert 'Unsupported mode' in str(expected_error)
+        LOGGER.info('received exception: %s', str(expected_error))
+        assert 'Unsupported mode' in str(expected_error)
 
 
 @pytest.mark.generic
@@ -205,7 +209,7 @@ def test_CvImageTools_module_action_get_mode_image(image_unit_tool, cvp_database
 
     LOGGER.info('module_action response: %s', str(result_data))
 
-    if 'images' in result_data and  len(result_data['images']) > 0:
+    if 'images' in result_data and len(result_data['images']) > 0:
         LOGGER.info('Size of DB is: %s', str(len(result_data['images'])))
         assert 'images' in result_data.keys()
         assert len(result_data['images']) == len(cvp_database.image_bundles['data'])
@@ -227,7 +231,7 @@ def test_CvImageTools_module_action_get_mode_images(image_unit_tool, cvp_databas
 
     LOGGER.info('module_action response: %s', str(result_data))
 
-    if 'images' in result_data and  len(result_data['images']) > 0:
+    if 'images' in result_data and len(result_data['images']) > 0:
         LOGGER.info('Size of DB is: %s', str(len(result_data['images'])))
         assert 'images' in result_data.keys()
         assert len(result_data['images']) == len(cvp_database.image_bundles['data'])
@@ -249,7 +253,7 @@ def test_CvImageTools_module_action_get_mode_bundle(image_unit_tool, cvp_databas
 
     LOGGER.info('module_action response: %s', str(result_data))
 
-    if 'bundles' in result_data and  len(result_data['bundles']) > 0:
+    if 'bundles' in result_data and len(result_data['bundles']) > 0:
         LOGGER.info('Size of DB is: %s', str(len(result_data['bundles'])))
         assert 'bundles' in result_data.keys()
         assert len(result_data['bundles']) == len(cvp_database.image_bundles['data'])
@@ -271,13 +275,13 @@ def test_CvImageTools_module_action_get_image_in_bundle_mode_bundle(image_unit_t
         pytest.skip('Not concerned by this test as no image bundle is in DB')
     # Iterate test
     for image in cvp_database.images['data']:
-        expected_image_list = [ image for bundle in cvp_database.image_bundles['data'] if 'imageIds' in bundle.keys() for image in bundle['imageIds'] ]
+        expected_image_list = [image for bundle in cvp_database.image_bundles['data'] if 'imageIds' in bundle.keys() for image in bundle['imageIds']]
         if image['imageFileName'] not in expected_image_list:
             pytest.skip('Image (%s) is not in a bundle', str(image['imageFileName']))
 
         changed_result, result_data, result_warning = image_unit_tool.module_action(
             mode='bundles',
-            image='fake/path/to/'+image['imageFileName'],
+            image='fake/path/to/' + image['imageFileName'],
             image_list=[],
             bundle_name=[]
         )
@@ -287,8 +291,9 @@ def test_CvImageTools_module_action_get_image_in_bundle_mode_bundle(image_unit_t
         LOGGER.info('Change flag is %s', str(changed_result))
         LOGGER.info('Data sent back is %s', str(result_data))
         LOGGER.info('Warning is %s', str(result_warning))
-        assert image['imageFileName'] in [ image for bundle in result_data['bundles'] if 'imageIds' in bundle.keys() for image in bundle['imageIds'] ]
+        assert image['imageFileName'] in [image for bundle in result_data['bundles'] if 'imageIds' in bundle.keys() for image in bundle['imageIds']]
         LOGGER.info('Tested image is correctly returned by ')
+
 
 @pytest.mark.generic
 @pytest.mark.image
@@ -354,6 +359,7 @@ def test_CvImageTools_module_action_get_mode_image_action_delete_not_supported(i
         LOGGER.info('module_action warning: %s', str(result_warning))
         LOGGER.info('module_action change: %s', str(changed_result))
         assert False
+
 
 @pytest.mark.generic
 @pytest.mark.image

--- a/tests/unit/test_cv_response.py
+++ b/tests/unit/test_cv_response.py
@@ -78,8 +78,8 @@ class TestCvReponseAction():
         api_result.add_entry(entry="action3")
         assert api_result.results["success"]
         assert api_result.results["changed"]
-        assert api_result.results[api_results_name+"_count"] == 3
-        assert len(api_result.results[api_results_name+"_list"]) == 3
+        assert api_result.results[api_results_name + "_count"] == 3
+        assert len(api_result.results[api_results_name + "_list"]) == 3
         logging.info("API strct result is {}".format(api_result.results))
 
 
@@ -115,7 +115,7 @@ class TestCvReponseManager():
         api_result.success = True
         api_manager.add_change(change=api_result)
         assert api_manager.success
-        assert int(api_manager.changes[management_name+"_count"]) == 3
+        assert int(api_manager.changes[management_name + "_count"]) == 3
         assert api_manager.changes[management_name +
                                    "_list"] == [api_results_name]
         logging.info("API Manager strct result is {}".format(

--- a/tests/unit/test_device_element.py
+++ b/tests/unit/test_device_element.py
@@ -15,6 +15,7 @@ from ansible_collections.arista.cvp.plugins.module_utils.resources.api.fields im
 from tests.lib.parametrize import generate_flat_data
 from tests.lib.utils import generate_container_ids
 
+
 @pytest.mark.generic
 @pytest.mark.parametrize("DEVICE", generate_flat_data(type="device"))
 class TestDeviceElement():


### PR DESCRIPTION
## Change Summary

Add autopep8 to pre-commit hooks and configure with .pep8 file as required by Ansible linter.
Do a run to sanitize the repo.

## Component(s) name

pre-commit

## Proposed changes
Added hook using https://github.com/pre-commit/mirrors-autopep8
Configure via .pep8 as per Ansible linter requirements when running `make sanity`
Propose new Makefile targets

## How to test
pre-commit run autopep8 --all-files

### User Checklist

Done

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
