### PR TITLE
Fix(cv_device_v3): fix device lookup to use search_key instead of FQDN always - issue456

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -1312,7 +1312,7 @@ class CvDeviceTools(object):
                     device_mac=device.system_mac)
                 MODULE_LOGGER.debug('Device {0} is currently under {1}'.format(
                     device.fqdn, current_container_info[Api.generic.NAME]))
-                device_info = self.get_device_facts(device_lookup=device.fqdn)
+                device_info = self.get_device_facts(device_lookup=device.info[self.__search_by])
                 if (current_container_info[Api.generic.NAME] == Api.container.UNDEFINED_CONTAINER_NAME):
                     if self.__check_mode:
                         result_data.changed = True


### PR DESCRIPTION
## Change Summary

When devices are in ZTP mode and if the fqdn is not set via DHCP the device lookup fails as it always tries to use the fqdn



## Related Issue(s)

Fixes #456 

## Component(s) name

`arista.cvp.cv_device_v3`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

in DHCP don't set the hostname, sample config:

```
host tp-avd-leaf1 {
       hardware ethernet 50:08:00:03:00:00;
       fixed-address 192.0.2.214;
       option bootfile-name "http://192.0.2.79/ztp/bootstrap";
       option routers 192.0.2.1;
       option domain-name-servers 192.0.2.10, 192.0.2.40;
}
```

wait for the device to come back in ztp mode and try to assign configlets to it with a playbook like below and setting ` search_key: 'serialNumber'`

```
---
- name: lab06 - cv_device_v3 lab
  hosts: cv_server
  connection: local
  gather_facts: no
  vars:
    CVP_CONFIGLETS:
      tp-avd_tp-avd-leaf1: ""
      vlan144: ""
      d1b1ef84-dc16-4279-a494-4f0fd81b25ad_BAD032986065E8DC14CBB6472EC314A6: ""

    CVP_DEVICES:
      - fqdn: 'tp-avd-leaf1'
        parentContainerName: TP_LEAF1
        configlets:
        - tp-avd_tp-avd-leaf1
        - vlan144
        serialNumber: BAD032986065E8DC14CBB6472EC314A6
  tasks:
    - name: "Configure devices on {{inventory_hostname}}"
      arista.cvp.cv_device_v3:
        devices: "{{CVP_DEVICES}}"
        search_key: 'serialNumber'
        state: present
      register: CVP_DEVICES_RESULTS
```

that should be successful and not throw the error messages thrown before

```
      File "/var/folders/xj/58jh5s5x05n4d_hcd_ybhgmr0000gq/T/ansible_arista.cvp.cv_device_v3_payload_vcyk01o6/ansible_arista.cvp.cv_device_v3_payload.zip/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py", line 1307, in deploy_device
      File "/Users/tamas/go/src/github.com/cvprac/cvprac/cvp_api.py", line 2856, in deploy_device
        info = 'Deploy device %s to container %s' % (device['fqdn'], container)
    KeyError: 'fqdn'
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: 1
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code has been rebased from devel before I start
- [x ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
