### PR TITLE
Fix: changed pytest to check for a warning

### DIFF
--- a/tests/unit/test_cv_image_tools.py
+++ b/tests/unit/test_cv_image_tools.py
@@ -369,19 +369,12 @@ def test_CvImageTools_module_action_get_mode_image_action_add_already_exist(imag
         fake_image_path = os.path.join(fake_folder, image['imageFileName'])
         Path(fake_image_path).touch(exist_ok=True)
         LOGGER.info('Test Path is %s', str(fake_image_path))
-        try:
-            changed_result, result_data, result_warning = image_unit_tool.module_action(
-                action='add',
-                mode='image',
-                image=fake_image_path,
-                image_list=[],
-                bundle_name=[]
-            )
-        except mock_ansible.AnsibleFailJson as expected_error:
-            LOGGER.info('received exception: %s', str(expected_error))
-            assert 'Image already present on server' in str(expected_error)
-        else:
-            LOGGER.info('module_action response: %s', str(result_data))
-            LOGGER.info('module_action warning: %s', str(result_warning))
-            LOGGER.info('module_action change: %s', str(changed_result))
-            assert False
+        _, _, result_warning = image_unit_tool.module_action(
+            action='add',
+            mode='image',
+            image=fake_image_path,
+            image_list=[],
+            bundle_name=[]
+        )
+        LOGGER.info('received warning: %s', str(result_warning))
+        assert 'Image already present on server' in result_warning[0]


### PR DESCRIPTION
## Change Summary

Changed pytest to check for a warning instead of an exception when adding an image that already exists

## Related Issue(s)

Fixes #484

## Component(s) name

`arista.cvp.cv_image_v3`
and all other components since pytest is run by CI for all PRs

## Proposed changes
Changed the pytest: unit/test_cv_image_tools.py::test_CvImageTools_module_action_get_mode_image_action_add_already_exist
to check for warning message instead of an exception

## How to test
`(bash)$ pytest unit/test_cv_image_tools.py::test_CvImageTools_module_action_get_mode_image_action_add_already_exist`

## Checklist

### User Checklist
- N/A

### Repository Checklist
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
