### PR TITLE
Feat(cv_facts_v3): Show assigned image bundles on devices and containers

### DIFF
--- a/ansible_collections/arista/cvp/docs/how-to/v3/cv_facts_v3.md
+++ b/ansible_collections/arista/cvp/docs/how-to/v3/cv_facts_v3.md
@@ -70,6 +70,7 @@ ok: [CloudVision] =>
         CVPRACTEST:
           configlets: []
           parentContainerName: ansible-tests
+          image_bundle: ""
       cvp_devices:
       - configlets:
         - leaf-2-unit-test
@@ -82,12 +83,14 @@ ok: [CloudVision] =>
         parentContainerName: ansible-tests
         serialNumber: A2BC886CB9408A0453A3CFDD9C251999
         systemMacAddress: 50:00:00:d5:5d:c0
+        image_bundle: ""
       - configlets: []
         fqdn: leaf-2-unit-test.ire.aristanetworks.com
         hostname: leaf-2-unit-test
         parentContainerName: ansible-tests
         serialNumber: 08A7E527AF711F688A6AD7D78BB5AD0A
         systemMacAddress: 50:00:00:cb:38:c2
+        image_bundle: ""
       - configlets:
         - test_configlet
         fqdn: leaf-2-unit-test.ire.aristanetworks.com
@@ -95,6 +98,7 @@ ok: [CloudVision] =>
         parentContainerName: ansible-tests
         serialNumber: 24666013EF2271599935B4A894F356E1
         systemMacAddress: 50:00:00:03:37:66
+        image_bundle: ""
     failed: false
 ```
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -410,9 +410,22 @@ class CvFactsTools():
         return self.__configletIds_to_configletName(configletIds=configletIds)
 
 
-    def __container_get_image_bundle(self, container_id):
-        current_image_bundle = []
-        bundle_data = {}
+    def __container_get_image_bundle_name(self, container_id):
+        """
+        __container_get_image_bundle_name Get the name of the image bundle attached to a container
+
+        Parameters
+        ----------
+        container_id : str
+            CVP Key for the container
+
+        Returns
+        -------
+        Str
+            The name of the image bundle, if assigned.
+        """
+        bundle_name = None
+
         try:
             bundle = self.__cv_client.api.get_image_bundle_by_container_id(container_id)
         except CvpApiError as error_msg:
@@ -420,16 +433,13 @@ class CvFactsTools():
         
         MODULE_LOGGER.debug('Bundle data assigned to container: %s', str(bundle) )
         if len(bundle['imageBundleList']) == 1:
-            bundle_data[Api.image.NAME] = bundle['imageBundleList'][0]['name']
-            bundle_data[Api.image.ID] = bundle['imageBundleList'][0]['key']
-            bundle_data[Api.image.TYPE] = bundle['imageBundleMapper'][bundle_data[Api.image.ID]]['type']
-            current_image_bundle.append(bundle_data)
+            bundle_name = bundle['imageBundleList'][0]['name']
         elif len(bundle['imageBundleList']) > 1:
             MODULE_LOGGER.error('Number of image bundles is > 1 on %s', str(container_id) )
         else:
             pass
         
-        return current_image_bundle
+        return bundle_name
 
 
     # Fact management
@@ -477,7 +487,7 @@ class CvFactsTools():
             if container[Api.generic.NAME] != 'Tenant':
                 MODULE_LOGGER.debug('Got following information for container: %s', str(container))
                 container[Api.generic.CONFIGLETS] = self.__containers_get_configlets(container_id=container[Api.container.KEY])
-                container[Api.generic.IMAGE_BUNDLE] = self.__container_get_image_bundle(container_id=container[Api.container.KEY])
+                container[Api.generic.IMAGE_BUNDLE] = self.__container_get_image_bundle_name(container_id=container[Api.container.KEY])
                 facts_builder.add(container)
         self._facts[FactsResponseFields.CONTAINER] = facts_builder.get(resource_model='container')
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -424,7 +424,7 @@ class CvFactsTools():
         Str
             The name of the image bundle, if assigned.
         """
-        bundle_name = None
+        bundle_name = ''
 
         try:
             bundle = self.__cv_client.api.get_image_bundle_by_container_id(container_id)
@@ -470,9 +470,7 @@ class CvFactsTools():
                     facts_builder.add(self.__device_update_info(device=device))
                 else:
                     device[Api.generic.CONFIGLETS] = self.__device_get_configlets(netid=device[Api.generic.KEY])
-                    image_bundle = self.__cv_client.api.get_device_image_info(device[Api.generic.KEY])
-                    if image_bundle is not None:
-                        device[Api.generic.IMAGE_BUNDLE] = image_bundle
+                    device[Api.generic.IMAGE_BUNDLE] = self.__cv_client.api.get_device_image_info(device[Api.generic.KEY])
                     
                     facts_builder.add(device)
         self._facts[FactsResponseFields.DEVICE] = facts_builder.get(resource_model='device', verbose=verbose)
@@ -490,9 +488,7 @@ class CvFactsTools():
             if container[Api.generic.NAME] != 'Tenant':
                 MODULE_LOGGER.debug('Got following information for container: %s', str(container))
                 container[Api.generic.CONFIGLETS] = self.__containers_get_configlets(container_id=container[Api.container.KEY])
-                image_bundle = self.__container_get_image_bundle_name(container_id=container[Api.container.KEY])
-                if image_bundle is not None:
-                    container[Api.generic.IMAGE_BUNDLE] = image_bundle
+                container[Api.generic.IMAGE_BUNDLE] = self.__container_get_image_bundle_name(container_id=container[Api.container.KEY])
                 facts_builder.add(container)
         self._facts[FactsResponseFields.CONTAINER] = facts_builder.get(resource_model='container')
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -454,7 +454,7 @@ class CvFactsTools():
                 MODULE_LOGGER.debug('Got following information for container: %s', str(container))
                 container[Api.generic.CONFIGLETS] = self.__containers_get_configlets(container_id=container[Api.container.KEY])
                 container[Api.container.IMAGE_BUNDLE] = self.__cv_client.api.get_image_bundle_by_container_id(container[Api.container.KEY])
-                MODULE_LOGGER.debug('%s container is assigned to %s', (str(container[Api.generic.NAME]), str(container[Api.container.IMAGE_BUNDLE])))
+                MODULE_LOGGER.debug('The following bundle is assigned: %s' % str(self.__cv_client.api.get_image_bundle_by_container_id(container[Api.container.KEY])))
                 facts_builder.add(container)
         self._facts[FactsResponseFields.CONTAINER] = facts_builder.get(resource_model='container')
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -430,12 +430,12 @@ class CvFactsTools():
             bundle = self.__cv_client.api.get_image_bundle_by_container_id(container_id)
         except CvpApiError as error_msg:
             MODULE_LOGGER.error('Error when collecting container bundle facts: %s', str(error_msg))
-        
-        MODULE_LOGGER.debug('Bundle data assigned to container: %s', str(bundle) )
+
+        MODULE_LOGGER.debug('Bundle data assigned to container: %s', str(bundle))
         if len(bundle['imageBundleList']) == 1:
             bundle_name = bundle['imageBundleList'][0]['name']
         elif len(bundle['imageBundleList']) > 1:
-            MODULE_LOGGER.error('Number of image bundles is > 1 on %s', str(container_id) )
+            MODULE_LOGGER.error('Number of image bundles is > 1 on %s', str(container_id))
         else:
             pass
         return bundle_name
@@ -461,10 +461,10 @@ class CvFactsTools():
             bundle = self.__cv_client.api.get_device_image_info(device_id)
         except CvpApiError as error_msg:
             MODULE_LOGGER.error('Error when collecting device bundle facts: %s', str(error_msg))
-        
-        MODULE_LOGGER.debug('Bundle data assigned to container: %s', str(bundle) )
+
+        MODULE_LOGGER.debug('Bundle data assigned to container: %s', str(bundle))
         if bundle['bundleName'] is not None:
-            return bundle['bundleName']    
+            return bundle['bundleName']
         else:
             return bundle_name
 
@@ -497,7 +497,7 @@ class CvFactsTools():
                 else:
                     device[Api.generic.CONFIGLETS] = self.__device_get_configlets(netid=device[Api.generic.KEY])
                     device[Api.generic.IMAGE_BUNDLE] = self.__device_get_image_bundle_name(device[Api.generic.KEY])
-                    
+
                     facts_builder.add(device)
         self._facts[FactsResponseFields.DEVICE] = facts_builder.get(resource_model='device', verbose=verbose)
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -438,9 +438,35 @@ class CvFactsTools():
             MODULE_LOGGER.error('Number of image bundles is > 1 on %s', str(container_id) )
         else:
             pass
-        
         return bundle_name
 
+
+    def __device_get_image_bundle_name(self, device_id):
+        """
+        __device_get_image_bundle_name Get the name of the image bundle attached to a device
+
+        Parameters
+        ----------
+        device_id : str
+            MAC address/key for the device
+
+        Returns
+        -------
+        Str
+            The name of the image bundle, if assigned.
+        """
+        bundle_name = ''
+
+        try:
+            bundle = self.__cv_client.api.get_device_image_info(device_id)
+        except CvpApiError as error_msg:
+            MODULE_LOGGER.error('Error when collecting device bundle facts: %s', str(error_msg))
+        
+        MODULE_LOGGER.debug('Bundle data assigned to container: %s', str(bundle) )
+        if bundle['bundleName'] is not None:
+            return bundle['bundleName']    
+        else:
+            return bundle_name
 
     # Fact management
 
@@ -470,7 +496,7 @@ class CvFactsTools():
                     facts_builder.add(self.__device_update_info(device=device))
                 else:
                     device[Api.generic.CONFIGLETS] = self.__device_get_configlets(netid=device[Api.generic.KEY])
-                    device[Api.generic.IMAGE_BUNDLE] = self.__cv_client.api.get_device_image_info(device[Api.generic.KEY])
+                    device[Api.generic.IMAGE_BUNDLE] = self.__device_get_image_bundle_name(device[Api.generic.KEY])
                     
                     facts_builder.add(device)
         self._facts[FactsResponseFields.DEVICE] = facts_builder.get(resource_model='device', verbose=verbose)

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -423,14 +423,13 @@ class CvFactsTools():
             bundle_data[Api.image.NAME] = bundle['imageBundleList'][0]['name']
             bundle_data[Api.image.ID] = bundle['imageBundleList'][0]['key']
             bundle_data[Api.image.TYPE] = bundle['imageBundleMapper'][bundle_data[Api.image.ID]]['type']
+            current_image_bundle.append(bundle_data)
         elif len(bundle['imageBundleList']) > 1:
             MODULE_LOGGER.error('Number of image bundles is > 1 on %s', str(container_id) )
         else:
-            bundle_data[Api.image.NAME] = None
-            bundle_data[Api.image.ID] = None
-            bundle_data[Api.image.TYPE] = None
+            pass
         
-        return current_image_bundle.append(bundle_data)
+        return current_image_bundle
 
 
     # Fact management

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -409,6 +409,22 @@ class CvFactsTools():
         MODULE_LOGGER.debug('** Configlet IDs are %s', str(configletIds))
         return self.__configletIds_to_configletName(configletIds=configletIds)
 
+
+    def __container_get_image_bundle(self, container_id):
+        current_image_bundle = []
+        bundle_data = {}
+        try:
+            bundle = self.__cv_client.api.get_image_bundle_by_container_id(container_id)
+        except CvpApiError as error_msg:
+            MODULE_LOGGER.error('Error when collecting container bundle facts: %s', str(error_msg))
+        
+        bundle_data[Api.image.NAME] = bundle['imageBundleList'][0]['name']
+        bundle_data[Api.image.ID] = bundle['imageBundleList'][0]['key']
+        bundle_data[Api.image.TYPE] = bundle['imageBundleMapper'][bundle_data[Api.image.ID]]['type']
+        
+        return current_image_bundle.append(bundle_data)
+
+
     # Fact management
 
     def __fact_devices(self, filter: str = '.*', verbose: bool = False):
@@ -454,8 +470,7 @@ class CvFactsTools():
             if container[Api.generic.NAME] != 'Tenant':
                 MODULE_LOGGER.debug('Got following information for container: %s', str(container))
                 container[Api.generic.CONFIGLETS] = self.__containers_get_configlets(container_id=container[Api.container.KEY])
-                container[Api.generic.IMAGE_BUNDLE] = self.__cv_client.api.get_image_bundle_by_container_id(container[Api.container.KEY])
-                MODULE_LOGGER.debug('The following bundle is assigned: %s' % str(self.__cv_client.api.get_image_bundle_by_container_id(container[Api.container.KEY])))
+                container[Api.generic.IMAGE_BUNDLE] = self.__container_get_image_bundle(container_id=container[Api.container.KEY])
                 facts_builder.add(container)
         self._facts[FactsResponseFields.CONTAINER] = facts_builder.get(resource_model='container')
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -454,6 +454,7 @@ class CvFactsTools():
                 MODULE_LOGGER.debug('Got following information for container: %s', str(container))
                 container[Api.generic.CONFIGLETS] = self.__containers_get_configlets(container_id=container[Api.container.KEY])
                 container[Api.container.IMAGE_BUNDLE] = self.__cv_client.api.get_image_bundle_by_container_id(container[Api.container.KEY])
+                MODULE_LOGGER.debug('%s container is assigned to %s', (str(container), str(container[Api.container.IMAGE_BUNDLE])))
                 facts_builder.add(container)
         self._facts[FactsResponseFields.CONTAINER] = facts_builder.get(resource_model='container')
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -419,10 +419,12 @@ class CvFactsTools():
             MODULE_LOGGER.error('Error when collecting container bundle facts: %s', str(error_msg))
         
         MODULE_LOGGER.debug('Bundle data assigned to container: %s', str(bundle) )
-        if len(bundle['imageBundleList'][0] > 0):
+        if len(bundle['imageBundleList'] == 1):
             bundle_data[Api.image.NAME] = bundle['imageBundleList'][0]['name']
             bundle_data[Api.image.ID] = bundle['imageBundleList'][0]['key']
             bundle_data[Api.image.TYPE] = bundle['imageBundleMapper'][bundle_data[Api.image.ID]]['type']
+        elif len(bundle['imageBundleList'] == 1) > 1:
+            MODULE_LOGGER.error('Number of image bundles is > 1 on %s', str(container_id) )
         else:
             bundle_data[Api.image.NAME] = None
             bundle_data[Api.image.ID] = None

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -83,7 +83,7 @@ class CvFactResource():
                 Api.device.SERIAL,
                 Api.device.SYSMAC,
                 Api.generic.CONFIGLETS,
-                Api.device.IMAGE_BUNDLE,
+                Api.generic.IMAGE_BUNDLE,
             ]
         }
         fact[Api.generic.PARENT_CONTAINER_NAME] = device_fact[Api.device.CONTAINER_NAME]

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -418,6 +418,7 @@ class CvFactsTools():
         except CvpApiError as error_msg:
             MODULE_LOGGER.error('Error when collecting container bundle facts: %s', str(error_msg))
         
+        MODULE_LOGGER.debug('Bundle data assigned to container: %s', str(bundle) )
         bundle_data[Api.image.NAME] = bundle['imageBundleList'][0]['name']
         bundle_data[Api.image.ID] = bundle['imageBundleList'][0]['key']
         bundle_data[Api.image.TYPE] = bundle['imageBundleMapper'][bundle_data[Api.image.ID]]['type']

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -470,7 +470,10 @@ class CvFactsTools():
                     facts_builder.add(self.__device_update_info(device=device))
                 else:
                     device[Api.generic.CONFIGLETS] = self.__device_get_configlets(netid=device[Api.generic.KEY])
-                    device[Api.generic.IMAGE_BUNDLE] = self.__cv_client.api.get_device_image_info(device[Api.generic.KEY])
+                    image_bundle = self.__cv_client.api.get_device_image_info(device[Api.generic.KEY])
+                    if image_bundle is not None:
+                        device[Api.generic.IMAGE_BUNDLE] = image_bundle
+                    
                     facts_builder.add(device)
         self._facts[FactsResponseFields.DEVICE] = facts_builder.get(resource_model='device', verbose=verbose)
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -139,7 +139,8 @@ class CvFactResource():
         if isinstance(self._cache, list):
             return {entry[Api.generic.NAME]: {
                 Api.generic.PARENT_CONTAINER_NAME: entry[Api.container.PARENT_NAME],
-                Api.generic.CONFIGLETS: entry[Api.generic.CONFIGLETS]}
+                Api.generic.CONFIGLETS: entry[Api.generic.CONFIGLETS],
+                Api.container.IMAGE_BUNDLE: entry[Api.container.IMAGE_BUNDLE]}
                 for entry in self._cache if Api.generic.NAME in entry.keys()}
 
     def _get_device(self, verbose: bool = False):

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -454,7 +454,7 @@ class CvFactsTools():
                 MODULE_LOGGER.debug('Got following information for container: %s', str(container))
                 container[Api.generic.CONFIGLETS] = self.__containers_get_configlets(container_id=container[Api.container.KEY])
                 container[Api.container.IMAGE_BUNDLE] = self.__cv_client.api.get_image_bundle_by_container_id(container[Api.container.KEY])
-                MODULE_LOGGER.debug('%s container is assigned to %s', (str(container), str(container[Api.container.IMAGE_BUNDLE])))
+                MODULE_LOGGER.debug('%s container is assigned to %s', (str(container[Api.generic.NAME]), str(container[Api.container.IMAGE_BUNDLE])))
                 facts_builder.add(container)
         self._facts[FactsResponseFields.CONTAINER] = facts_builder.get(resource_model='container')
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -419,11 +419,11 @@ class CvFactsTools():
             MODULE_LOGGER.error('Error when collecting container bundle facts: %s', str(error_msg))
         
         MODULE_LOGGER.debug('Bundle data assigned to container: %s', str(bundle) )
-        if len(bundle['imageBundleList'] == 1):
+        if len(bundle['imageBundleList']) == 1:
             bundle_data[Api.image.NAME] = bundle['imageBundleList'][0]['name']
             bundle_data[Api.image.ID] = bundle['imageBundleList'][0]['key']
             bundle_data[Api.image.TYPE] = bundle['imageBundleMapper'][bundle_data[Api.image.ID]]['type']
-        elif len(bundle['imageBundleList'] == 1) > 1:
+        elif len(bundle['imageBundleList']) > 1:
             MODULE_LOGGER.error('Number of image bundles is > 1 on %s', str(container_id) )
         else:
             bundle_data[Api.image.NAME] = None

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -453,7 +453,7 @@ class CvFactsTools():
             if container[Api.generic.NAME] != 'Tenant':
                 MODULE_LOGGER.debug('Got following information for container: %s', str(container))
                 container[Api.generic.CONFIGLETS] = self.__containers_get_configlets(container_id=container[Api.container.KEY])
-                container[Api.container.IMAGE_BUNDLE] = self.__cv_client.api.get_image_bundle_by_container_id(container_id=container[Api.container.KEY])
+                container[Api.container.IMAGE_BUNDLE] = self.__cv_client.api.get_image_bundle_by_container_id(container[Api.container.KEY])
                 facts_builder.add(container)
         self._facts[FactsResponseFields.CONTAINER] = facts_builder.get(resource_model='container')
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -409,7 +409,6 @@ class CvFactsTools():
         MODULE_LOGGER.debug('** Configlet IDs are %s', str(configletIds))
         return self.__configletIds_to_configletName(configletIds=configletIds)
 
-
     def __container_get_image_bundle_name(self, container_id):
         """
         __container_get_image_bundle_name Get the name of the image bundle attached to a container
@@ -440,7 +439,6 @@ class CvFactsTools():
             pass
         return bundle_name
 
-
     def __device_get_image_bundle_name(self, device_id):
         """
         __device_get_image_bundle_name Get the name of the image bundle attached to a device
@@ -469,7 +467,6 @@ class CvFactsTools():
             return bundle_name
 
     # Fact management
-
     def __fact_devices(self, filter: str = '.*', verbose: bool = False):
         """
         __fact_devices Collect facts related to device inventory

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -419,9 +419,14 @@ class CvFactsTools():
             MODULE_LOGGER.error('Error when collecting container bundle facts: %s', str(error_msg))
         
         MODULE_LOGGER.debug('Bundle data assigned to container: %s', str(bundle) )
-        bundle_data[Api.image.NAME] = bundle['imageBundleList'][0]['name']
-        bundle_data[Api.image.ID] = bundle['imageBundleList'][0]['key']
-        bundle_data[Api.image.TYPE] = bundle['imageBundleMapper'][bundle_data[Api.image.ID]]['type']
+        if len(bundle['imageBundleList'][0] > 0):
+            bundle_data[Api.image.NAME] = bundle['imageBundleList'][0]['name']
+            bundle_data[Api.image.ID] = bundle['imageBundleList'][0]['key']
+            bundle_data[Api.image.TYPE] = bundle['imageBundleMapper'][bundle_data[Api.image.ID]]['type']
+        else:
+            bundle_data[Api.image.NAME] = None
+            bundle_data[Api.image.ID] = None
+            bundle_data[Api.image.TYPE] = None
         
         return current_image_bundle.append(bundle_data)
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -490,7 +490,9 @@ class CvFactsTools():
             if container[Api.generic.NAME] != 'Tenant':
                 MODULE_LOGGER.debug('Got following information for container: %s', str(container))
                 container[Api.generic.CONFIGLETS] = self.__containers_get_configlets(container_id=container[Api.container.KEY])
-                container[Api.generic.IMAGE_BUNDLE] = self.__container_get_image_bundle_name(container_id=container[Api.container.KEY])
+                image_bundle = self.__container_get_image_bundle_name(container_id=container[Api.container.KEY])
+                if image_bundle is not None:
+                    container[Api.generic.IMAGE_BUNDLE] = image_bundle
                 facts_builder.add(container)
         self._facts[FactsResponseFields.CONTAINER] = facts_builder.get(resource_model='container')
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -140,7 +140,7 @@ class CvFactResource():
             return {entry[Api.generic.NAME]: {
                 Api.generic.PARENT_CONTAINER_NAME: entry[Api.container.PARENT_NAME],
                 Api.generic.CONFIGLETS: entry[Api.generic.CONFIGLETS],
-                Api.container.IMAGE_BUNDLE: entry[Api.container.IMAGE_BUNDLE]}
+                Api.generic.IMAGE_BUNDLE: entry[Api.generic.IMAGE_BUNDLE]}
                 for entry in self._cache if Api.generic.NAME in entry.keys()}
 
     def _get_device(self, verbose: bool = False):
@@ -437,7 +437,7 @@ class CvFactsTools():
                     facts_builder.add(self.__device_update_info(device=device))
                 else:
                     device[Api.generic.CONFIGLETS] = self.__device_get_configlets(netid=device[Api.generic.KEY])
-                    device[Api.device.IMAGE_BUNDLE] = self.__cv_client.api.get_device_image_info(device[Api.generic.KEY])
+                    device[Api.generic.IMAGE_BUNDLE] = self.__cv_client.api.get_device_image_info(device[Api.generic.KEY])
                     facts_builder.add(device)
         self._facts[FactsResponseFields.DEVICE] = facts_builder.get(resource_model='device', verbose=verbose)
 
@@ -454,7 +454,7 @@ class CvFactsTools():
             if container[Api.generic.NAME] != 'Tenant':
                 MODULE_LOGGER.debug('Got following information for container: %s', str(container))
                 container[Api.generic.CONFIGLETS] = self.__containers_get_configlets(container_id=container[Api.container.KEY])
-                container[Api.container.IMAGE_BUNDLE] = self.__cv_client.api.get_image_bundle_by_container_id(container[Api.container.KEY])
+                container[Api.generic.IMAGE_BUNDLE] = self.__cv_client.api.get_image_bundle_by_container_id(container[Api.container.KEY])
                 MODULE_LOGGER.debug('The following bundle is assigned: %s' % str(self.__cv_client.api.get_image_bundle_by_container_id(container[Api.container.KEY])))
                 facts_builder.add(container)
         self._facts[FactsResponseFields.CONTAINER] = facts_builder.get(resource_model='container')

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -83,6 +83,7 @@ class CvFactResource():
                 Api.device.SERIAL,
                 Api.device.SYSMAC,
                 Api.generic.CONFIGLETS,
+                Api.device.IMAGE_BUNDLE,
             ]
         }
         fact[Api.generic.PARENT_CONTAINER_NAME] = device_fact[Api.device.CONTAINER_NAME]
@@ -435,6 +436,7 @@ class CvFactsTools():
                     facts_builder.add(self.__device_update_info(device=device))
                 else:
                     device[Api.generic.CONFIGLETS] = self.__device_get_configlets(netid=device[Api.generic.KEY])
+                    device[Api.device.IMAGE_BUNDLE] = self.__cv_client.api.get_device_image_info(device[Api.generic.KEY])
                     facts_builder.add(device)
         self._facts[FactsResponseFields.DEVICE] = facts_builder.get(resource_model='device', verbose=verbose)
 
@@ -451,6 +453,7 @@ class CvFactsTools():
             if container[Api.generic.NAME] != 'Tenant':
                 MODULE_LOGGER.debug('Got following information for container: %s', str(container))
                 container[Api.generic.CONFIGLETS] = self.__containers_get_configlets(container_id=container[Api.container.KEY])
+                container[Api.container.IMAGE_BUNDLE] = self.__cv_client.api.get_image_bundle_by_container_id(container_id=container[Api.container.KEY])
                 facts_builder.add(container)
         self._facts[FactsResponseFields.CONTAINER] = facts_builder.get(resource_model='container')
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/resources/api/fields.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/resources/api/fields.py
@@ -80,6 +80,14 @@ class ApiDevice():
 
 
 # @dataclass
+class ApiImageBundle():
+    """Keys specific to image bundle resources"""
+    NAME: str = 'bundleName'
+    ID: str = 'imageBundleId'
+    TYPE: str = 'type'
+
+
+# @dataclass
 class ApiConfiglet():
     """Keys specific to Configlet resources"""
     ID: str = 'configletId'
@@ -106,3 +114,4 @@ class Api():
     generic: ApiGeneric = ApiGeneric
     mappers: ApiMappers = ApiMappers
     task: ApiTask = ApiTask
+    image: ApiImageBundle = ApiImageBundle

--- a/ansible_collections/arista/cvp/plugins/module_utils/resources/api/fields.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/resources/api/fields.py
@@ -59,6 +59,7 @@ class ApiContainer():
     COUNT_CONTAINER: str = 'childContainerCount'
     COUNT_DEVICE: str = 'childNetElementCount'
     ID: str = 'containerId'
+    IMAGE_BUNDLE: str = 'image_bundle'
     KEY: str = 'Key'
     TOPOLOGY: str = 'topology'
     UNDEFINED_CONTAINER_ID: str = 'undefined_container'

--- a/ansible_collections/arista/cvp/plugins/module_utils/resources/api/fields.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/resources/api/fields.py
@@ -49,6 +49,7 @@ class ApiGeneric():
     NAME: str = 'name'
     PARENT_CONTAINER_ID: str = 'parentContainerId'
     PARENT_CONTAINER_NAME: str = 'parentContainerName'
+    IMAGE_BUNDLE: str = 'image_bundle'
 
 
 # @dataclass
@@ -59,7 +60,6 @@ class ApiContainer():
     COUNT_CONTAINER: str = 'childContainerCount'
     COUNT_DEVICE: str = 'childNetElementCount'
     ID: str = 'containerId'
-    IMAGE_BUNDLE: str = 'image_bundle'
     KEY: str = 'Key'
     TOPOLOGY: str = 'topology'
     UNDEFINED_CONTAINER_ID: str = 'undefined_container'
@@ -74,7 +74,6 @@ class ApiDevice():
     FQDN: str = 'fqdn'
     HOSTNAME: str = 'hostname'
     ID: str = 'key'
-    IMAGE_BUNDLE: str = 'image_bundle'
     SERIAL: str = 'serialNumber'
     SYSMAC: str = 'systemMacAddress'
     PARENT_CONTAINER_KEY: str = 'parentContainerKey'

--- a/ansible_collections/arista/cvp/plugins/module_utils/resources/modules/fields.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/resources/modules/fields.py
@@ -40,6 +40,7 @@ class FactsResponseFields():
     CONFIGLET: str = 'cvp_configlets'
     CONTAINER: str = 'cvp_containers'
     DEVICE: str = 'cvp_devices'
+    IMAGE_BUNDLE: str = 'cvp_image_bundle'
 
 
 # @dataclass


### PR DESCRIPTION
## Change Summary

Add the info on assigned image bundle to the device and container info

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.cvp.cv_facts_v3`

## Proposed changes
Add an additional key `image_bundle` with the name of the assigned image (or an empty string, if not)

```
cvp_containers {               
       "Undefined": {
                    "configlets": [],
                    "image_bundle": "EOS-4.25.4M",
                    "parentContainerName": "Tenant"
                },
                "test": {
                    "configlets": [],
                    "image_bundle": "",
                    "parentContainerName": "Tenant"
                },
```
```
cvp_devices {
                {
                    "configlets": [
                        "DC1-AVD_DC1-LEAF-3a"
                    ],
                    "fqdn": "DC1-LEAF-3a",
                    "hostname": "DC1-LEAF-3a",
                    "image_bundle": "",
                    "parentContainerName": "DC1_LEAF3",
                    "serialNumber": "567C2AB3BD50F6CE7C897783405AB04A",
                    "systemMacAddress": "50:78:00:50:37:0f"
                },
                {
                    "configlets": [
                        "DC1-AVD_DC1-SPINE-1"
                    ],
                    "fqdn": "DC1-SPINE-1",
                    "hostname": "DC1-SPINE-1",
                    "image_bundle": "EOS-4.25.4M",
                    "parentContainerName": "DC1_SPINES",
                    "serialNumber": "9B8CB6BCCCFE0D107D1951EFB557D7B4",
                    "systemMacAddress": "50:78:00:54:5e:26"
                },
```
<!--- Describe data model implemented for new features -->

## How to test
Tested with
- cvprac 1.0.7
- CVP 2021.2.2

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
