### PR TITLE
Doc: Release notes from v3.4.0

### DIFF
--- a/ansible_collections/arista/cvp/docs/release-notes/v3.x.md
+++ b/ansible_collections/arista/cvp/docs/release-notes/v3.x.md
@@ -25,7 +25,7 @@ Full release note available on [github](https://github.com/aristanetworks/ansibl
 
 ### Deprecation
 
-- Version 01 of `arista.cvp` module are now deprecated and will be removed from next release
+- Version 1 of `arista.cvp` module are now deprecated and will be removed from next release
 
 
 ## Release 3.3.0

--- a/ansible_collections/arista/cvp/docs/release-notes/v3.x.md
+++ b/ansible_collections/arista/cvp/docs/release-notes/v3.x.md
@@ -22,6 +22,7 @@ Full release note available on [github](https://github.com/aristanetworks/ansibl
 
 - `cv_image_v3` Warn if image already exists (#471)
 - `cv_container_v3` Fix partial topology removal and container removal
+- `cv_device_v3` Fix device lookup to use search_key instead of FQDN always
 
 ### Deprecation
 

--- a/ansible_collections/arista/cvp/docs/release-notes/v3.x.md
+++ b/ansible_collections/arista/cvp/docs/release-notes/v3.x.md
@@ -8,6 +8,26 @@
 - On premise version higher than 2018.2.5
 - Cloudvision as a Service
 
+## Release 3.4.0
+
+Full release note available on [github](https://github.com/aristanetworks/ansible-cvp/releases/tag/v3.4.0)
+
+### Enhancements
+
+- Implement initial module for tags management: `arista.cvp.cv_tag_v3`
+- Implement initial module for changecontrol management: `arista.cvp.cv_change_control_v3`
+- Add support for new auth method for on-perm devices
+
+### Bug fixes
+
+- `cv_image_v3` Warn if image already exists (#471)
+- `cv_container_v3` Fix partial topology removal and container removal
+
+### Deprecation
+
+- Version 01 of `arista.cvp` module are now deprecated and will be removed from next release
+
+
 ## Release 3.3.0
 
 Full release note available on [github](https://github.com/aristanetworks/ansible-cvp/releases/tag/v3.3.0)
@@ -26,7 +46,7 @@ Full release note available on [github](https://github.com/aristanetworks/ansibl
 
 ### Deprecation
 
-- Version 01 of `arista.cvp` module are now deprecated and will be renmoved starting April 2022
+- Version 01 of `arista.cvp` module are now deprecated and will be removed starting April 2022
 
 ## Release 3.2.0
 

--- a/ansible_collections/arista/cvp/galaxy.yml
+++ b/ansible_collections/arista/cvp/galaxy.yml
@@ -7,7 +7,7 @@ namespace: arista
 name: cvp
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.0.0
+version: 3.4.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/ansible_collections/arista/cvp/galaxy.yml
+++ b/ansible_collections/arista/cvp/galaxy.yml
@@ -7,7 +7,7 @@ namespace: arista
 name: cvp
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.4.0
+version: 0.0.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
## Release 3.4.0

Full release note available on [github](https://github.com/aristanetworks/ansible-cvp/releases/tag/v3.4.0)

### Enhancements

- Implement initial module for tags management: `arista.cvp.cv_tag_v3`
- Implement initial module for changecontrol management: `arista.cvp.cv_change_control_v3`
- Add support for new auth method for on-perm devices

### Bug fixes

- `cv_image_v3` Warn if image already exists (#471)
- `cv_container_v3` Fix partial topology removal and container removal
- `cv_device_v3` Fix strict mode not inheriting configlets from containers

### Deprecation

- Version 01 of `arista.cvp` module are now deprecated and will be removed from next release


