### PR TITLE
Feat(cv_device_v3): support device decommissioning and device removal from provisioning

### DIFF
--- a/ansible_collections/arista/cvp/docs/_build/cv_device_v3.rst
+++ b/ansible_collections/arista/cvp/docs/_build/cv_device_v3.rst
@@ -78,7 +78,7 @@ The following options may be specified for this module:
     <td>str</td>
     <td>no</td>
     <td>present</td>
-    <td><ul><li>present</li><li>factory_reset</li></ul></td>
+    <td><ul><li>present</li><li>factory_reset</li><li>provisioning_reset</li><li>absent</li></ul></td>
     <td>
         <div>Set if ansible should build or remove devices on CLoudvision</div>
     </td>
@@ -153,6 +153,52 @@ Examples:
             devices: '{{CVP_DEVICES}}'
             state: present
             apply_mode: strict
+
+    # Decommission devices (remove from both provisioning and telemetry)
+    - name: Decommission device
+      hosts: cv_server
+      connection: local
+      gather_facts: no
+      vars:
+        CVP_DEVICES:
+          - fqdn: leaf1
+            parentContainerName: ""
+      tasks:
+      - name: decommission device
+        arista.cvp.cv_device_v3:
+            devices: '{{CVP_DEVICES}}'
+            state: absent
+
+    # Remove a device from provisioning
+    # Post 2021.3.0 the device will be automatically re-registered and moved to the Undefined container
+    - name: Remove device
+      hosts: CVP
+      connection: local
+      gather_facts: no
+      vars:
+        CVP_DEVICES:
+          - fqdn: leaf2
+            parentContainerName: ""
+      tasks:
+      - name: remove device
+        arista.cvp.cv_device_v3:
+            devices: '{{CVP_DEVICES}}'
+            state: provisioning_reset
+
+    # Factory reset a device (moves the device to ZTP mode)
+    - name: Factory reset device
+      hosts: CVP
+      connection: local
+      gather_facts: no
+      vars:
+        CVP_DEVICES:
+          - fqdn: leaf2
+            parentContainerName: ""
+      tasks:
+      - name: remove device
+        arista.cvp.cv_device_v3:
+            devices: '{{CVP_DEVICES}}'
+            state: factory_reset
 
 
 

--- a/ansible_collections/arista/cvp/docs/modules/cv_device_v3.rst.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_device_v3.rst.md
@@ -67,7 +67,7 @@ The following options may be specified for this module:
 <td>str</td>
 <td>no</td>
 <td>present</td>
-<td><ul><li>present</li><li>factory_reset</li></ul></td>
+<td><ul><li>present</li><li>factory_reset</li><li>provisioning_reset</li><li>absent</li></ul></td>
 <td>
     <div>Set if ansible should build or remove devices on CLoudvision</div>
 </td>
@@ -137,6 +137,52 @@ The following options may be specified for this module:
             devices: '{{CVP_DEVICES}}'
             state: present
             apply_mode: strict
+
+    # Decommission devices (remove from both provisioning and telemetry)
+    - name: Decommission device
+      hosts: cv_server
+      connection: local
+      gather_facts: no
+      vars:
+        CVP_DEVICES:
+          - fqdn: leaf1
+            parentContainerName: ""
+      tasks:
+      - name: decommission device
+        arista.cvp.cv_device_v3:
+            devices: '{{CVP_DEVICES}}'
+            state: absent
+
+    # Remove a device from provisioning
+    # Post 2021.3.0 the device will be automatically re-registered and moved to the Undefined container
+    - name: Remove device
+      hosts: CVP
+      connection: local
+      gather_facts: no
+      vars:
+        CVP_DEVICES:
+          - fqdn: leaf2
+            parentContainerName: ""
+      tasks:
+      - name: remove device
+        arista.cvp.cv_device_v3:
+            devices: '{{CVP_DEVICES}}'
+            state: provisioning_reset
+
+    # Factory reset a device (moves the device to ZTP mode)
+    - name: Factory reset device
+      hosts: CVP
+      connection: local
+      gather_facts: no
+      vars:
+        CVP_DEVICES:
+          - fqdn: leaf2
+            parentContainerName: ""
+      tasks:
+      - name: remove device
+        arista.cvp.cv_device_v3:
+            devices: '{{CVP_DEVICES}}'
+            state: factory_reset
 
 ### Author
 

--- a/ansible_collections/arista/cvp/examples/cv_device_v3/device_config_assign_fqdn.yaml
+++ b/ansible_collections/arista/cvp/examples/cv_device_v3/device_config_assign_fqdn.yaml
@@ -1,0 +1,18 @@
+- name: Device Management in Cloudvision
+  hosts: cv_server
+  connection: local
+  gather_facts: false
+  collections:
+    - arista.cvp
+  vars:
+    CVP_DEVICES:
+      - fqdn: CV-ANSIBLE-EOS01
+        parentContainerName: ANSIBLE
+        configlets:
+            - 'CV-EOS-ANSIBLE01'
+  tasks:
+    - name: "Configure devices on {{inventory_hostname}}"
+      arista.cvp.cv_device_v3:
+        devices: '{{CVP_DEVICES}}'
+        state: present
+        search_key: fqdn

--- a/ansible_collections/arista/cvp/examples/cv_device_v3/device_config_assign_loose_sn.yaml
+++ b/ansible_collections/arista/cvp/examples/cv_device_v3/device_config_assign_loose_sn.yaml
@@ -1,0 +1,18 @@
+- name: Device Management in Cloudvision
+  hosts: cv_server
+  connection: local
+  gather_facts: false
+  collections:
+    - arista.cvp
+  vars:
+    CVP_DEVICES:
+      - serialNumber: xxxxxxxxxxxx
+        parentContainerName: ANSIBLE
+        configlets:
+            - 'CV-EOS-ANSIBLE01'
+  tasks:
+    - name: "Configure devices on {{inventory_hostname}}"
+      arista.cvp.cv_device_v3:
+        devices: '{{CVP_DEVICES}}'
+        state: present
+        search_key: serialNumber

--- a/ansible_collections/arista/cvp/examples/cv_device_v3/device_config_assign_strict.yaml
+++ b/ansible_collections/arista/cvp/examples/cv_device_v3/device_config_assign_strict.yaml
@@ -1,0 +1,18 @@
+- name: Device Management in Cloudvision
+  hosts: cv_server
+  connection: local
+  gather_facts: false
+  collections:
+    - arista.cvp
+  vars:
+    CVP_DEVICES:
+      - fqdn: CV-ANSIBLE-EOS01
+        parentContainerName: ANSIBLE
+        configlets:
+            - 'CV-EOS-ANSIBLE01'
+  tasks:
+    - name: "Configure devices on {{inventory_hostname}}"
+      arista.cvp.cv_device_v3:
+        devices: '{{CVP_DEVICES}}'
+        state: present
+        apply_mode: strict

--- a/ansible_collections/arista/cvp/examples/cv_device_v3/device_decommissioning.yaml
+++ b/ansible_collections/arista/cvp/examples/cv_device_v3/device_decommissioning.yaml
@@ -1,0 +1,13 @@
+- name: Decommission device
+  hosts: cv_server
+  connection: local
+  gather_facts: no
+  vars:
+    CVP_DEVICES:
+      - fqdn: leaf1
+        parentContainerName: ""
+  tasks:
+  - name: decommission device
+    arista.cvp.cv_device_v3:
+        devices: '{{CVP_DEVICES}}'
+        state: absent

--- a/ansible_collections/arista/cvp/examples/cv_device_v3/device_factory_reset.yaml
+++ b/ansible_collections/arista/cvp/examples/cv_device_v3/device_factory_reset.yaml
@@ -1,0 +1,13 @@
+- name: Factory reset device
+  hosts: cv_server
+  connection: local
+  gather_facts: no
+  vars:
+    CVP_DEVICES:
+      - fqdn: leaf2
+        parentContainerName: ""
+  tasks:
+  - name: remove device
+    arista.cvp.cv_device_v3:
+        devices: '{{CVP_DEVICES}}'
+        state: factory_reset

--- a/ansible_collections/arista/cvp/examples/cv_device_v3/device_provisioning_reset.yaml
+++ b/ansible_collections/arista/cvp/examples/cv_device_v3/device_provisioning_reset.yaml
@@ -1,0 +1,13 @@
+- name: Remove device
+  hosts: cv_server
+  connection: local
+  gather_facts: no
+  vars:
+    CVP_DEVICES:
+      - fqdn: leaf2
+        parentContainerName: ""
+  tasks:
+  - name: remove device
+    arista.cvp.cv_device_v3:
+        devices: '{{CVP_DEVICES}}'
+        state: provisioning_reset

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -1094,7 +1094,7 @@ class CvDeviceTools(object):
         elif state == ModuleOptionValues.STATE_MODE_REMOVE:
             MODULE_LOGGER.info('Processing data to reset devices')
             response = self.__state_provisioning_reset(user_inventory=user_inventory)
-        
+
         elif state == ModuleOptionValues.STATE_MODE_DECOMM:
             MODULE_LOGGER.info('Processing data to decommission devices')
             response = self.__state_absent(user_inventory=user_inventory)
@@ -1459,7 +1459,7 @@ class CvDeviceTools(object):
                 req_id = str(uuid.uuid4())
                 device_fact = self.get_device_facts(device_lookup=device.hostname)
                 device_id = device_fact['serialNumber']
-                MODULE_LOGGER.info(f"Found device serial number: {device_id}")
+                MODULE_LOGGER.info('Found device serial number: %s', device_id)
                 self.__cv_client.api.device_decommissioning(device_id, req_id)
             except CvpApiError:
                 MODULE_LOGGER.error('Error decommissioning device')
@@ -1474,7 +1474,7 @@ class CvDeviceTools(object):
                     try:
                         status = self.__cv_client.api.device_decommissioning_status_get_one(req_id)['value']['status']
                     except CvpRequestError:
-                        continue                 
+                        continue
                     if status == decomm_failure:
                         err_msg = status['result']['value']['error']
                         msg = f"Device decommissioning failed due to {err_msg}"

--- a/ansible_collections/arista/cvp/plugins/module_utils/resources/modules/fields.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/resources/modules/fields.py
@@ -28,6 +28,8 @@ class ModuleOptionValues():
     APPLY_MODE_STRICT: str = 'strict'
     STATE_MODE_ABSENT: str = 'factory_reset'
     STATE_MODE_PRESENT: str = 'present'
+    STATE_MODE_DECOMM: str = 'absent'
+    STATE_MODE_REMOVE: str = 'provisioning_reset'
 
 
 # @dataclass
@@ -58,3 +60,5 @@ class DeviceResponseFields():
     DEVICE_DEPLOYED: str = 'devices_deployed'
     DEVICE_MOVED: str = 'devices_moved'
     DEVICE_RESET: str = 'devices_reset'
+    DEVICE_DECOMMISSIONED: str = 'devices_decommissioned'
+    DEVICE_REMOVED: str = 'devices_removed'

--- a/ansible_collections/arista/cvp/plugins/modules/cv_device_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_device_v3.py
@@ -118,6 +118,52 @@ EXAMPLES = r'''
         devices: '{{CVP_DEVICES}}'
         state: present
         apply_mode: strict
+
+# Decommission devices (remove from both provisioning and telemetry)
+- name: Decommission device
+  hosts: cv_server
+  connection: local
+  gather_facts: no
+  vars:
+    CVP_DEVICES:
+      - fqdn: leaf1
+        parentContainerName: ""
+  tasks:
+  - name: decommission device
+    arista.cvp.cv_device_v3:
+        devices: '{{CVP_DEVICES}}'
+        state: absent
+
+# Remove a device from provisioning
+# Post 2021.3.0 the device will be automatically re-registered and moved to the Undefined container
+- name: Remove device
+  hosts: CVP
+  connection: local
+  gather_facts: no
+  vars:
+    CVP_DEVICES:
+      - fqdn: leaf2
+        parentContainerName: ""
+  tasks:
+  - name: remove device
+    arista.cvp.cv_device_v3:
+        devices: '{{CVP_DEVICES}}'
+        state: provisioning_reset
+
+# Factory reset a device (moves the device to ZTP mode)
+- name: Factory reset device
+  hosts: CVP
+  connection: local
+  gather_facts: no
+  vars:
+    CVP_DEVICES:
+      - fqdn: leaf2
+        parentContainerName: ""
+  tasks:
+  - name: remove device
+    arista.cvp.cv_device_v3:
+        devices: '{{CVP_DEVICES}}'
+        state: factory_reset
 '''
 
 import logging

--- a/ansible_collections/arista/cvp/plugins/modules/cv_device_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_device_v3.py
@@ -163,7 +163,7 @@ def main():
         state=dict(type='str',
                    required=False,
                    default='present',
-                   choices=['present', 'factory_reset']),
+                   choices=['present', 'factory_reset', 'provisioning_reset', 'absent']),
         apply_mode=dict(type='str',
                         required=False,
                         default='loose',

--- a/ansible_collections/arista/cvp/plugins/modules/cv_device_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_device_v3.py
@@ -42,7 +42,7 @@ options:
     description: Set if ansible should build or remove devices on CLoudvision
     required: false
     default: 'present'
-    choices: ['present', 'factory_reset']
+    choices: ['present', 'factory_reset', 'provisioning_reset', 'absent']
     type: str
   apply_mode:
     description: Set how configlets are attached/detached on device. If set to strict all configlets not listed in your vars are detached.


### PR DESCRIPTION
## Change Summary

Adding support for device decommissioning and resetting device provisioning state (removing it from provisioning and moving it back to Undefined container)

## Related Issue(s)

Fixes #506 

## Component(s) name

`arista.cvp.cv_device_v3`

## Proposed changes
Similarly to `factory_reset` state, I've added `absent` (full device decomissioning which shuts down TerminAttr and removes the device entirely from CVP) and `provisioning_reset` which uses the inventory REST API to remove the device from provisioning, which then gets automatically added back to the Undefined container (2021.3.0+)

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

To fully decomission a device a similar playbook can be used:

```yaml
- name: Decommission device
  hosts: CVP
  connection: local
  gather_facts: no
  vars:
    CVP_DEVICES:
      - fqdn: leaf1
        parentContainerName: ""
  tasks:
  - name: decommission device
    arista.cvp.cv_device_v3:
        devices: '{{CVP_DEVICES}}'
        state: absent
```

Post playbook execution the device should disappear from the inventory and Network Provisioning.

To remove the device from provisioning we can use a playbook like below:

```yaml
- name: Remove device
  hosts: CVP
  connection: local
  gather_facts: no
  vars:
    CVP_DEVICES:
      - fqdn: leaf2
        parentContainerName: ""

  tasks:
  - name: remove device
    arista.cvp.cv_device_v3:
        devices: '{{CVP_DEVICES}}'
        state: provisioning_reset
```

Post playbook execution the device should land in the Undefined container (post 2021.3.0+), pre 2021.3.0 the device will be removed from Network Provisioning.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code has been rebased from devel before I start
- [x ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
