### PR TITLE
Fix: Remove ansible-test enforced GPL3 header for modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,4 +118,4 @@ venv.bak/
 *.DS_Store
 *.log
 *.log.*
-ansible_collections/arista/cvp/tests/*
+ansible_collections/arista/cvp/tests/output

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2021 Arista Networks AS-EMEA
+# Copyright 2021 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/module_utils/configlet_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/configlet_tools.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -3,9 +3,7 @@
 # pylint: disable=logging-format-interpolation
 # flake8: noqa: W1202
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2022 Arista Networks AS-EMEA
+# Copyright 2022 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/module_utils/generic_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/generic_tools.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/module_utils/image_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/image_tools.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2021 Arista Networks AS-EMEA
+# Copyright 2021 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/module_utils/logger.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/logger.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/module_utils/resources/api/fields.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/resources/api/fields.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2022 Arista Networks AS-EMEA
+# Copyright 2022 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/module_utils/resources/exceptions.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/resources/exceptions.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/module_utils/resources/modules/fields.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/resources/modules/fields.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2022 Arista Networks AS-EMEA
+# Copyright 2022 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/module_utils/resources/schemas/v1.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/resources/schemas/v1.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2022 Arista Networks AS-EMEA
+# Copyright 2022 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/module_utils/resources/schemas/v3.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/resources/schemas/v3.py
@@ -4,9 +4,7 @@
 # pylint: disable = duplicate-code
 # flake8: noqa: R0801
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/module_utils/response.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/response.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/module_utils/schema_v1.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/schema_v1.py
@@ -4,9 +4,7 @@
 # pylint: disable = duplicate-code
 # flake8: noqa: R0801
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/module_utils/tag_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tag_tools.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/module_utils/task_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/task_tools.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools_inventory.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools_inventory.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools_schema.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools_schema.py
@@ -4,9 +4,7 @@
 # pylint: disable = duplicate-code
 # flake8: noqa: R0801
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools_tree.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools_tree.py
@@ -2,9 +2,7 @@
 # coding: utf-8 -*-
 # pylint: disable=bare-except
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
@@ -1,9 +1,7 @@
 #!/usr/bin/python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
@@ -1,9 +1,7 @@
 #!/usr/bin/python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/modules/cv_configlet_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_configlet_v3.py
@@ -4,9 +4,7 @@
 # pylint: disable=dangerous-default-value
 # flake8: noqa: W503
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/modules/cv_container.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_container.py
@@ -4,9 +4,7 @@
 # pylint: disable=logging-format-interpolation
 # flake8: noqa: W1202
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/modules/cv_container_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_container_v3.py
@@ -8,9 +8,7 @@
 # pylint: disable = duplicate-code
 # flake8: noqa: R0801
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/modules/cv_device.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_device.py
@@ -1,9 +1,7 @@
 #!/usr/bin/python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/modules/cv_device_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_device_v3.py
@@ -4,9 +4,7 @@
 # pylint: disable=dangerous-default-value
 # flake8: noqa: W503
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
@@ -1,9 +1,7 @@
 #!/usr/bin/python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/modules/cv_facts_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_facts_v3.py
@@ -4,9 +4,7 @@
 # pylint: disable=dangerous-default-value
 # flake8: noqa: W503
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2022 Arista Networks AS-EMEA
+# Copyright 2022 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/modules/cv_image_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_image_v3.py
@@ -1,9 +1,7 @@
 #!/usr/bin/python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/modules/cv_tag_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_tag_v3.py
@@ -1,9 +1,7 @@
 #!/usr/bin/python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/modules/cv_task.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_task.py
@@ -1,9 +1,7 @@
 #!/usr/bin/python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/plugins/modules/cv_task_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_task_v3.py
@@ -1,9 +1,7 @@
 #!/usr/bin/python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/cvp/tests/sanity/ignore-2.11.txt
+++ b/ansible_collections/arista/cvp/tests/sanity/ignore-2.11.txt
@@ -1,0 +1,13 @@
+plugins/modules/cv_change_control_v3.py validate-modules:missing-gplv3-license
+plugins/modules/cv_configlet_v3.py validate-modules:missing-gplv3-license
+plugins/modules/cv_configlet.py validate-modules:missing-gplv3-license
+plugins/modules/cv_container_v3.py validate-modules:missing-gplv3-license
+plugins/modules/cv_container.py validate-modules:missing-gplv3-license
+plugins/modules/cv_device_v3.py validate-modules:missing-gplv3-license
+plugins/modules/cv_device.py validate-modules:missing-gplv3-license
+plugins/modules/cv_facts_v3.py validate-modules:missing-gplv3-license
+plugins/modules/cv_facts.py validate-modules:missing-gplv3-license
+plugins/modules/cv_image_v3.py validate-modules:missing-gplv3-license
+plugins/modules/cv_tag_v3.py validate-modules:missing-gplv3-license
+plugins/modules/cv_task_v3.py validate-modules:missing-gplv3-license
+plugins/modules/cv_task.py validate-modules:missing-gplv3-license

--- a/ansible_collections/arista/cvp/tests/sanity/ignore-2.12.txt
+++ b/ansible_collections/arista/cvp/tests/sanity/ignore-2.12.txt
@@ -1,0 +1,13 @@
+plugins/modules/cv_change_control_v3.py validate-modules:missing-gplv3-license
+plugins/modules/cv_configlet_v3.py validate-modules:missing-gplv3-license
+plugins/modules/cv_configlet.py validate-modules:missing-gplv3-license
+plugins/modules/cv_container_v3.py validate-modules:missing-gplv3-license
+plugins/modules/cv_container.py validate-modules:missing-gplv3-license
+plugins/modules/cv_device_v3.py validate-modules:missing-gplv3-license
+plugins/modules/cv_device.py validate-modules:missing-gplv3-license
+plugins/modules/cv_facts_v3.py validate-modules:missing-gplv3-license
+plugins/modules/cv_facts.py validate-modules:missing-gplv3-license
+plugins/modules/cv_image_v3.py validate-modules:missing-gplv3-license
+plugins/modules/cv_tag_v3.py validate-modules:missing-gplv3-license
+plugins/modules/cv_task_v3.py validate-modules:missing-gplv3-license
+plugins/modules/cv_task.py validate-modules:missing-gplv3-license

--- a/tests/data/container_tools_unit.py
+++ b/tests/data/container_tools_unit.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/data/facts_system_cvaas.py
+++ b/tests/data/facts_system_cvaas.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2022 Arista Networks AS-EMEA
+# Copyright 2022 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/data/image_unit.py
+++ b/tests/data/image_unit.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/lib/cvaas_configlet.py
+++ b/tests/lib/cvaas_configlet.py
@@ -4,9 +4,7 @@
 # pylint: disable = duplicate-code
 # flake8: noqa: R0801
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/lib/helpers.py
+++ b/tests/lib/helpers.py
@@ -4,9 +4,7 @@
 # pylint: disable = duplicate-code
 # flake8: noqa: R0801
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/lib/json_data.py
+++ b/tests/lib/json_data.py
@@ -4,9 +4,7 @@
 # pylint: disable = duplicate-code
 # flake8: noqa: R0801
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/lib/static_content.py
+++ b/tests/lib/static_content.py
@@ -4,9 +4,7 @@
 # pylint: disable = duplicate-code
 # flake8: noqa: R0801
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Remove ansible-test enforced GPL3 header from modules

Ansible-test sanity enforces a GPL3 license in all modules. This is not intended for collections, but only for Ansible Core, so we will add ignores for these rules and remove the GPL3 line.
The collection is licensed under Apache 2.0 as it is mentioned everywhere else.