### PR TITLE
Fix(module_utils): dict key check on CC indexing is broken

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -505,7 +505,7 @@ class CvChangeControlTools():
         self.__cc_index.clear()
 
         for entry in self.change_controls['data']:
-            if 'name' not in entry['result']['value']['change']['name']:
+            if 'name' not in entry['result']['value']['change']:
                 self.__cc_index.append(('Undefined', entry['result']['value']['key']['id']))
             else:
                 self.__cc_index.append((entry['result']['value']['change']['name'], entry['result']['value']['key']['id']))


### PR DESCRIPTION
## Change Summary
When the `CvChangeControlTools` class is attempting to index the name+key for the change controls, the check to ensure that the `name` is defined is looking one dict too deep (the UI blocks a CC from not having a name, but the API does allow it). 

## Related Issue(s)

Fixes #523 

## Component(s) name

`arista.cvp.cv_change_control_v3`

## Proposed changes
Simple change to make sure we are looking in the right place for the `name` key.

## How to test
Tested against any existing named CC
```yaml
---
- name: CVP Image Update
  hosts: cv_server
  gather_facts: no
  vars:

  tasks:

    - name: "Get the created change control {{inventory_hostname}}"
      arista.cvp.cv_change_control_v3:
        state: show
        name: Change 20220815_145635
      register: cv_facts

    - name: "Show the created CC from {{inventory_hostname}}"
      debug:
        msg: "{{cv_facts}}"
```
The result should be a data dict, containing a list of `change_controls`.
```
TASK [Show the created CC from cv_server] **************************************
ok: [cv_server] => {
    "msg": {
        "changed": false,
        "data": {
            "change_controls:": [
                {
                    "time": "2022-08-15T13:57:42.856946946Z",
                    "value": {
                        "approve": {
                            "time": "2022-08-15T13:57:10.439743633Z",
                            "user": "cvpadmin",
                            "value": true
                        },
                        "change": {
                            "name": "Change 20220815_145635",
                            "notes": "",
                            "rootStageId": "wNdfYIXL2c",
                            "stages": {
...
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
