### PR TITLE
Refactor: relax the condition to raise exception for inline vault password

### DIFF
--- a/ansible_collections/arista/cvp/docs/how-to/cvp-authentication.md
+++ b/ansible_collections/arista/cvp/docs/how-to/cvp-authentication.md
@@ -45,7 +45,7 @@ ansible_network_os: eos
 ```
 
 !!! note
-    Depending on the ansible version, vault encrypted variables may not supported because of https://github.com/ansible/ansible/issues/75503. ansible-cvp code will check if the provided password (and password only) is malformed and inform the user by raising an exception.
+    Depending on the ansible version, vault encrypted variables may not be supported because of https://github.com/ansible/ansible/issues/75503. ansible-cvp code will check if the provided password (and password only) is malformed and inform the user by raising an exception.
     Either upgrade ansible-core to a version that has the fix: https://github.com/ansible/ansible/pull/78236 or use ansible vault file instead: https://docs.ansible.com/ansible/latest/user_guide/vault.html#encrypting-files-with-ansible-vault
 
 ### Example reading from a file

--- a/ansible_collections/arista/cvp/docs/how-to/cvp-authentication.md
+++ b/ansible_collections/arista/cvp/docs/how-to/cvp-authentication.md
@@ -45,7 +45,8 @@ ansible_network_os: eos
 ```
 
 !!! note
-    Vault encrypted variables are not supported as password yet. Use ansible vault file instead. https://docs.ansible.com/ansible/latest/user_guide/vault.html#encrypting-files-with-ansible-vault
+    Depending on the ansible version, vault encrypted variables may not supported because of https://github.com/ansible/ansible/issues/75503. ansible-cvp code will check if the provided password (and password only) is malformed and inform the user by raising an exception.
+    Either upgrade ansible-core to a version that has the fix: https://github.com/ansible/ansible/pull/78236 or use ansible vault file instead: https://docs.ansible.com/ansible/latest/user_guide/vault.html#encrypting-files-with-ansible-vault
 
 ### Example reading from a file
 
@@ -105,7 +106,7 @@ all:
 5. Run the playbook with `ansible-playbook example.yaml --ask-vault-pass` or instead of `--ask-vault-pass`
 provide the password with any other methods as described in the [ansible vault documentation](https://docs.ansible.com/ansible/latest/user_guide/vault.html#using-encrypted-variables-and-files).
 
-> NOTE Encrypting individual variables using vault is not yet supported.
+> NOTE Encrypting individual variables using vault may not be supported - cf notes at the end of ## On-premise CloudVision authentication section
 
 ## CloudVision as a Service authentication
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
@@ -73,7 +73,7 @@ def cv_connect(module):
         LOGGER.error('Cannot connect to CVP, password is encrypted')
         raise NotImplementedError("Vault encrypted variables are not supported for password with your version of ansible. "
                                   "Because of https://github.com/ansible/ansible/issues/75503. "
-                                  "You may either upgrade ansible of use ansible vault file instead."
+                                  "You may either upgrade ansible or use ansible vault file instead."
                                   "https://docs.ansible.com/ansible/latest/user_guide/vault.html#encrypting-files-with-ansible-vault")
 
     if cert_validation:

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
@@ -71,7 +71,7 @@ def cv_connect(module):
     # This is a failsafe in case the ansible version is not high enough to have the fix
     if isinstance(user_authentication, dict) and "__ansible_vault" in user_authentication:
         LOGGER.error('Cannot connect to CVP, password is encrypted')
-        raise NotImplementedError("Vault encrypted variables are not supported with as password with your version of ansible. "
+        raise NotImplementedError("Vault encrypted variables are not supported for password with your version of ansible. "
                                   "Because of https://github.com/ansible/ansible/issues/75503. "
                                   "You may either upgrade ansible of use ansible vault file instead."
                                   "https://docs.ansible.com/ansible/latest/user_guide/vault.html#encrypting-files-with-ansible-vault")

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
@@ -66,10 +66,14 @@ def cv_connect(module):
     ansible_connect_timeout = connection.get_option(
         "persistent_connect_timeout")
 
-    if not isinstance(user_authentication, str):
+    # The following is needed because of https://github.com/ansible/ansible/issues/75503
+    # Which was fixed in https://github.com/ansible/ansible/pull/78236
+    # This is a failsafe in case the ansible version is not high enough to have the fix
+    if isinstance(user_authentication, dict) and "__ansible_vault" in user_authentication:
         LOGGER.error('Cannot connect to CVP, password is encrypted')
-        raise NotImplementedError("Vault encrypted variables are not supported "
-                                  "as password yet. Use ansible vault file instead."
+        raise NotImplementedError("Vault encrypted variables are not supported with as password with your version of ansible. "
+                                  "Because of https://github.com/ansible/ansible/issues/75503. "
+                                  "You may either upgrade ansible of use ansible vault file instead."
                                   "https://docs.ansible.com/ansible/latest/user_guide/vault.html#encrypting-files-with-ansible-vault")
 
     if cert_validation:

--- a/tests/unit/test_tools_cv.py
+++ b/tests/unit/test_tools_cv.py
@@ -81,16 +81,24 @@ def does_not_raise():
 @pytest.mark.parametrize(
     "connection, connect_side_effect, expectation",
     [
-        (module_values(), None, does_not_raise()),
-        (
+        pytest.param(module_values(), None, does_not_raise(), id="Succes"),
+        pytest.param(
             module_values(password={"__ansible_vault": "DUMMY VAULT"}),
             None,
             pytest.raises(NotImplementedError),
+            id="Vault variable undecrypted",
         ),
-        (
+        pytest.param(
             module_values(),
             CvpLoginError("Test Exception"),
             pytest.raises(AnsibleFailJson),
+            id="Failed Connection",
+        ),
+        pytest.param(
+            module_values(password=1234),
+            None,
+            does_not_raise(),
+            id="Password not a string not raising",
         ),
     ],
     indirect=["connection"],


### PR DESCRIPTION
Some issues (unrelated to this piece of code) have demonstrated that it is necessary to actually relax the test to check if `tools_cv.py` receives an encrypted VAULT password.

Btw this should happen less and less because ansible has fixed the issue in all train in: https://github.com/ansible/ansible/pull/78236 

## Change Summary

Rather than raising if the password is not a string, raise only if the password is a dict that containt the `__ansible_vault` key. More specific and better.

Fix the documentation to reflect that this should not be an issue anymore in recent versions of ansible.

Update the error message as well

## Component(s) name

`arista.cvp.plugins`

## Proposed changes

Cf summary changes

## How to test

Run the test suite one test added

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
