### PR TITLE
Fix(cv_device_v3): Allow all search_by options when assigning and removing image bundles

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -1266,7 +1266,7 @@ class CvDeviceTools(object):
                 continue
 
             # GET IMAGE BUNDLE
-            MODULE_LOGGER.debug("Attempting to get current image bundle for %s using %s", str(device.fqdn), str(device_lookup=device.info[self.__search_by]))
+            MODULE_LOGGER.debug("Attempting to get current image bundle for %s using %s", str(device.fqdn), str(device.info[self.__search_by]))
             current_image_bundle = self.get_device_image_bundle(device_lookup=device.info[self.__search_by])
             MODULE_LOGGER.debug("Current image bundle assigned is: %s", str(current_image_bundle))
             MODULE_LOGGER.debug("User assigned image bundle is: %s", str(device.image_bundle))
@@ -1346,7 +1346,7 @@ class CvDeviceTools(object):
                 continue
 
             # GET IMAGE BUNDLE
-            MODULE_LOGGER.debug("Attempting to get current image bundle for %s using %s", str(device.fqdn), str(device_lookup=device.info[self.__search_by]))
+            MODULE_LOGGER.debug("Attempting to get current image bundle for %s using %s", str(device.fqdn), str(device.info[self.__search_by]))
             current_image_bundle = self.get_device_image_bundle(device_lookup=device.info[self.__search_by])
             MODULE_LOGGER.debug("Current image bundle assigned is: %s", str(current_image_bundle))
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -1266,8 +1266,8 @@ class CvDeviceTools(object):
                 continue
 
             # GET IMAGE BUNDLE
-            MODULE_LOGGER.debug("Get image bundle for %s", str(device.serial_number))
-            current_image_bundle = self.get_device_image_bundle(device_lookup=self.__search_by)
+            MODULE_LOGGER.debug("Attempting to get current image bundle for %s using %s", str(device.fqdn), str(device_lookup=device.info[self.__search_by]))
+            current_image_bundle = self.get_device_image_bundle(device_lookup=device.info[self.__search_by])
             MODULE_LOGGER.debug("Current image bundle assigned is: %s", str(current_image_bundle))
             MODULE_LOGGER.debug("User assigned image bundle is: %s", str(device.image_bundle))
 
@@ -1346,7 +1346,9 @@ class CvDeviceTools(object):
                 continue
 
             # GET IMAGE BUNDLE
-            current_image_bundle = self.get_device_image_bundle(device_lookup=self.__search_by)
+            MODULE_LOGGER.debug("Attempting to get current image bundle for %s using %s", str(device.fqdn), str(device_lookup=device.info[self.__search_by]))
+            current_image_bundle = self.get_device_image_bundle(device_lookup=device.info[self.__search_by])
+            MODULE_LOGGER.debug("Current image bundle assigned is: %s", str(current_image_bundle))
 
             # Check to make sure that the assigned image isn't inherited from the container
             if current_image_bundle is not None and current_image_bundle[Api.image.TYPE] == 'netelement':

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -1267,7 +1267,7 @@ class CvDeviceTools(object):
 
             # GET IMAGE BUNDLE
             MODULE_LOGGER.debug("Get image bundle for %s", str(device.serial_number))
-            current_image_bundle = self.get_device_image_bundle(device_lookup=device.serial_number)
+            current_image_bundle = self.get_device_image_bundle(device_lookup=self.__search_by)
             MODULE_LOGGER.debug("Current image bundle assigned is: %s", str(current_image_bundle))
             MODULE_LOGGER.debug("User assigned image bundle is: %s", str(device.image_bundle))
 
@@ -1346,7 +1346,7 @@ class CvDeviceTools(object):
                 continue
 
             # GET IMAGE BUNDLE
-            current_image_bundle = self.get_device_image_bundle(device_lookup=device.serial_number)
+            current_image_bundle = self.get_device_image_bundle(device_lookup=self.__search_by)
 
             # Check to make sure that the assigned image isn't inherited from the container
             if current_image_bundle is not None and current_image_bundle[Api.image.TYPE] == 'netelement':


### PR DESCRIPTION
## Change Summary

Original bundle assignment was assuming serial number was always available, but when user didn't device search_by or was using hostname/FQDN this was failing. We now use the same search_by method that the user specifies

## Related Issue(s)

Fixes #540 

## Component(s) name

`arista.cvp.cv_device_v3`

## Proposed changes
Change the function call to retrieve the current image bundle to use the provided `device_lookup` e.g. `device.info[self.__search_by]`

## How to test
```yaml
---
- name: CVP Device Test
  hosts: cv_server
  gather_facts: no
  vars:
    CVP_DEVICES:
      - fqdn: DC1-POD1-LEAF1A
        parentContainerName: DC1_POD1_LEAFS
        configlets:
          - AMS-AVD_DC1-POD1-LEAF1A
  tasks:
  - name: "Configure devices on {{ inventory_hostname }}"
    arista.cvp.cv_device_v3:
      devices: "{{ CVP_DEVICES }}"
      state: present
    register: CVP_DEVICES_RESULTS
```
Playbook should complete successfully
```
2022-10-28 14:32:30,933 - ansible_collections.arista.cvp.plugins.module_utils.device_tools: DEBUG - func: apply_bundle (L:1270) - Attempting to get current image bundle for DC1-SPINE-1 using DC1-SPINE-1
2022-10-28 14:32:30,933 - ansible_collections.arista.cvp.plugins.module_utils.device_tools: DEBUG - func: __get_device (L:429) - Looking for device using hostname as search_by
2022-10-28 14:32:31,141 - ansible_collections.arista.cvp.plugins.module_utils.device_tools: DEBUG - func: __get_device (L:444) - Got following data for DC1-SPINE-1 using hostname: {'modelName': '', 'internalVersion': '4.26.2F', 'systemMacAddress': '50:78:00:54:5e:26', 'serialNumber': '9B8CB6BCCCFE0D107D1951EFB557D7B4', 'memTotal': 0, 'bootupTimeStamp': 1666342531.381122, 'memFree': 0, 'version': '4.26.2F', 'architecture': '', 'internalBuildId': 'fa3a49f3-6093-4925-ad11-55fe15eac5ae', 'hardwareRevision': '', 'fqdn': 'DC1-SPINE-1', 'key': '50:78:00:54:5e:26', 'ztpMode': 'false', 'type': 'netelement', 'ipAddress': '10.83.31.65', 'taskIdList': [], 'isDANZEnabled': 'no', 'isMLAGEnabled': 'no', 'complianceIndication': '', 'tempAction': [], 'complianceCode': '0000', 'lastSyncUp': 0, 'unAuthorized': False, 'deviceInfo': None, 'deviceStatus': 'Registered', 'parentContainerId': 'container_0ea6f580-5127-4d39-a180-fcbaa7cd97b8', 'sslEnabledByCVP': False, 'sslConfigAvailable': False, 'dcaKey': '', 'containerName': 'DC1_SPINES', 'streamingStatus': 'active', 'status': 'Registered', 'mlagEnabled': 'no', 'danzEnabled': 'no', 'parentContainerKey': 'container_0ea6f580-5127-4d39-a180-fcbaa7cd97b8', 'bootupTimestamp': 1666342531.381122, 'internalBuild': 'fa3a49f3-6093-4925-ad11-55fe15eac5ae', 'imageBundle': {'macAddress': '50:78:00:54:5e:26', 'serialNumber': '9B8CB6BCCCFE0D107D1951EFB557D7B4', 'eosVersion': '4.26.2F', 'fqdn': 'DC1-SPINE-1', 'imageBundleMapper': {}, 'ipAddress': '10.83.31.65', 'bundleName': None, 'imageBundleId': ''}}
2022-10-28 14:32:31,141 - ansible_collections.arista.cvp.plugins.module_utils.device_tools: DEBUG - func: get_device_image_bundle (L:944) - cv_data lookup returned: {'modelName': '', 'internalVersion': '4.26.2F', 'systemMacAddress': '50:78:00:54:5e:26', 'serialNumber': '9B8CB6BCCCFE0D107D1951EFB557D7B4', 'memTotal': 0, 'bootupTimeStamp': 1666342531.381122, 'memFree': 0, 'version': '4.26.2F', 'architecture': '', 'internalBuildId': 'fa3a49f3-6093-4925-ad11-55fe15eac5ae', 'hardwareRevision': '', 'fqdn': 'DC1-SPINE-1', 'key': '50:78:00:54:5e:26', 'ztpMode': 'false', 'type': 'netelement', 'ipAddress': '10.83.31.65', 'taskIdList': [], 'isDANZEnabled': 'no', 'isMLAGEnabled': 'no', 'complianceIndication': '', 'tempAction': [], 'complianceCode': '0000', 'lastSyncUp': 0, 'unAuthorized': False, 'deviceInfo': None, 'deviceStatus': 'Registered', 'parentContainerId': 'container_0ea6f580-5127-4d39-a180-fcbaa7cd97b8', 'sslEnabledByCVP': False, 'sslConfigAvailable': False, 'dcaKey': '', 'containerName': 'DC1_SPINES', 'streamingStatus': 'active', 'status': 'Registered', 'mlagEnabled': 'no', 'danzEnabled': 'no', 'parentContainerKey': 'container_0ea6f580-5127-4d39-a180-fcbaa7cd97b8', 'bootupTimestamp': 1666342531.381122, 'internalBuild': 'fa3a49f3-6093-4925-ad11-55fe15eac5ae', 'imageBundle': {'macAddress': '50:78:00:54:5e:26', 'serialNumber': '9B8CB6BCCCFE0D107D1951EFB557D7B4', 'eosVersion': '4.26.2F', 'fqdn': 'DC1-SPINE-1', 'imageBundleMapper': {}, 'ipAddress': '10.83.31.65', 'bundleName': None, 'imageBundleId': ''}}
2022-10-28 14:32:31,141 - ansible_collections.arista.cvp.plugins.module_utils.device_tools: DEBUG - func: apply_bundle (L:1272) - Current image bundle assigned is: {'imageBundle': None, 'imageBundleId': None, 'type': None}
2022-10-28 14:32:31,141 - ansible_collections.arista.cvp.plugins.module_utils.device_tools: DEBUG - func: apply_bundle (L:1273) - User assigned image bundle is: None
2022-10-28 14:32:31,141 - ansible_collections.arista.cvp.plugins.module_utils.device_tools: DEBUG - func: __state_present (L:632) - AnsibleResponse updated, new content with cv_move: {'devices_moved': {'devices_moved_list': [], 'success': False, 'changed': False, 'taskIds': [], 'diff': {}, 'devices_moved_count': 0}, 'success': False, 'changed': False, 'taskIds': []}
2022-10-28 14:32:31,141 - ansible_collections.arista.cvp.plugins.module_utils.device_tools: DEBUG - func: __state_present (L:634) - AnsibleResponse updated, new content with cv_deploy: {'devices_moved': {'devices_moved_list': [], 'success': False, 'changed': False, 'taskIds': [], 'diff': {}, 'devices_moved_count': 0}, 'success': False, 'changed': False, 'taskIds': [], 'devices_deployed': {'devices_deployed_list': [], 'success': False, 'changed': False, 'taskIds': [], 'diff': {}, 'devices_deployed_count': 0}}
2022-10-28 14:32:31,142 - ansible_collections.arista.cvp.plugins.module_utils.device_tools: DEBUG - func: __state_present (L:636) - AnsibleResponse updated, new content with cv_configlets_attach: {'devices_moved': {'devices_moved_list': [], 'success': False, 'changed': False, 'taskIds': [], 'diff': {}, 'devices_moved_count': 0}, 'success': False, 'changed': False, 'taskIds': [], 'devices_deployed': {'devices_deployed_list': [], 'success': False, 'changed': False, 'taskIds': [], 'diff': {}, 'devices_deployed_count': 0}, 'configlets_attached': {'configlets_attached_list': [], 'success': False, 'changed': False, 'taskIds': [], 'diff': {}, 'configlets_attached_count': 0}}
2022-10-28 14:32:31,142 - ansible_collections.arista.cvp.plugins.module_utils.device_tools: DEBUG - func: __state_present (L:638) - AnsibleResponse updated, new content with cv_bundle_attach: {'devices_moved': {'devices_moved_list': [], 'success': False, 'changed': False, 'taskIds': [], 'diff': {}, 'devices_moved_count': 0}, 'success': False, 'changed': False, 'taskIds': [], 'devices_deployed': {'devices_deployed_list': [], 'success': False, 'changed': False, 'taskIds': [], 'diff': {}, 'devices_deployed_count': 0}, 'configlets_attached': {'configlets_attached_list': [], 'success': False, 'changed': False, 'taskIds': [], 'diff': {}, 'configlets_attached_count': 0}, 'bundle_attached': {'bundle_attached_list': [], 'success': False, 'changed': False, 'taskIds': [], 'diff': {}, 'bundle_attached_count': 0}}
2022-10-28 14:32:31,142 - ansible_collections.arista.cvp.plugins.module_utils.device_tools: DEBUG - func: __state_present (L:640) - AnsibleResponse updated, new content with cv_configlets_detach: {'devices_moved': {'devices_moved_list': [], 'success': False, 'changed': False, 'taskIds': [], 'diff': {}, 'devices_moved_count': 0}, 'success': False, 'changed': False, 'taskIds': [], 'devices_deployed': {'devices_deployed_list': [], 'success': False, 'changed': False, 'taskIds': [], 'diff': {}, 'devices_deployed_count': 0}, 'configlets_attached': {'configlets_attached_list': [], 'success': False, 'changed': False, 'taskIds': [], 'diff': {}, 'configlets_attached_count': 0}, 'bundle_attached': {'bundle_attached_list': [], 'success': False, 'changed': False, 'taskIds': [], 'diff': {}, 'bundle_attached_count': 0}, 'configlets_detached': {'configlets_detached_list': [], 'success': False, 'changed': False, 'taskIds': [], 'diff': {}, 'configlets_detached_count': 0}}
2022-10-28 14:32:31,142 - ansible_collections.arista.cvp.plugins.module_utils.device_tools: DEBUG - func: __state_present (L:642) - AnsibleResponse updated, new content with cv_bundle_detach: {'devices_moved': {'devices_moved_list': [], 'success': False, 'changed': False, 'taskIds': [], 'diff': {}, 'devices_moved_count': 0}, 'success': False, 'changed': False, 'taskIds': [], 'devices_deployed': {'devices_deployed_list': [], 'success': False, 'changed': False, 'taskIds': [], 'diff': {}, 'devices_deployed_count': 0}, 'configlets_attached': {'configlets_attached_list': [], 'success': False, 'changed': False, 'taskIds': [], 'diff': {}, 'configlets_attached_count': 0}, 'bundle_attached': {'bundle_attached_list': [], 'success': False, 'changed': False, 'taskIds': [], 'diff': {}, 'bundle_attached_count': 0}, 'configlets_detached': {'configlets_detached_list': [], 'success': False, 'changed': False, 'taskIds': [], 'diff': {}, 'configlets_detached_count': 0}, 'bundle_detached': {'bundle_detached_list': [], 'success': False, 'changed': False, 'taskIds': [], 'diff': {}, 'bundle_detached_count': 0}}
```
## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- x ] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
