### PR TITLE
Doc: Minor nits in documentation

### DIFF
--- a/ansible_collections/arista/cvp/docs/_build/cv_change_control_v3.rst
+++ b/ansible_collections/arista/cvp/docs/_build/cv_change_control_v3.rst
@@ -69,7 +69,18 @@ The following options may be specified for this module:
     <td></td>
     <td></td>
     <td>
-        <div>The name of the change control. If not provided, one will be generated.</div>
+        <div>The name of the change control, If not provided, one will be generated automatically.</div>
+    </td>
+    </tr>
+
+    <tr>
+    <td>schedule_time<br/><div style="font-size: small;"></div></td>
+    <td>str</td>
+    <td>no</td>
+    <td></td>
+    <td></td>
+    <td>
+        <div>RFC3339 time format, e.g., 2021-12-23T02:07:00.0</div>
     </td>
     </tr>
 
@@ -78,7 +89,7 @@ The following options may be specified for this module:
     <td>str</td>
     <td>no</td>
     <td>show</td>
-    <td><ul><li>show</li><li>set</li><li>remove</li></ul></td>
+    <td><ul><li>show</li><li>set</li><li>remove</li><li>approve</li><li>unapprove</li><li>execute</li><li>schedule</li><li>approve_and_execute</li><li>schedule_and_approve</li></ul></td>
     <td>
         <div>Set if we should get, set/update, or remove the change control</div>
     </td>
@@ -112,6 +123,7 @@ Examples:
                   value: <device serial number>
               stage: Pre-Checks
             - action: "Switch Healthcheck"
+              name: Switch2_healthcheck
               arguments:
                 - name: DeviceID
                   value: <device serial number>
@@ -150,6 +162,7 @@ Examples:
           arista.cvp.cv_change_control_v3:
             state: set
             change: "{{ change }}"
+          register: cv_change_control
 
         - name: "Get the created change control {{inventory_hostname}}"
           arista.cvp.cv_change_control_v3:
@@ -171,6 +184,16 @@ Examples:
         - name: "Show deleted CCs"
           debug:
             msg: "{{cv_deleted}}"
+
+        - name: "Approve a change control on {{inventory_hostname}}"
+          arista.cvp.cv_change_control_v3:
+            state: approve
+            change_id: ["{{ cv_change_control.data.id }}"]
+
+        - name: "Execute a change control on {{inventory_hostname}}"
+          arista.cvp.cv_change_control_v3:
+            state: execute
+            change_id: ["{{ cv_change_control.data.id }}"]
 
 
 

--- a/ansible_collections/arista/cvp/docs/_build/cv_container_v3.rst
+++ b/ansible_collections/arista/cvp/docs/_build/cv_container_v3.rst
@@ -48,7 +48,7 @@ The following options may be specified for this module:
     <td>loose</td>
     <td><ul><li>loose</li><li>strict</li></ul></td>
     <td>
-        <div>Set how configlets are attached/detached on container. If set to strict all configlets not listed in your vars are detached.</div>
+        <div>Set how configlets are attached/detached to containers. If set to strict all configlets not listed in your vars will be detached.</div>
     </td>
     </tr>
 
@@ -59,7 +59,7 @@ The following options may be specified for this module:
     <td>present</td>
     <td><ul><li>present</li><li>absent</li></ul></td>
     <td>
-        <div>Set if ansible should build or remove devices on CloudVision</div>
+        <div>Set if Ansible should build or remove devices on CloudVision</div>
     </td>
     </tr>
 
@@ -70,7 +70,7 @@ The following options may be specified for this module:
     <td></td>
     <td></td>
     <td>
-        <div>Yaml dictionary to describe intended containers</div>
+        <div>YAML dictionary to describe intended containers</div>
     </td>
     </tr>
 

--- a/ansible_collections/arista/cvp/docs/_build/cv_device_v3.rst
+++ b/ansible_collections/arista/cvp/docs/_build/cv_device_v3.rst
@@ -47,7 +47,7 @@ The following options may be specified for this module:
     <td>loose</td>
     <td><ul><li>loose</li><li>strict</li></ul></td>
     <td>
-        <div>Set how configlets are attached/detached on device. If set to strict all configlets and image bundles not listed in your vars are detached.</div>
+        <div>Set how configlets are attached/detached on device. If set to strict, all configlets and image bundles not listed in your vars are detached.</div>
     </td>
     </tr>
 
@@ -58,7 +58,7 @@ The following options may be specified for this module:
     <td></td>
     <td></td>
     <td>
-        <div>List of devices with their container, configlet and image bundle information</div>
+        <div>List of devices with their container, configlet, and image bundle information</div>
     </td>
     </tr>
 
@@ -80,7 +80,7 @@ The following options may be specified for this module:
     <td>present</td>
     <td><ul><li>present</li><li>factory_reset</li><li>provisioning_reset</li><li>absent</li></ul></td>
     <td>
-        <div>Set if ansible should build or remove devices on CLoudvision</div>
+        <div>Set if Ansible should build, remove devices from provisioning, fully decommission or factory reset devices on CloudVision</div>
     </td>
     </tr>
 

--- a/ansible_collections/arista/cvp/docs/modules/cv_change_control_v3.rst.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_change_control_v3.rst.md
@@ -56,7 +56,18 @@ The following options may be specified for this module:
 <td></td>
 <td></td>
 <td>
-    <div>The name of the change control. If not provided, one will be generated.</div>
+    <div>The name of the change control, If not provided, one will be generated automatically.</div>
+</td>
+</tr>
+
+<tr>
+<td>schedule_time<br/><div style="font-size: small;"></div></td>
+<td>str</td>
+<td>no</td>
+<td></td>
+<td></td>
+<td>
+    <div>RFC3339 time format, e.g., 2021-12-23T02:07:00.0</div>
 </td>
 </tr>
 
@@ -65,7 +76,7 @@ The following options may be specified for this module:
 <td>str</td>
 <td>no</td>
 <td>show</td>
-<td><ul><li>show</li><li>set</li><li>remove</li></ul></td>
+<td><ul><li>show</li><li>set</li><li>remove</li><li>approve</li><li>unapprove</li><li>execute</li><li>schedule</li><li>approve_and_execute</li><li>schedule_and_approve</li></ul></td>
 <td>
     <div>Set if we should get, set/update, or remove the change control</div>
 </td>
@@ -94,6 +105,7 @@ The following options may be specified for this module:
                   value: <device serial number>
               stage: Pre-Checks
             - action: "Switch Healthcheck"
+              name: Switch2_healthcheck
               arguments:
                 - name: DeviceID
                   value: <device serial number>
@@ -132,6 +144,7 @@ The following options may be specified for this module:
           arista.cvp.cv_change_control_v3:
             state: set
             change: "{{ change }}"
+          register: cv_change_control
 
         - name: "Get the created change control {{inventory_hostname}}"
           arista.cvp.cv_change_control_v3:
@@ -153,6 +166,16 @@ The following options may be specified for this module:
         - name: "Show deleted CCs"
           debug:
             msg: "{{cv_deleted}}"
+
+        - name: "Approve a change control on {{inventory_hostname}}"
+          arista.cvp.cv_change_control_v3:
+            state: approve
+            change_id: ["{{ cv_change_control.data.id }}"]
+
+        - name: "Execute a change control on {{inventory_hostname}}"
+          arista.cvp.cv_change_control_v3:
+            state: execute
+            change_id: ["{{ cv_change_control.data.id }}"]
 
 ### Author
 

--- a/ansible_collections/arista/cvp/docs/modules/cv_container_v3.rst.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_container_v3.rst.md
@@ -37,7 +37,7 @@ The following options may be specified for this module:
 <td>loose</td>
 <td><ul><li>loose</li><li>strict</li></ul></td>
 <td>
-    <div>Set how configlets are attached/detached on container. If set to strict all configlets not listed in your vars are detached.</div>
+    <div>Set how configlets are attached/detached to containers. If set to strict all configlets not listed in your vars will be detached.</div>
 </td>
 </tr>
 
@@ -48,7 +48,7 @@ The following options may be specified for this module:
 <td>present</td>
 <td><ul><li>present</li><li>absent</li></ul></td>
 <td>
-    <div>Set if ansible should build or remove devices on CloudVision</div>
+    <div>Set if Ansible should build or remove devices on CloudVision</div>
 </td>
 </tr>
 
@@ -59,7 +59,7 @@ The following options may be specified for this module:
 <td></td>
 <td></td>
 <td>
-    <div>Yaml dictionary to describe intended containers</div>
+    <div>YAML dictionary to describe intended containers</div>
 </td>
 </tr>
 

--- a/ansible_collections/arista/cvp/docs/modules/cv_device_v3.rst.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_device_v3.rst.md
@@ -36,7 +36,7 @@ The following options may be specified for this module:
 <td>loose</td>
 <td><ul><li>loose</li><li>strict</li></ul></td>
 <td>
-    <div>Set how configlets are attached/detached on device. If set to strict all configlets and image bundles not listed in your vars are detached.</div>
+    <div>Set how configlets are attached/detached on device. If set to strict, all configlets and image bundles not listed in your vars are detached.</div>
 </td>
 </tr>
 
@@ -47,7 +47,7 @@ The following options may be specified for this module:
 <td></td>
 <td></td>
 <td>
-    <div>List of devices with their container, configlet and image bundle information</div>
+    <div>List of devices with their container, configlet, and image bundle information</div>
 </td>
 </tr>
 
@@ -69,7 +69,7 @@ The following options may be specified for this module:
 <td>present</td>
 <td><ul><li>present</li><li>factory_reset</li><li>provisioning_reset</li><li>absent</li></ul></td>
 <td>
-    <div>Set if ansible should build or remove devices on CLoudvision</div>
+    <div>Set if Ansible should build, remove devices from provisioning, fully decommission or factory reset devices on CloudVision</div>
 </td>
 </tr>
 

--- a/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
@@ -31,7 +31,7 @@ description:
   - ''
 options:
   name:
-    description: The name of the change control. If not provided, one will be generated.
+    description: The name of the change control, If not provided, one will be generated automatically.
     required: false
     type: str
   change:

--- a/ansible_collections/arista/cvp/plugins/modules/cv_container_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_container_v3.py
@@ -39,17 +39,17 @@ description:
   - Returns number of created and/or deleted containers
 options:
   topology:
-    description: Yaml dictionary to describe intended containers
+    description: YAML dictionary to describe intended containers
     required: true
     type: dict
   state:
-    description: Set if ansible should build or remove devices on CloudVision
+    description: Set if Ansible should build or remove devices on CloudVision
     required: false
     default: 'present'
     choices: ['present', 'absent']
     type: str
   apply_mode:
-    description: Set how configlets are attached/detached on container. If set to strict all configlets not listed in your vars are detached.
+    description: Set how configlets are attached/detached to containers. If set to strict all configlets not listed in your vars will be detached.
     required: false
     default: 'loose'
     choices: ['loose', 'strict']

--- a/ansible_collections/arista/cvp/plugins/modules/cv_device_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_device_v3.py
@@ -39,7 +39,7 @@ options:
     type: list
     elements: dict
   state:
-    description: Set if ansible should build or remove devices on CLoudvision
+    description: Set if Ansible should build, remove devices from provisioning, fully decommission or factory reset devices on CloudVision
     required: false
     default: 'present'
     choices: ['present', 'factory_reset', 'provisioning_reset', 'absent']


### PR DESCRIPTION
## Change Summary
Fixed a few nits in documentation to match changes in `schema documentation`

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name


## Proposed changes

## How to test
`make webdoc`
`mkdocs serve`

## Checklist

### User Checklist

- N/A

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
