### PR TITLE
Doc: Enable twitter, edit path, bump material

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -228,12 +228,13 @@ jobs:
           until docker exec webdoc_cvp curl -s -I http://localhost:8000/ ; do sleep 2; done
       - name: check links for 404
         run: |
-          docker run --network container:webdoc_cvp raviqqe/muffet:2.4.0 http://127.0.0.1:8000 \
+          docker run --network container:webdoc_cvp raviqqe/muffet:2.6.1 http://127.0.0.1:8000 \
             -e ".*fonts.googleapis.com.*" \
             -e ".*fonts.gstatic.com.*" \
             -e ".*edit.*" \
             -e ".*aristanetworks.force.com.*" \
             -e ".*https://s3.amazonaws.com/onelogin-sourcemaps/.*" \
+            -e "twitter.com" \
             -f --buffer-size=8192 \
             --color=always \
             --skip-tls-verification \

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ webdoc: ## Build documentation to publish static content
 
 .PHONY: check-cvp-404
 check-cvp-404: ## Check local 404 links for AVD documentation
-	docker run --rm --network container:webdoc_cvp raviqqe/muffet:1.5.7 http://127.0.0.1:8001 -e ".*fonts.googleapis.com.*" -e ".*fonts.gstatic.com.*" -e ".*edit.*" -f --limit-redirections=3 --timeout=${MUFFET_TIMEOUT}
+	docker run --rm --network container:webdoc_cvp raviqqe/muffet:2.6.1 http://127.0.0.1:8001 -e ".*fonts.googleapis.com.*" -e ".*fonts.gstatic.com.*" -e ".*tools.ietf.org.*" -e ".*edit.*" -e ".*docs.github.com.*" -e "twitter.com" -f --max-redirections=3 --timeout=$(MUFFET_TIMEOUT) --rate-limit=1
 
 #########################################
 # Misc Actions 							#

--- a/ansible_collections/arista/cvp/docs/requirements.txt
+++ b/ansible_collections/arista/cvp/docs/requirements.txt
@@ -1,6 +1,6 @@
 mkdocs
 mkdocs-bootswatch
-mkdocs-material==8.5.1
+mkdocs-material==8.5.7
 mkdocs-material-extensions
 fontawesome-markdown
 pymdown-extensions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,7 @@ repo_url: https://github.com/aristanetworks/ansible-cvp
 
 # Configuration
 use_directory_urls: true
-edit_uri: ""
+edit_uri: edit/devel/ansible_collections/arista/cvp/
 theme:
   name: material
   custom_dir: ansible_collections/arista/cvp/docs/_overrides
@@ -25,6 +25,7 @@ theme:
   icon:
     repo: fontawesome/brands/github
     logo: fontawesome/solid/book
+    edit: fontawesome/solid/file-pen
   favicon: docs/_media/favicon.ico
   font:
     code: Fira Mono
@@ -47,8 +48,8 @@ extra:
   social:
     - icon: fontawesome/brands/github-alt
       link: https://github.com/aristanetworks/ansible-cvp
-    # - icon: fontawesome/brands/twitter
-    #   link: https://twitter.com/AristaNetworks
+    - icon: fontawesome/brands/twitter
+      link: https://twitter.com/AristaNetworks
     - icon: fontawesome/solid/globe
       link: https://www.arista.com
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -156,20 +156,20 @@ nav:
     - CloudVision Configlet Sync: roles/configlets_sync/README.md
   - Modules documentation:
     - Modules version 1:
-      - Module cv_facts: docs/modules/cv_facts.rst/
-      - Module cv_configlet: docs/modules/cv_configlet.rst/
-      - Module cv_container: docs/modules/cv_container.rst/
-      - Module cv_device: docs/modules/cv_device.rst/
-      - Module cv_task: docs/modules/cv_task.rst/
+      - cv_facts: docs/modules/cv_facts.rst/
+      - cv_configlet: docs/modules/cv_configlet.rst/
+      - cv_container: docs/modules/cv_container.rst/
+      - cv_device: docs/modules/cv_device.rst/
+      - cv_task: docs/modules/cv_task.rst/
     - Module version 3:
-      - Module cv_configlet_v3: docs/modules/cv_configlet_v3.rst.md
-      - Module cv_container_v3: docs/modules/cv_container_v3.rst.md
-      - Module cv_device_v3: docs/modules/cv_device_v3.rst.md
-      - Module cv_task_v3: docs/modules/cv_task_v3.rst.md
-      - Module cv_facts_v3: docs/modules/cv_facts_v3.rst.md
-      - Module cv_image_v3: docs/modules/cv_image_v3.rst.md
-      - Module cv_tag_v3: docs/modules/cv_tag_v3.rst.md
-      - Module cv_change_control_v3: docs/modules/cv_change_control_v3.rst.md
+      - cv_configlet_v3: docs/modules/cv_configlet_v3.rst.md
+      - cv_container_v3: docs/modules/cv_container_v3.rst.md
+      - cv_device_v3: docs/modules/cv_device_v3.rst.md
+      - cv_task_v3: docs/modules/cv_task_v3.rst.md
+      - cv_facts_v3: docs/modules/cv_facts_v3.rst.md
+      - cv_image_v3: docs/modules/cv_image_v3.rst.md
+      - cv_tag_v3: docs/modules/cv_tag_v3.rst.md
+      - cv_change_control_v3: docs/modules/cv_change_control_v3.rst.md
   - External resources:
     - Ansible collection user guide: https://docs.ansible.com/ansible/latest/user_guide/collections_using.html
     - Ansible User guide: https://docs.ansible.com/ansible/latest/user_guide/index.html


### PR DESCRIPTION
## Change Summary

This change modifies the following:

- Updates CI and Make to exclude Twitter on link checks
- Bumped raviqqe/muffet to 2.6.1
- Adds Twitter social to site
- Corrected edit path and enabled for future contributions from community!
- Bumped MkDocs version from 8.5.1 to 8.5.7, [see changelog](https://squidfunk.github.io/mkdocs-material/changelog/)

## Proposed changes

General improvements to site. See change summary for a change breakdown.

## How to test

Reviewers can do either of the following:

```shell
Checkout this PR
python3 -m venv venv
source venv/bin/activate
pip install -r ansible_collections/arista/cvp/docs/requirements.txt
mkdocs serve
```

Or visit the build based on this PR [here](https://ansible-cvp-juliopdx.readthedocs.io/en/mkdocs_updates/)

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
