### PR TITLE
Doc: Update cvp version support for schedule option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ This repository provides content for Ansible's collection **arista.cvp** with fo
 - [**arista.cvp.cv_task_v3**](https://cvp.avd.sh/en/latest/docs/modules/cv_task_v3.rst/) - Run tasks created on CVP.
 - [**arista.cvp.cv_facts_v3**](https://cvp.avd.sh/en/latest/docs/modules/cv_facts_v3.rst/) - Collect information from CloudVision.
 - [**arista.cvp.cv_image_v3**](https://cvp.avd.sh/en/latest/docs/modules/cv_image_v3.rst/) - Create EOS images and bundles on CloudVision.
+- [**arista.cvp.cv_tag_v3**](https://cvp.avd.sh/en/latest/docs/modules/cv_tag_v3.rst/) - Create, delete, assign and unassign tags on CloudVision.
+- [**arista.cvp.cv_change_control_v3**](https://cvp.avd.sh/en/latest/docs/modules/cv_change_control_v3.rst/) - Manage change controls on CloudVision.
 
 ### List of available roles
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ This repository provides content for Ansible's collection **arista.cvp** with fo
 - [**arista.cvp.cv_task_v3**](https://cvp.avd.sh/en/latest/docs/modules/cv_task_v3.rst/) - Run tasks created on CVP.
 - [**arista.cvp.cv_facts_v3**](https://cvp.avd.sh/en/latest/docs/modules/cv_facts_v3.rst/) - Collect information from CloudVision.
 - [**arista.cvp.cv_image_v3**](https://cvp.avd.sh/en/latest/docs/modules/cv_image_v3.rst/) - Create EOS images and bundles on CloudVision.
-- [**arista.cvp.cv_tag_v3**](https://cvp.avd.sh/en/latest/docs/modules/cv_tag_v3.rst/) - Create, delete, assign and unassign tags on CloudVision.
-- [**arista.cvp.cv_change_control_v3**](https://cvp.avd.sh/en/latest/docs/modules/cv_change_control_v3.rst/) - Manage change controls on CloudVision.
 
 ### List of available roles
 

--- a/ansible_collections/arista/cvp/README.md
+++ b/ansible_collections/arista/cvp/README.md
@@ -85,6 +85,8 @@ This repository provides content for Ansible's collection **arista.cvp** with fo
 - [**arista.cvp.cv_task_v3**](docs/modules/cv_task_v3.rst/) - Run tasks created on CVP.
 - [**arista.cvp.cv_facts_v3**](docs/modules/cv_facts_v3.rst/) - Collect information from CloudVision.
 - [**arista.cvp.cv_image_v3**](https://cvp.avd.sh/en/latest/docs/modules/cv_image_v3.rst/) - Create EOS images and bundles on CloudVision.
+- [**arista.cvp.cv_tag_v3**](https://cvp.avd.sh/en/latest/docs/modules/cv_tag_v3.rst/) - Create, delete, assign and unassign tags on CloudVision.
+- [**arista.cvp.cv_change_control_v3**](https://cvp.avd.sh/en/latest/docs/modules/cv_change_control_v3.rst/) - Manage change controls on CloudVision.
 
 ### List of available roles
 

--- a/ansible_collections/arista/cvp/docs/how-to/v3/cv_change_control_v3.md
+++ b/ansible_collections/arista/cvp/docs/how-to/v3/cv_change_control_v3.md
@@ -18,9 +18,9 @@
   - `state: approve`: Approve Change control
   - `state: unapprove`: Unpprove Change control
   - `state: execute`: Execute Change control
-  - `state: schedule`: Schedule Change control (available only on cvp2022.1.0 and newer)
+  - `state: schedule`: Schedule Change control (available only on CVP 2022.1.0 and newer or CVaaS)
   - `state: approve_and_execute`: Approve and Execute Change control
-  - `state: schedule_and_approve`: Schedule and Approve Change control (available only on cvp2022.1.0 and newer)
+  - `state: schedule_and_approve`: Schedule and Approve Change control (available only on CVP 2022.1.0 and newer or CVaaS)
 - `change`: A dict, with the structure of the change. The change dict is structured as follows:
 
 ```yaml

--- a/ansible_collections/arista/cvp/docs/how-to/v3/cv_change_control_v3.md
+++ b/ansible_collections/arista/cvp/docs/how-to/v3/cv_change_control_v3.md
@@ -18,9 +18,9 @@
   - `state: approve`: Approve Change control
   - `state: unapprove`: Unpprove Change control
   - `state: execute`: Execute Change control
-  - `state: schedule`: Schedule Change control
+  - `state: schedule`: Schedule Change control (available only on cvp2022.1.0 and newer)
   - `state: approve_and_execute`: Approve and Execute Change control
-  - `state: schedule_and_approve`: Schedule and Approve Change control
+  - `state: schedule_and_approve`: Schedule and Approve Change control (available only on cvp2022.1.0 and newer)
 - `change`: A dict, with the structure of the change. The change dict is structured as follows:
 
 ```yaml


### PR DESCRIPTION
## Change Summary

`schedule` option in `cv_change_control_v3` is available only from cvp2022.1.0 and newer. Updating this in docs

## Related Issue(s)

Fixes #545 

## Component(s) name

`arista.cvp.cv_change_control_v3`

## Proposed changes

## How to test
`make webdocs`
`mkdocs serve`
or check readthedocs built on this PR: https://ansible-cvp-forked.readthedocs.io/en/doc_cc_v3/docs/how-to/v3/cv_change_control_v3/

## Checklist

### User Checklist

- N/A

### Repository Checklist
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
