### PR TITLE
Fix(cv_facts_v3): Handle stale and empty devices in the inventory having an image bundle of type None

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -462,7 +462,7 @@ class CvFactsTools():
             MODULE_LOGGER.error('Error when collecting device bundle facts: %s', str(error_msg))
 
         MODULE_LOGGER.debug('Bundle data assigned to container: %s', str(bundle))
-        if bundle['bundleName'] is not None:
+        if bundle is not None and bundle['bundleName'] is not None:
             return bundle['bundleName']
         else:
             return bundle_name


### PR DESCRIPTION
## Change Summary

As described in issue #568 if the API call to `get_device_image_info()` returns type `None` we weren't handling this correctly

## Related Issue(s)

Fixes #568 

## Component(s) name

`arista.cvp.cv_facts_v3`

## Proposed changes
Check for returned type being `None` and handle it

## How to test
Tested fix against production system running `2021.2.1` where this was first encountered. Fix resolved the problem.
Issue #568 shows (with the serial number scrubbed) the cvprac API output that triggered this issue.

## Checklist

### User Checklist

- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
