### PR TITLE
Fix: Allow tag assignment to serial numbers

### DIFF
--- a/ansible_collections/arista/cvp/docs/schema/cv_tag_v3.md
+++ b/ansible_collections/arista/cvp/docs/schema/cv_tag_v3.md
@@ -6,6 +6,7 @@
 | mode | str | No |  | create<br>delete<br>assign<br>unassign | action to carry out on the tags. <br>create - create tags<br>delete - delete tags<br>assign - assign existing tags on device<br>unassign - unassign existing tags from device |
 | tags | list | Yes |  |  | CVP tags |
 | &nbsp;&nbsp;&nbsp;&nbsp;device | str | No |  |  | device to assign tags to |
+| &nbsp;&nbsp;&nbsp;&nbsp;device_id | str | No |  |  | serial number of the device to assign tags to |
 | &nbsp;&nbsp;&nbsp;&nbsp;device_tags | List | No |  |  | device tags |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- name | str | Yes |  |  | name of tag |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;value |  str | Yes |  |  | value of tag |

--- a/ansible_collections/arista/cvp/examples/cv_tag_v3/assign.unassign-device-autocreate.yml
+++ b/ansible_collections/arista/cvp/examples/cv_tag_v3/assign.unassign-device-autocreate.yml
@@ -7,16 +7,16 @@
       # - device_id: leaf1
       - device: leaf1.atd.lab
         device_tags:
-          - name: leaf1DTag1
-            value: leaf1DVal1
-      # - device: leaf2.atd.lab
+          - name: leaf1DTag1_new
+            value: leaf1DVal1_new
       - device_id: leaf2
+      # - device: leaf2.atd.lab
         device_tags:
-          - name: leaf2DTag1
-            value: leaf2DVal1
+          - name: leaf2DTag1_new
+            value: leaf2DVal1_new
   tasks:
-    - name: assign/unassign existing device tags
+    - name: assign/unassign non-existing device tags
       arista.cvp.cv_tag_v3:
         tags: "{{CVP_TAGS}}"
         mode: assign
-        # mode: unassign
+        auto_create: true

--- a/ansible_collections/arista/cvp/examples/cv_tag_v3/assign.unassign-device.yml
+++ b/ansible_collections/arista/cvp/examples/cv_tag_v3/assign.unassign-device.yml
@@ -1,0 +1,17 @@
+- name: Test cv_tag_v3
+  hosts: CloudVision
+  connection: local
+  gather_facts: no
+  vars:
+    CVP_TAGS:
+      - device_id: leaf1
+      # - device: leaf1.atd.lab
+        device_tags:
+          - name: d_t2
+            value: 123
+  tasks:
+    - name: create tags
+      arista.cvp.cv_tag_v3:
+        tags: "{{CVP_TAGS}}"
+        # mode: unassign
+        mode: assign

--- a/ansible_collections/arista/cvp/examples/cv_tag_v3/assign.unassign-interface-autocreate.yml
+++ b/ansible_collections/arista/cvp/examples/cv_tag_v3/assign.unassign-interface-autocreate.yml
@@ -8,23 +8,23 @@
       # - device_id: leaf1
         interface_tags:
           - tags:
-            - name: leaf1IntfTag1
-              value: leaf1IntfVal1
+            - name: leaf1IntfTag1_new
+              value: leaf1IntfVal1_new
             interface: Ethernet1
           - tags:
-            - name: leaf1IntfTag2
-              value: leaf1IntfVal2
+            - name: leaf1IntfTag2_new
+              value: leaf1IntfVal2_new
             interface: Ethernet2
       - device_id: leaf2
       # - device: leaf2.atd.lab
         interface_tags:
           - tags:
-            - name: leaf2IntfTag1
-              value: leaf2IntfVal1
+            - name: leaf2IntfTag1_new
+              value: leaf2IntfVal1_new
             interface: Ethernet1
   tasks:
-    - name: assign/unassign existing interface tags
+    - name: assign/unassign non-existing interface tags
       arista.cvp.cv_tag_v3:
         tags: "{{CVP_TAGS}}"
         mode: assign
-        # mode: unassign
+        auto_create: true

--- a/ansible_collections/arista/cvp/examples/cv_tag_v3/assign.unassign-interface.yml
+++ b/ansible_collections/arista/cvp/examples/cv_tag_v3/assign.unassign-interface.yml
@@ -1,0 +1,21 @@
+- name: Test cv_tag_v3
+  hosts: CloudVision
+  connection: local
+  gather_facts: no
+  vars:
+    CVP_TAGS:
+      - device: leaf1.atd.lab
+      # - device_id: leaf1
+        interface_tags:
+          - tags:
+              - name: i_t1
+                value: i_v1
+              - name: i_t2
+                value: i_v2
+            interface: Ethernet1/1
+  tasks:
+    - name: create tags
+      arista.cvp.cv_tag_v3:
+        tags: "{{CVP_TAGS}}"
+        # mode: unassign
+        mode: assign

--- a/ansible_collections/arista/cvp/examples/cv_tag_v3/create.delete-device.yml
+++ b/ansible_collections/arista/cvp/examples/cv_tag_v3/create.delete-device.yml
@@ -1,0 +1,17 @@
+- name: Test cv_tag_v3
+  hosts: CloudVision
+  connection: local
+  gather_facts: no
+  vars:
+    CVP_TAGS:
+      - device_id: leaf1
+      # - device: leaf1.atd.lab
+        device_tags:
+          - name: d_t2
+            value: 123
+  tasks:
+    - name: create tags
+      arista.cvp.cv_tag_v3:
+        tags: "{{CVP_TAGS}}"
+        # mode: delete
+        mode: create

--- a/ansible_collections/arista/cvp/examples/cv_tag_v3/create.delete-device.yml
+++ b/ansible_collections/arista/cvp/examples/cv_tag_v3/create.delete-device.yml
@@ -4,14 +4,14 @@
   gather_facts: no
   vars:
     CVP_TAGS:
-      - device_id: leaf1
-      # - device: leaf1.atd.lab
-        device_tags:
-          - name: d_t2
-            value: 123
+      - device_tags:
+          - name: leaf1DTag1
+            value: leaf1DVal1
+          - name: leaf1DTag2
+            value: leaf1DVal2
   tasks:
-    - name: create tags
+    - name: create/delete device tags
       arista.cvp.cv_tag_v3:
         tags: "{{CVP_TAGS}}"
-        # mode: delete
         mode: create
+        # mode: delete

--- a/ansible_collections/arista/cvp/examples/cv_tag_v3/create.delete-interface.yml
+++ b/ansible_collections/arista/cvp/examples/cv_tag_v3/create.delete-interface.yml
@@ -1,0 +1,21 @@
+- name: Test cv_tag_v3
+  hosts: CloudVision
+  connection: local
+  gather_facts: no
+  vars:
+    CVP_TAGS:
+      - device_id: leaf1
+      # - device: leaf1.atd.lab
+        interface_tags:
+          - tags:
+              - name: i_t1
+                value: i_v1
+              - name: i_t2
+                value: i_v2
+            interface: Ethernet1/1
+  tasks:
+    - name: create tags
+      arista.cvp.cv_tag_v3:
+        tags: "{{CVP_TAGS}}"
+        # mode: delete
+        mode: create

--- a/ansible_collections/arista/cvp/examples/cv_tag_v3/create.delete-interface.yml
+++ b/ansible_collections/arista/cvp/examples/cv_tag_v3/create.delete-interface.yml
@@ -4,18 +4,17 @@
   gather_facts: no
   vars:
     CVP_TAGS:
-      - device_id: leaf1
-      # - device: leaf1.atd.lab
-        interface_tags:
+      - interface_tags:
           - tags:
-              - name: i_t1
-                value: i_v1
-              - name: i_t2
-                value: i_v2
-            interface: Ethernet1/1
+              - name: leaf1IntfTag1
+                value: leaf1IntfVal1
+              - name: leaf1IntfTag2
+                value: leaf1IntfVal2
+              - name: leaf2IntfTag1
+                value: leaf2IntfVal1
   tasks:
-    - name: create tags
+    - name: create/delete interface tags
       arista.cvp.cv_tag_v3:
         tags: "{{CVP_TAGS}}"
-        # mode: delete
-        mode: create
+        # mode: create
+        mode: delete

--- a/ansible_collections/arista/cvp/plugins/module_utils/resources/schemas/v3.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/resources/schemas/v3.py
@@ -287,6 +287,14 @@ SCHEMA_CV_TAG = {
                     "leaf1"
                 ]
             },
+            "device_id": {
+                "title": "The device Schema",
+                "type": "string",
+                "default": "",
+                "examples": [
+                    "JPE19181517"
+                ]
+            },
             "device_tags": {
                 "title": "The device_tags Schema",
                 "type": "array",

--- a/ansible_collections/arista/cvp/plugins/module_utils/tag_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tag_tools.py
@@ -118,10 +118,10 @@ class CvTagTools(object):
         # create tags and assign tags
         for per_device in tags:
             if mode in ('assign', 'unassign'):
-                device_name = per_device['device']
                 if 'device_id' in per_device:
                     device_id = per_device['device_id']
                 else:
+                    device_name = per_device['device']
                     device_id = self.get_serial_num(device_name)
             tag_type = per_device.keys()
             MODULE_LOGGER.info('tag_type = %s', tag_type)

--- a/ansible_collections/arista/cvp/plugins/module_utils/tag_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tag_tools.py
@@ -119,7 +119,10 @@ class CvTagTools(object):
         for per_device in tags:
             if mode in ('assign', 'unassign'):
                 device_name = per_device['device']
-                device_id = self.get_serial_num(device_name)
+                if 'device_id' in per_device:
+                    device_id = per_device['device_id']
+                else:
+                    device_id = self.get_serial_num(device_name)
             tag_type = per_device.keys()
             MODULE_LOGGER.info('tag_type = %s', tag_type)
             if 'device_tags' in tag_type:

--- a/ansible_collections/arista/cvp/plugins/modules/cv_tag_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_tag_v3.py
@@ -271,14 +271,11 @@ def main():
     # check for incompatible options
     if ansible_module.params['mode'] == 'assign' or ansible_module.params['mode'] == 'unassign':
         for per_device in ansible_module.params['tags']:
-            if 'device_tags' in per_device.keys() and 'device' not in per_device.keys():
-                ansible_module.fail_json(msg="Error, 'device' needed for each 'device_tags"
-                                             " when mode is 'assign' or 'unassign'")
+            if not ('device' in per_device.keys() or 'device_id' in per_device.keys()):
+                error_msg = "Error, either 'device' or 'device_id' needed for each 'device tags/interface tags when mode is 'assign' or 'unassign'"
+                ansible_module.fail_json(msg=error_msg)
             if 'interface_tags' in per_device.keys():
                 MODULE_LOGGER.info('interface tags in keys')
-                if 'device' not in per_device.keys():
-                    ansible_module.fail_json(msg="Error, 'device' needed for each 'interface_tags'"
-                                                 " when mode is 'assign' or 'unassign'")
                 for per_intf in per_device['interface_tags']:
                     MODULE_LOGGER.info('per_intf: %s', per_intf)
                     MODULE_LOGGER.info('keys: %s', per_intf.keys())

--- a/ansible_collections/arista/cvp/plugins/modules/cv_tag_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_tag_v3.py
@@ -111,14 +111,14 @@ EXAMPLES = r'''
         mode: assign
         auto_create: true
 
-# Delete device and interface tags
+# Delete device and interface tags using device_id
 - name: cv_tag_v3 example2
   hosts: cv_server
   connection: local
   gather_facts: no
   vars:
     CVP_TAGS:
-      - device: leaf1
+      - device_id: JPE123435
         device_tags:
           - name: tag1
             value: value1
@@ -133,14 +133,14 @@ EXAMPLES = r'''
         tags: "{{CVP_TAGS}}"
         mode: delete
 
-# Create device and interface tags (without assigning to the devices)
+# Create device and interface tags (without assigning to the devices) using device_id
 - name: cv_tag_v3 example3
   hosts: cv_server
   connection: local
   gather_facts: no
   vars:
     CVP_TAGS:
-      - device: leaf1
+      - device_id: JPE123435
         device_tags:
           - name: tag1
             value: value1


### PR DESCRIPTION
## Change Summary

Assign tags to Serial Number of the device. 
Eg: 
```
- name: Test cv_tag_v3
  hosts: CloudVision
  connection: local
  gather_facts: no
  vars:
    CVP_TAGS:
      - interface_tags:
          - tags:
              - name: intfT1
                value: intfV1
              - name: intfT2
                value: intfV2
            interface: Ethernet1/1
        device_id: JPE19181517
  tasks:
    - name: assign tags
      arista.cvp.cv_tag_v3:
        tags: "{{CVP_TAGS}}"
        mode: assign
```
Works the same way for `device tags`.

## Related Issue(s)

Fixes #558 

## Component(s) name

`arista.cvp.cv_tag_v3`

## Proposed changes
Added a new keyword `device_id` to capture serial number of the device

## How to test

### End to End test
* Follow the instruction on [Readme](https://github.com/aristanetworks/ansible-cvp/blob/devel/tests/PR_testing/README.md) to setup testing environment.
* Run the following playbooks (found on your ATD under `persist/PR_testing/cv_tag_v3`) and verify the results on CVP
`assign.unassign-device-autocreate.yml`
`assign.unassign-device.yml`
`assign.unassign-interface-autocreate.yml`
`assign.unassign-interface.yml`
`create.delete-device.yml`
`create.delete-interface.yml`

## Checklist

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
