### PR TITLE
Fix(cv_container_v3): check_mode error

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
@@ -830,7 +830,7 @@ class CvContainerTools(object):
                 if self.__check_mode:
                     change_result.success = True
                     change_result.changed = True
-                    change_result.add_entry(container[Api.generic.NAME])
+                    change_result.add_entry(container)
                 else:
                     try:
                         resp = self.__cvp_client.api.add_container(


### PR DESCRIPTION
## Change Summary

Running `cv_container_v3` with `--check` is throwing an error:
`TypeError: string indices must be integers`

## Related Issue(s)

Fixes #582 

## Component(s) name

`arista.cvp.cv_container_v3`

## How to test
```
---
- name: cv_container_v3
  hosts: CloudVision
  connection: local
  gather_facts: no
  check_mode: True
  vars:
    CVP_CONTAINERS:
      Sugetha:
        parentContainerName: Tenant
      TestCreate:
        parentContainerName: Sugetha

  tasks:
    - name: "Configure containers on {{inventory_hostname}}"
      arista.cvp.cv_container_v3:
        topology: "{{CVP_CONTAINERS}}"
        state: present
        apply_mode: loose
  ```
Output:
```
changed: [CloudVision] => changed=true 
  configlets_attached:
    changed: false
    configlets_attached_count: 0
    configlets_attached_list: []
    diff: {}
    success: false
    taskIds: []
  configlets_detached:
    changed: false
    configlets_detached_count: 0
    configlets_detached_list: []
    diff: {}
    success: true
    taskIds: []
  container_added:
    changed: true
    container_added_count: 1
    container_added_list:
    - TestCreate
    diff: {}
    success: true
    taskIds: []
  container_deleted:
    changed: false
    container_deleted_count: 0
    container_deleted_list: []
    diff: {}
    success: false
    taskIds: []
  success: true
  taskIds: []
  ```
  

## Checklist

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
