### PR TITLE
Doc: Clarification of applying topology

### DIFF
--- a/ansible_collections/arista/cvp/docs/modules/cv_container_v3.rst.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_container_v3.rst.md
@@ -15,6 +15,14 @@ containers with their parent, to create and delete containers on CVP
 side. Module also supports to configure configlets at container level.
 Returns number of created and/or deleted containers
 
+The module doesn't merge the existing container structure with the one
+specified in your playbook's topology; instead, it will try to remove
+unspecified containers from CVP. Existing containers are removed under
+two circumstances:
+
+-   The container has no confliglets attached to it.
+-   Strict apply_mode is set (see below).
+
 ## Module-specific Options
 
 The following options may be specified for this module:
@@ -86,7 +94,7 @@ The following options may be specified for this module:
       tasks:
         - name: 'running cv_container'
           arista.cvp.cv_container_v3:
-            topology: "{{CVP_CONTAINERS}}"
+            topology: "{{ containers }}"
 
     # task in strict mode
     - name: Create container topology on CVP
@@ -105,7 +113,7 @@ The following options may be specified for this module:
       tasks:
         - name: 'running cv_container'
           arista.cvp.cv_container_v3:
-            topology: "{{CVP_CONTAINERS}}"
+            topology: "{{ containers }}"
             apply_mode: strict
 
 ### Author

--- a/ansible_collections/arista/cvp/docs/modules/cv_container_v3.rst.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_container_v3.rst.md
@@ -12,16 +12,14 @@ Module added in version 3.0.0
 
 CloudVision Portal Configlet configuration requires a dictionary of
 containers with their parent, to create and delete containers on CVP
-side. Module also supports to configure configlets at container level.
-Returns number of created and/or deleted containers
-
-The module doesn't merge the existing container structure with the one
-specified in your playbook's topology; instead, it will try to remove
-unspecified containers from CVP. Existing containers are removed under
-two circumstances:
-
--   The container has no confliglets attached to it.
--   Strict apply_mode is set (see below).
+side The Module also supports assigning configlets at the container
+level Returns number of created and/or deleted containers With the
+argument <span class="title-ref">apply_mode</span> set to <span
+class="title-ref">loose</span> the module will only add new containers
+When <span class="title-ref">apply_mode</span> is set to <span
+class="title-ref">strict</span> the module will try to remove
+unspecified containers from CloudVision. This will fail if the container
+has configlets attached to it or devices are placed in the container.
 
 ## Module-specific Options
 
@@ -90,11 +88,10 @@ The following options may be specified for this module:
                 parentContainerName: Fabric
                 configlets:
                     - container_configlet
-                imageBundle: EOS-4.25.4M
       tasks:
         - name: 'running cv_container'
           arista.cvp.cv_container_v3:
-            topology: "{{ containers }}"
+            topology: "{{containers}}"
 
     # task in strict mode
     - name: Create container topology on CVP
@@ -113,12 +110,12 @@ The following options may be specified for this module:
       tasks:
         - name: 'running cv_container'
           arista.cvp.cv_container_v3:
-            topology: "{{ containers }}"
+            topology: "{{containers}}"
             apply_mode: strict
 
 ### Author
 
--   Ansible Arista Team (@aristanetworks)
+- Ansible Arista Team (@aristanetworks)
 
 ### Full Schema
 

--- a/ansible_collections/arista/cvp/plugins/modules/cv_container_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_container_v3.py
@@ -34,9 +34,12 @@ author: Ansible Arista Team (@aristanetworks)
 short_description: Manage Provisioning topology.
 description:
   - CloudVision Portal Configlet configuration requires a dictionary of containers with their parent,
-    to create and delete containers on CVP side.
-  - Module also supports to configure configlets at container level.
+    to create and delete containers on CVP side
+  - The Module also supports assigning configlets at the container level
   - Returns number of created and/or deleted containers
+  - With the argument `apply_mode` set to `loose` the module will only add new containers
+  - When `apply_mode` is set to `strict` the module will try to remove unspecified containers from CloudVision.
+    This will fail if the container has configlets attached to it or devices are placed in the container.
 options:
   topology:
     description: YAML dictionary to describe intended containers
@@ -74,7 +77,7 @@ EXAMPLES = r'''
   tasks:
     - name: 'running cv_container'
       arista.cvp.cv_container_v3:
-        topology: "{{CVP_CONTAINERS}}"
+        topology: "{{containers}}"
 
 # task in strict mode
 - name: Create container topology on CVP
@@ -93,7 +96,7 @@ EXAMPLES = r'''
   tasks:
     - name: 'running cv_container'
       arista.cvp.cv_container_v3:
-        topology: "{{CVP_CONTAINERS}}"
+        topology: "{{containers}}"
         apply_mode: strict
 '''
 


### PR DESCRIPTION
## Change Summary

The documentation didn't describe how the a container topology is applied. One could think the new and the existing topologies are merged or only the specified containers are updated.

I fixed a variable reference in the examples too.

## Component(s) name

`arista.cvp.cv_container_v3`

## Proposed changes
I added a paragraph to the synopsis.

## How to test
No testing is needed, this is just a documentation update.

## Checklist

### User Checklist

- Checked the module's behavior with @colinmacgiolla 
- Checked with MD linter
- Checked spelling

### Repository Checklist

- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
