### PR TITLE
Refactor: Avoid redundant API calls

### DIFF
--- a/ansible_collections/arista/cvp/examples/cv_device_v3/device_config_assign_atd.yaml
+++ b/ansible_collections/arista/cvp/examples/cv_device_v3/device_config_assign_atd.yaml
@@ -1,0 +1,55 @@
+- name: Playbook to demonstrate cvp modules.
+  hosts: cv_server
+  connection: local
+  gather_facts: no
+  vars:
+    # Container definition
+    containers_provision:
+        ATD_FABRIC:
+          parentContainerName: Tenant
+        ATD_LEAFS:
+          parentContainerName: ATD_FABRIC
+        ATD_SPINES:
+          parentContainerName: ATD_FABRIC
+        ATD_LEAF1:
+          parentContainerName: ATD_LEAFS
+        ATD_LEAF2:
+          parentContainerName: ATD_LEAFS
+
+    # Device definition
+    devices_provision:
+      - fqdn: spine1
+        parentContainerName: 'ATD_SPINES'
+        configlets:
+        - BaseIPv4_Spine1_EVPN_GUIDE
+      - fqdn: spine2
+        parentContainerName: 'ATD_SPINES'
+        configlets:
+        - BaseIPv4_Spine2_EVPN_GUIDE
+      - fqdn: leaf1
+        parentContainerName: 'ATD_LEAF1'
+        configlets:
+        - BaseIPv4_Leaf1_EVPN_GUIDE
+      - fqdn: leaf2
+        parentContainerName: 'ATD_LEAF1'
+        configlets:
+        - BaseIPv4_Leaf2_EVPN_GUIDE
+      - fqdn: leaf3
+        parentContainerName: 'ATD_LEAF2'
+        configlets:
+        - BaseIPv4_Leaf3_EVPN_GUIDE
+      - fqdn: leaf4
+        parentContainerName: 'ATD_LEAF2'
+        configlets:
+        - BaseIPv4_Leaf4_EVPN_GUIDE
+
+
+  tasks:
+    - name: "Build Container topology on {{inventory_hostname}}"
+      arista.cvp.cv_container_v3:
+        topology: '{{containers_provision}}'
+
+    - name: "Configure devices on {{inventory_hostname}}"
+      arista.cvp.cv_device_v3:
+        devices: '{{devices_provision}}'
+        apply_mode: loose

--- a/ansible_collections/arista/cvp/plugins/module_utils/configlet_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/configlet_tools.py
@@ -195,7 +195,7 @@ class CvConfigletTools(object):
             cv_data = self.get_configlet_data_cv(
                 configlet_name=configlet[Api.generic.NAME])
             if present:
-                if self.is_present(configlet_name=configlet[Api.generic.NAME]):
+                if cv_data is not None:
                     configlet[Api.generic.KEY] = cv_data[Api.generic.KEY]
                     configlet['diff'] = self._compare(
                         fromText=cv_data[Api.generic.CONFIG], toText=configlet[Api.generic.CONFIG], fromName='CVP', toName='Ansible')
@@ -207,7 +207,7 @@ class CvConfigletTools(object):
 
                 else:
                     to_create.append(configlet)
-            elif self.is_present(configlet_name=configlet[Api.generic.NAME]):
+            elif cv_data is not None:
                 configlet[Api.generic.KEY] = cv_data[Api.generic.KEY]
                 configlet['diff'] = self._compare(
                     fromText=cv_data[Api.generic.CONFIG], toText=configlet[Api.generic.CONFIG], fromName='CVP', toName='Ansible')

--- a/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
@@ -22,6 +22,7 @@ __metaclass__ = type
 import traceback
 import logging
 import pprint
+from functools import lru_cache
 from typing import List
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.arista.cvp.plugins.module_utils.resources.api.fields import Api
@@ -729,6 +730,7 @@ class CvContainerTools(object):
     #   Boolean & getters functions
     #############################################
 
+    @lru_cache
     def is_empty(self, container_name: str):
         """
         is_empty Test if container has no child AND no devices attached to it
@@ -758,6 +760,7 @@ class CvContainerTools(object):
             return True
         return False
 
+    @lru_cache
     def is_container_exists(self, container_name):
         """
         is_container_exists Test if a given container exists on CV
@@ -846,6 +849,10 @@ class CvContainerTools(object):
                             change_result.success = True
                             change_result.changed = True
                             change_result.count += 1
+
+                            # Invalidate the cached result of is_container_exists
+                            self.is_container_exists.cache_clear()
+
         else:
             message = "Parent container (" + str(
                 parent) + ") is missing for container " + str(container)
@@ -918,6 +925,10 @@ class CvContainerTools(object):
                         change_result.success = True
                         change_result.changed = True
                         change_result.count += 1
+
+                        # Invalidate the cached result of is_container_exists
+                        self.is_container_exists.cache_clear()
+
         return change_result
 
     def configlets_attach(self, container: str, configlets: List[str], strict: bool = False):


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Improve performance of especially `cv_device_v3` by avoiding redundant API calls.

## Component(s) name

- `configlet_tools.py`
- `container_tools.py`
- `device_tools.py`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Refactoring code to avoid duplicate API calls
- Implement `lru_cache` on some methods with API calls, to cache the result for repeated calls.
- Invalidate `lru_cache` for containers when containers are created/deleted.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Pass all CI.

Testing with small 6 device inventory in 3 containers. No imagebundles.

### Before
- Initial run - creating containers, adding configlets, moving devices (Creating tasks)
  **100 seconds**
- Subsequent run with no changes
  **60 seconds**

### After
- Initial run - creating containers, adding configlets, moving devices (Creating tasks)
  **66 seconds**
- Subsequent run with no changes
  **30 seconds**

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
