### PR TITLE
Fix(cv_device_v3): Fix check for missing devices

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -441,8 +441,6 @@ class CvDeviceTools(object):
 
         if cv_data is not None and len(cv_data) > 0:
             cv_data[Api.device.BUNDLE] = self.__cv_client.api.get_device_image_info(cv_data['key'])
-        else:
-            cv_data[Api.device.BUNDLE] = None
 
         MODULE_LOGGER.debug('Got following data for %s using %s: %s', str(search_value), str(search_by), str(cv_data))
         return cv_data


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix check for missing devices

## Related Issue(s)

Fixes #578 

## Component(s) name

`arista.cvp.cv_device_v3`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
The missing device check was failing because we always inserted information about imageBundle, even if the device was not on CVP.

This meant that any subsequent actions failed badly, because they assumed the device was there.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Tested manually by pushing to a missing device.

### Error Before fix
```
fatal: [CV_AVD_FABRIC]: FAILED! => {"changed": false, "module_stderr": "/home/avd/.local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.cv-staging.corp.arista.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n  warnings.warn(\n/home/avd/.local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.cv-staging.corp.arista.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n  warnings.warn(\n/home/avd/.local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.cv-staging.corp.arista.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n  warnings.warn(\n/home/avd/.local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.cv-staging.corp.arista.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n  warnings.warn(\n/home/avd/.local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.cv-staging.corp.arista.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n  warnings.warn(\n/home/avd/.local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.cv-staging.corp.arista.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n  warnings.warn(\n/home/avd/.local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.cv-staging.corp.arista.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n  warnings.warn(\n/home/avd/.local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.cv-staging.corp.arista.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n  warnings.warn(\n/home/avd/.local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.cv-staging.corp.arista.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n  warnings.warn(\n/home/avd/.local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.cv-staging.corp.arista.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n  warnings.warn(\n/home/avd/.local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.cv-staging.corp.arista.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n  warnings.warn(\n/home/avd/.local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.cv-staging.corp.arista.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n  warnings.warn(\n/home/avd/.local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.cv-staging.corp.arista.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n  warnings.warn(\n/home/avd/.local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.cv-staging.corp.arista.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n  warnings.warn(\n/home/avd/.local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.cv-staging.corp.arista.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n  warnings.warn(\n/home/avd/.local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.cv-staging.corp.arista.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n  warnings.warn(\n/home/avd/.local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.cv-staging.corp.arista.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n  warnings.warn(\n/home/avd/.local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.cv-staging.corp.arista.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n  warnings.warn(\n/home/avd/.local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.cv-staging.corp.arista.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n  warnings.warn(\n/home/avd/.local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.cv-staging.corp.arista.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n  warnings.warn(\n/home/avd/.local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.cv-staging.corp.arista.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n  warnings.warn(\n/home/avd/.local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.cv-staging.corp.arista.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n  warnings.warn(\nTraceback (most recent call last):\n  File \"/home/avd/.ansible/tmp/ansible-local-9328x5r1bubt/ansible-tmp-1677061318.5386138-9932-239311417291886/AnsiballZ_cv_device_v3.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/home/avd/.ansible/tmp/ansible-local-9328x5r1bubt/ansible-tmp-1677061318.5386138-9932-239311417291886/AnsiballZ_cv_device_v3.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/avd/.ansible/tmp/ansible-local-9328x5r1bubt/ansible-tmp-1677061318.5386138-9932-239311417291886/AnsiballZ_cv_device_v3.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.arista.cvp.plugins.modules.cv_device_v3', init_globals=dict(_module_fqn='ansible_collections.arista.cvp.plugins.modules.cv_device_v3', _modlib_path=modlib_path),\n  File \"/usr/local/lib/python3.9/runpy.py\", line 210, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/local/lib/python3.9/runpy.py\", line 97, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/local/lib/python3.9/runpy.py\", line 87, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_arista.cvp.cv_device_v3_payload_rp2srznu/ansible_arista.cvp.cv_device_v3_payload.zip/ansible_collections/arista/cvp/plugins/modules/cv_device_v3.py\", line 268, in <module>\n  File \"/tmp/ansible_arista.cvp.cv_device_v3_payload_rp2srznu/ansible_arista.cvp.cv_device_v3_payload.zip/ansible_collections/arista/cvp/plugins/modules/cv_device_v3.py\", line 258, in main\n  File \"/tmp/ansible_arista.cvp.cv_device_v3_payload_rp2srznu/ansible_arista.cvp.cv_device_v3_payload.zip/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py\", line 1164, in manager\n  File \"/tmp/ansible_arista.cvp.cv_device_v3_payload_rp2srznu/ansible_arista.cvp.cv_device_v3_payload.zip/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py\", line 593, in __state_present\n  File \"/tmp/ansible_arista.cvp.cv_device_v3_payload_rp2srznu/ansible_arista.cvp.cv_device_v3_payload.zip/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py\", line 530, in __refresh_user_inventory\n  File \"/tmp/ansible_arista.cvp.cv_device_v3_payload_rp2srznu/ansible_arista.cvp.cv_device_v3_payload.zip/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py\", line 1035, in refresh_systemMacAddress\nKeyError: 'systemMacAddress'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

### Error after fix
```
fatal: [CV_AVD_FABRIC]: FAILED! => {"changed": false, "msg": "Error - the following devices do not exist in CVP ['spine2'] but are defined in the playbook.                 \nMake sure that the devices are provisioned and defined with the full fqdn name                 (including the domain name) if needed."}
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
