### PR TITLE
Fix: update cv_task_v3 module documentation

### DIFF
--- a/ansible_collections/arista/cvp/docs/modules/cv_task_v3.rst.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_task_v3.rst.md
@@ -56,11 +56,11 @@ The following options may be specified for this module:
 
     ---
     - name: Execute all tasks registered in cvp_configlets variable
-      arista.cvp.cv_task:
+      arista.cvp.cv_task_v3:
         tasks: "{{ cvp_configlets.taskIds }}"
 
     - name: Cancel a list of pending tasks
-      arista.cvp.cv_task:
+      arista.cvp.cv_task_v3:
         tasks: ['666', '667']
         state: cancelled
 

--- a/ansible_collections/arista/cvp/plugins/modules/cv_task_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_task_v3.py
@@ -49,11 +49,11 @@ options:
 EXAMPLES = '''
 ---
 - name: Execute all tasks registered in cvp_configlets variable
-  arista.cvp.cv_task:
+  arista.cvp.cv_task_v3:
     tasks: "{{ cvp_configlets.taskIds }}"
 
 - name: Cancel a list of pending tasks
-  arista.cvp.cv_task:
+  arista.cvp.cv_task_v3:
     tasks: ['666', '667']
     state: cancelled
 '''


### PR DESCRIPTION
update the examples to leverage the cv_task_v3 module instead of cv_task as it's no longer working

## Change Summary

update documentation to use the cv_task_v3 module

## Related Issue(s)

Fixes -

## Component(s) name

documentation

## Proposed changes

update documentation

## How to test

n/a

## Checklist

### User Checklist


### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
