### PR TITLE
Fix(dhcp_configuration) Per dhcp client registration setting not working

### DIFF
--- a/ansible_collections/arista/cvp/roles/dhcp_configuration/templates/dhcpd.conf.j2
+++ b/ansible_collections/arista/cvp/roles/dhcp_configuration/templates/dhcpd.conf.j2
@@ -48,7 +48,11 @@ host {{ client.name }} {
     hardware ethernet {{ client.mac | string }};
 {%     endif %}
     fixed-address {{client.ip4}};
+{%     if client.registration is defined %}
+    option bootfile-name "{{ client.registration }}";
+{%     elif ztp.default.registration is defined %}
     option bootfile-name "{{ ztp.default.registration }}";
+{%     endif %}
 {%     if client.gateway is defined %}
     option routers {{ client.gateway }};
 {%     elif ztp.default.gateway is defined %}


### PR DESCRIPTION
## Change Summary

This fixes the behaviour that the dhcp bootfile-name option is now also rendered on a per client basis instead of only global.
Futher it aligns to the AVD documentation now.

## Related Issue(s)

Fixes #605

## Component(s) name

`arista.cvp.dhcp_configuration`

## Proposed changes
dhcp.conf.j2 is adjusted:
old:
```option bootfile-name "{{ ztp.default.registration }}";```

new:
```
{%     if client.registration is defined %}
    option bootfile-name "{{ client.registration }}";
{%     elif ztp.default.registration is defined %}
    option bootfile-name "{{ ztp.default.registration }}";
{%     endif %}
```

## How to test
Use the key ```registration```per dhcp client:

```
---
ztp:
  default:
    registration: 'http://10.0.110.12/ztp/bootstrap'
    nameservers:
      - '10.0.0.21'
  general:
    subnets:
      - network: 10.0.110.0
        netmask: 255.255.255.0
        gateway: 10.0.110.1
        nameservers:
          - '10.0.0.21'
        start: 10.0.110.240
        end: 10.0.110.254
        lease_time: 300
    - name: KHM-SW-SPINE-101
      mac: '50:DE:01:02:00:00'
      ip4: 10.0.110.10
      registration: 'http://10.0.110.17/ztp/bootstrap'
      gateway: 10.0.110.1
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
