### PR TITLE
Fix(cv_device): Remove unnecessary bounds check in build_new_devices_list

### DIFF
--- a/ansible_collections/arista/cvp/plugins/modules/cv_device.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_device.py
@@ -479,17 +479,16 @@ def build_new_devices_list(module):
             )
             if cvp_device is None:
                 module.fail_json(msg="Device not available on Cloudvision (" + ansible_device_hostname + ")")
-            if len(cvp_device) >= 0:
-                if is_in_container(device=cvp_device, container="undefined_container"):
-                    device_info = {
-                        "name": ansible_device_hostname,
-                        "parentContainerName": ansible_device["parentContainerName"],
-                        "configlets": ansible_device["configlets"],
-                        "cv_configlets": [],
-                        "imageBundle": ansible_device["imageBundle"],
-                        "message": "Device will be provisionned",
-                    }
-                    devices_info.append(device_info)
+            if is_in_container(device=cvp_device, container="undefined_container"):
+                device_info = {
+                    "name": ansible_device_hostname,
+                    "parentContainerName": ansible_device["parentContainerName"],
+                    "configlets": ansible_device["configlets"],
+                    "cv_configlets": [],
+                    "imageBundle": ansible_device["imageBundle"],
+                    "message": "Device will be provisionned",
+                }
+                devices_info.append(device_info)
     return devices_info
 
 


### PR DESCRIPTION
## Change Summary
`cvp_device` in this location is either a dict or `None`. The condition checked here would succeed for every non-`None` dict, so this can be safely removed.

## Related Issue(s)

None.

## Component(s) name

`arista.cvp.cv_device`

## Proposed changes
This PR removes a single if-condition from `build_new_devices_list` in the above module which always succeeds on its given inputs.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

We have made the same change on an internal mirror of the repository, which has been validated by SonarQube. We have observed no change in behaviour for playbooks run on behalf of this customer.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
