### PR TITLE
CI: Add cv_tag_v3 to PR semantic

### DIFF
--- a/.github/workflows/pull-request-triage.yml
+++ b/.github/workflows/pull-request-triage.yml
@@ -80,6 +80,7 @@ jobs:
             cv_image_v3
             cv_facts_v3
             cv_change_control_v3
+            cv_tag_v3
             cv_facts
             cv_device
             cv_container


### PR DESCRIPTION
## Change Summary

Adde cv_tag_v3 to PR semantic CI test to help pipeline pass here:
https://github.com/aristanetworks/ansible-cvp/actions/runs/5320888980/jobs/9635259752?pr=634