### PR TITLE
Doc: Remove stale link

### DIFF
--- a/ansible_collections/arista/cvp/roles/configlets_sync/README.md
+++ b/ansible_collections/arista/cvp/roles/configlets_sync/README.md
@@ -6,8 +6,6 @@ This role synchronize a designated set of CVP Configlets across multiple CVP ins
 
 ![CVP Sync](files/ansible-cvp-sync.png)
 
-This role is implementation of example describe on [EOS Central blog](https://eos.arista.com/synchronising-cloudvision-portal-configlets-with-ansible/) by @Hugh-Adams.
-
 ## Requirements
 
 No specific requirements to use this role.


### PR DESCRIPTION
## Change Summary
Removed stale link under [Roles Documentation](https://cvp.avd.sh/en/stable/roles/configlets_sync/) section on the website

## How to test
`mkdocs serve`

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
