### PR TITLE
Feat(cv_facts_v3): raise errors when svcaccount/user is not authorized

### DIFF
--- a/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
@@ -433,12 +433,12 @@ class CvContainerTools(object):
                     create_task=save_topology
                 )
             except CvpRequestError as e:
-                    if "Forbidden" in str(e):
-                        message = "Error removing configlets. User is unauthorized!"
-                    else:
-                        message = "Error removing configlets " + str(configlets) + " to container " + str(container) + ". Exception: " + str(e)
-                    MODULE_LOGGER.error(message)
-                    self.__ansible.fail_json(msg=message)
+                if "Forbidden" in str(e):
+                    message = "Error removing configlets. User is unauthorized!"
+                else:
+                    message = "Error removing configlets " + str(configlets) + " to container " + str(container) + ". Exception: " + str(e)
+                MODULE_LOGGER.error(message)
+                self.__ansible.fail_json(msg=message)
             except CvpApiError as e:
                 message = "Error removing configlets " + str(configlets) + " from container " + str(container) + ". Exception: " + str(e)
                 MODULE_LOGGER.error(message)
@@ -871,7 +871,7 @@ class CvContainerTools(object):
                         if "Forbidden" in str(e):
                             message = "Error creating container. User is unauthorized!"
                         else:
-                            message = "Error creating container " + str(container) +  ". Exception: " + str(e)
+                            message = "Error creating container " + str(container) + ". Exception: " + str(e)
                         MODULE_LOGGER.error(message)
                         self.__ansible.fail_json(msg=message)
                     except CvpApiError as e:
@@ -954,7 +954,7 @@ class CvContainerTools(object):
                     if "Forbidden" in str(e):
                         message = "Error deleting container. User is unauthorized!"
                     else:
-                        message = "Error deleting container " + str(container) +  ". Exception: " + str(e)
+                        message = "Error deleting container " + str(container) + ". Exception: " + str(e)
                     MODULE_LOGGER.error(message)
                     self.__ansible.fail_json(msg=message)
                 except CvpApiError as e:

--- a/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
@@ -32,7 +32,7 @@ from ansible_collections.arista.cvp.plugins.module_utils.resources.schemas impor
 from ansible_collections.arista.cvp.plugins.module_utils.tools_schema import validate_json_schema
 from ansible_collections.arista.cvp.plugins.module_utils.resources.exceptions import AnsibleCVPApiError, AnsibleCVPNotFoundError, CVPRessource
 try:
-    from cvprac.cvp_client_errors import CvpClientError, CvpApiError
+    from cvprac.cvp_client_errors import CvpClientError, CvpApiError, CvpRequestError
     HAS_CVPRAC = True
 except ImportError:
     HAS_CVPRAC = False
@@ -356,6 +356,13 @@ class CvContainerTools(object):
                         container=container,
                         create_task=save_topology
                     )
+                except CvpRequestError as e:
+                    if "Forbidden" in str(e):
+                        message = "Error configuring configlets. User is unauthorized!"
+                    else:
+                        message = "Error configuring configlets " + str(configlets) + " to container " + str(container) + ". Exception: " + str(e)
+                    MODULE_LOGGER.error(message)
+                    self.__ansible.fail_json(msg=message)
                 except CvpApiError as e:
                     message = "Error configuring configlets " + str(configlets) + " to container " + str(container) + ". Exception: " + str(e)
                     MODULE_LOGGER.error(message)
@@ -425,6 +432,13 @@ class CvContainerTools(object):
                     container=container,
                     create_task=save_topology
                 )
+            except CvpRequestError as e:
+                    if "Forbidden" in str(e):
+                        message = "Error removing configlets. User is unauthorized!"
+                    else:
+                        message = "Error removing configlets " + str(configlets) + " to container " + str(container) + ". Exception: " + str(e)
+                    MODULE_LOGGER.error(message)
+                    self.__ansible.fail_json(msg=message)
             except CvpApiError as e:
                 message = "Error removing configlets " + str(configlets) + " from container " + str(container) + ". Exception: " + str(e)
                 MODULE_LOGGER.error(message)
@@ -507,6 +521,13 @@ class CvContainerTools(object):
                                 container[Api.generic.NAME],
                                 'container'
                             )
+                        except CvpRequestError as e:
+                            if "Forbidden" in str(e):
+                                message = "Error applying bundle to container. User is unauthorized!"
+                            else:
+                                message = "Error applying bundle to container " + str(container[Api.generic.NAME]) + ". Exception: " + str(e)
+                            MODULE_LOGGER.error(message)
+                            self.__ansible.fail_json(msg=message)
                         except CvpApiError as catch_error:
                             MODULE_LOGGER.error('Error applying bundle to device: %s', str(catch_error))
                             self.__ansible.fail_json(msg='Error applying bundle to container' + container[Api.generic.NAME] + ': ' + catch_error)
@@ -567,6 +588,13 @@ class CvContainerTools(object):
                             container[Api.generic.NAME],
                             'container'
                         )
+                    except CvpRequestError as e:
+                        if "Forbidden" in str(e):
+                            message = "Error removing bundle from container. User is unauthorized!"
+                        else:
+                            message = "Error removing bundle from container " + str(container[Api.generic.NAME]) + ". Exception: " + str(e)
+                        MODULE_LOGGER.error(message)
+                        self.__ansible.fail_json(msg=message)
                     except CvpApiError as catch_error:
                         MODULE_LOGGER.error('Error removing bundle from container: %s', str(catch_error))
                         self.__ansible.fail_json(msg='Error removing bundle from container: ' + container[Api.generic.NAME] + ': ' + catch_error)
@@ -839,6 +867,13 @@ class CvContainerTools(object):
                     try:
                         resp = self.__cvp_client.api.add_container(
                             container_name=container, parent_key=parent_id, parent_name=parent)
+                    except CvpRequestError as e:
+                        if "Forbidden" in str(e):
+                            message = "Error creating container. User is unauthorized!"
+                        else:
+                            message = "Error creating container " + str(container) +  ". Exception: " + str(e)
+                        MODULE_LOGGER.error(message)
+                        self.__ansible.fail_json(msg=message)
                     except CvpApiError as e:
                         # Add Ansible error management
                         message = "Error creating container " + str(container) + " on CV. Exception: " + str(e)
@@ -915,6 +950,13 @@ class CvContainerTools(object):
                 try:
                     resp = self.__cvp_client.api.delete_container(
                         container_name=container, container_key=container_id, parent_key=parent_id, parent_name=parent)
+                except CvpRequestError as e:
+                    if "Forbidden" in str(e):
+                        message = "Error deleting container. User is unauthorized!"
+                    else:
+                        message = "Error deleting container " + str(container) +  ". Exception: " + str(e)
+                    MODULE_LOGGER.error(message)
+                    self.__ansible.fail_json(msg=message)
                 except CvpApiError as e:
                     # Add Ansible error management
                     message = "Error deleting container " + str(container) + " on CV. Exception: " + str(e)

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -1700,6 +1700,13 @@ class CvDeviceTools(object):
                             self.__ansible.fail_json(
                                 msg=f"Error applying bundle to device {device.fqdn}: {str(catch_error)}"
                             )
+                        except CvpRequestError as catch_error:
+                            MODULE_LOGGER.error(
+                                "Error applying bundle to device: %s", str(catch_error)
+                            )
+                            self.__ansible.fail_json(
+                                msg=f"Error applying bundle to device {device.fqdn}: {str(catch_error)}"
+                            )
                         else:
                             if resp and resp["data"]["status"] == "success":
                                 result_data.changed = True

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -1936,10 +1936,9 @@ class CvDeviceTools(object):
                             msg="Error applying configlets to device"
                         )
                     except CvpRequestError:
-                        MODULE_LOGGER.error("Error applying configlets to device. User is unauthorized!")
-                        self.__ansible.fail_json(
-                            msg="Error applying configlets to device. User is unauthorized!"
-                        )
+                        message = "Failed to apply configlets to device. User is unauthorized!"
+                        MODULE_LOGGER.error(message)
+                        self.__ansible.fail_json(msg=message)
                     else:
                         if resp["data"]["status"] == "success":
                             result_data.changed = True
@@ -2235,10 +2234,9 @@ class CvDeviceTools(object):
                         msg="Error removing device from provisioning"
                     )
                 except CvpRequestError:
-                    MODULE_LOGGER.error("Removing device from provisioning failed. User is unauthorized!")
-                    self.__ansible.fail_json(
-                        msg="Removing device from provisioning failed. User is unauthorized!"
-                    )
+                    message = "Failed to remove device from provisioning. User is unauthorized!"
+                    MODULE_LOGGER.error(message)
+                    self.__ansible.fail_json(msg=message)
                 else:
                     if resp["result"] == "success":
                         result_data.changed = True
@@ -2279,7 +2277,7 @@ class CvDeviceTools(object):
                 self.__ansible.fail_json(msg="Error decommissioning device")
             except CvpRequestError as e:
                 if "403 Forbidden" in e.msg:
-                    request_err_msg = f"User is unauthorized to decommission device {device_id}"
+                    request_err_msg = f"Failed to decommission device {device_id}. User is unauthorized!"
                 else:
                     request_err_msg = f"Device with {device_id} does not exist or is not registered to decommission"
                 MODULE_LOGGER.error(request_err_msg)
@@ -2345,8 +2343,9 @@ class CvDeviceTools(object):
                     MODULE_LOGGER.error("Error resetting device")
                     self.__ansible.fail_json(msg="Error resetting device")
                 except CvpRequestError:
-                    MODULE_LOGGER.error("Error resetting device. Users is unauthorized!")
-                    self.__ansible.fail_json(msg="Error resetting device. Users is unauthorized!")
+                    message = "Failed to reset device. Users is unauthorized!"
+                    MODULE_LOGGER.error(message)
+                    self.__ansible.fail_json(msg=message)
                 else:
                     if resp and resp["data"]["status"] == "success":
                         result_data.changed = True

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -2272,7 +2272,7 @@ class CvDeviceTools(object):
                 self.__ansible.fail_json(msg="Error decommissioning device")
             except CvpRequestError as e:
                 if "403 Forbidden" in e.msg:
-                    request_err_msg =  f"User is unauthorized to decommission device {device_id}"
+                    request_err_msg = f"User is unauthorized to decommission device {device_id}"
                 else:
                     request_err_msg = f"Device with {device_id} does not exist or is not registered to decommission"
                 MODULE_LOGGER.error(request_err_msg)

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -24,13 +24,11 @@ import logging
 import re
 import os
 from typing import List
-from ansible.module_utils.basic import AnsibleModule
 from concurrent.futures import ThreadPoolExecutor
 import ansible_collections.arista.cvp.plugins.module_utils.logger   # noqa # pylint: disable=unused-import
 from ansible_collections.arista.cvp.plugins.module_utils.resources.api.fields import Api
 from ansible_collections.arista.cvp.plugins.module_utils.resources.modules.fields import FactsResponseFields
 import ansible_collections.arista.cvp.plugins.module_utils.tools_schema as schema   # noqa # pylint: disable=unused-import
-from ansible_collections.arista.cvp.plugins.module_utils.tools_cv import authorization_error
 try:
     from cvprac.cvp_client import CvpClient  # noqa # pylint: disable=unused-import
     from cvprac.cvp_client_errors import CvpApiError, CvpRequestError  # noqa # pylint: disable=unused-import
@@ -324,9 +322,8 @@ class CvFactsTools():
     CvFactsTools Object to operate Facts from Cloudvision
     """
 
-    def __init__(self, cv_connection, ansible_module: AnsibleModule = None):
+    def __init__(self, cv_connection):
         self.__cv_client = cv_connection
-        self.__ansible = ansible_module
         self._cache = {FactsResponseFields.CACHE_CONTAINERS: None, FactsResponseFields.CACHE_MAPPERS: None}
         self._max_worker = min(32, (os.cpu_count() or 1) + 4)
         self.__init_facts()
@@ -595,7 +592,7 @@ class CvFactsTools():
             cv_devices = self.__cv_client.api.get_inventory()
         except CvpApiError as error_msg:
             MODULE_LOGGER.error('Error when collecting devices facts: %s', str(error_msg))
-            authorization_error(self.__ansible.fail_json, error_msg)
+            raise error_msg
         MODULE_LOGGER.info('Extract device data using filter %s', str(filter))
         facts_builder = CvFactResource()
         for device in cv_devices:
@@ -618,7 +615,7 @@ class CvFactsTools():
             cv_containers = self.__cv_client.api.get_containers()
         except CvpApiError as error_msg:
             MODULE_LOGGER.error('Error when collecting containers facts: %s', str(error_msg))
-            authorization_error(self.__ansible.fail_json, error_msg)
+            raise error_msg
         facts_builder = CvFactResource()
         for container in cv_containers['data']:
             if container[Api.generic.NAME] != 'Tenant':
@@ -646,7 +643,7 @@ class CvFactsTools():
             max_range_calc = self.__cv_client.api.get_configlets(start=0, end=1)['total'] + 1
         except CvpApiError as error_msg:
             MODULE_LOGGER.error('Error when collecting configlets facts: %s', str(error_msg))
-            authorization_error(self.__ansible.fail_json, error_msg)
+            raise error_msg
         futures_list = []
         results = []
         with ThreadPoolExecutor(max_workers=self._max_worker) as executor:
@@ -687,7 +684,7 @@ class CvFactsTools():
             cv_images = self.__cv_client.api.get_images()
         except CvpApiError as error_msg:
             MODULE_LOGGER.error('Error when collecting images facts: %s', str(error_msg))
-            authorization_error(self.__ansible.fail_json, error_msg)
+            raise error_msg
 
         facts_builder = CvFactResource()
         for image in cv_images['data']:
@@ -720,21 +717,21 @@ class CvFactsTools():
                 cv_tasks = cv_tasks['data']
             except CvpApiError as error_msg:
                 MODULE_LOGGER.error('Error when collecting task facts: %s', str(error_msg))
-                authorization_error(self.__ansible.fail_json, error_msg)
+                raise error_msg
         elif isinstance(filter, str):
             # filter by task status
             try:
                 cv_tasks = self.__cv_client.api.get_tasks_by_status(filter)
             except CvpApiError as error_msg:
                 MODULE_LOGGER.error('Error when collecting %s task facts: %s', filter, str(error_msg))
-                authorization_error(self.__ansible.fail_json, error_msg)
+                raise error_msg
         elif isinstance(filter, int):
             # filter by task_id
             try:
                 cv_tasks = self.__cv_client.api.get_task_by_id(filter)
             except CvpApiError as error_msg:
                 MODULE_LOGGER.error('Error when collecting %s task facts: %s', filter, str(error_msg))
-                authorization_error(self.__ansible.fail_json, error_msg)
+                raise error_msg
 
         for task in cv_tasks:
             MODULE_LOGGER.debug('Got following information for task: %s', str(task))

--- a/ansible_collections/arista/cvp/plugins/module_utils/tag_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tag_tools.py
@@ -115,7 +115,11 @@ class CvTagTools(object):
         workspace_id = workspace_name_id
 
         workspace_name = workspace_name_id
-        self.__cv_client.api.workspace_config(workspace_id, workspace_name)
+        try:
+            self.__cv_client.api.workspace_config(workspace_id, workspace_name)
+        except CvpRequestError:
+            MODULE_LOGGER.info('Workspace creation failed. User is unauthorized!')
+            self.__ansible.fail_json(msg='Workspace creation failed. User is unauthorized!')
 
         # create tags and assign tags
         for per_device in tags:

--- a/ansible_collections/arista/cvp/plugins/module_utils/task_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/task_tools.py
@@ -143,7 +143,7 @@ class CvTaskTools():
                         if "Forbidden" in str(e):
                             message = "Error while adding note and executing task. User is unauthorized!"
                         else:
-                            message = "Error while adding note to task: {}".format(str(e))
+                            message = "Error while adding note to task: {0}".format(str(e))
                         logging.error(message)
                         self.__ansible.fail_json(msg=message)
                     if state == "executed":

--- a/ansible_collections/arista/cvp/plugins/module_utils/task_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/task_tools.py
@@ -137,7 +137,15 @@ class CvTaskTools():
             api_result = CvApiResult(action_name='task_' + str(task_id))
             if self.is_actionable(task_data=self.__get_task_data(task_id)):
                 if self.__ansible.check_mode is False:
-                    self.__cv_client.api.add_note_to_task(task_id, "Executed by Ansible")
+                    try:
+                        self.__cv_client.api.add_note_to_task(task_id, "Executed by Ansible")
+                    except CvpRequestError as e:
+                        if "Forbidden" in str(e):
+                            message = "Error while adding note and executing task. User is unauthorized!"
+                        else:
+                            message = "Error while adding note to task: {}".format(str(e))
+                        logging.error(message)
+                        self.__ansible.fail_json(msg=message)
                     if state == "executed":
                         api_result.add_entry(self.execute_task(task_id))
                         api_result.changed = True

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
@@ -207,3 +207,19 @@ def cv_update_configlets_on_device(module, device_facts, add_configlets, del_con
         LOGGER.info(" * cv_update_configlets_on_device - device_addition result: %s", str(device_addition))
     LOGGER.info(" * cv_update_configlets_on_device - final result: %s", str(response))
     return response
+
+
+def authorization_error(module, error_msg):
+    """
+    Function to handle authorization error and fail module with correct message.
+
+    Parameters
+    ----------
+    module : AnsibleModule
+        Ansible module information
+    error : str
+        Error message to check if it is an authorization error or not.
+
+    """
+    if "Unauthorized" in str(error_msg):
+        module(msg="Unauthorized access to CloudVision. Please check your credentials or service account token validty!")

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
@@ -207,19 +207,3 @@ def cv_update_configlets_on_device(module, device_facts, add_configlets, del_con
         LOGGER.info(" * cv_update_configlets_on_device - device_addition result: %s", str(device_addition))
     LOGGER.info(" * cv_update_configlets_on_device - final result: %s", str(response))
     return response
-
-
-def authorization_error(module, error_msg):
-    """
-    Function to handle authorization error and fail module with correct message.
-
-    Parameters
-    ----------
-    module : AnsibleModule
-        Ansible module information
-    error : str
-        Error message to check if it is an authorization error or not.
-
-    """
-    if "Unauthorized" in str(error_msg):
-        module(msg="Unauthorized access to CloudVision. Please check your credentials or service account token validty!")

--- a/ansible_collections/arista/cvp/plugins/modules/cv_facts_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_facts_v3.py
@@ -187,7 +187,7 @@ def main():
     try:
       facts = facts_collector.facts(scope=ansible_module.params['facts'], regex_filter=ansible_module.params['regexp_filter'],
                                     verbose=ansible_module.params['verbose'])
-    except Exception as e:
+    except CvpClientError as e:
       ansible_module.fail_json(msg=str(e))
     result = dict(changed=False, data=facts, failed=False)
 

--- a/ansible_collections/arista/cvp/plugins/modules/cv_facts_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_facts_v3.py
@@ -183,7 +183,7 @@ def main():
     cv_client = tools_cv.cv_connect(ansible_module)
 
     # Instantiate ansible results
-    facts_collector = CvFactsTools(cv_connection=cv_client)
+    facts_collector = CvFactsTools(cv_connection=cv_client, ansible_module=ansible_module)
     facts = facts_collector.facts(scope=ansible_module.params['facts'], regex_filter=ansible_module.params['regexp_filter'],
                                   verbose=ansible_module.params['verbose'])
     result = dict(changed=False, data=facts, failed=False)

--- a/ansible_collections/arista/cvp/plugins/modules/cv_facts_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_facts_v3.py
@@ -183,9 +183,12 @@ def main():
     cv_client = tools_cv.cv_connect(ansible_module)
 
     # Instantiate ansible results
-    facts_collector = CvFactsTools(cv_connection=cv_client, ansible_module=ansible_module)
-    facts = facts_collector.facts(scope=ansible_module.params['facts'], regex_filter=ansible_module.params['regexp_filter'],
-                                  verbose=ansible_module.params['verbose'])
+    facts_collector = CvFactsTools(cv_connection=cv_client)
+    try:
+      facts = facts_collector.facts(scope=ansible_module.params['facts'], regex_filter=ansible_module.params['regexp_filter'],
+                                    verbose=ansible_module.params['verbose'])
+    except Exception as e:
+      ansible_module.fail_json(msg=str(e))
     result = dict(changed=False, data=facts, failed=False)
 
     # Implement logic

--- a/ansible_collections/arista/cvp/plugins/modules/cv_facts_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_facts_v3.py
@@ -185,10 +185,10 @@ def main():
     # Instantiate ansible results
     facts_collector = CvFactsTools(cv_connection=cv_client)
     try:
-      facts = facts_collector.facts(scope=ansible_module.params['facts'], regex_filter=ansible_module.params['regexp_filter'],
+        facts = facts_collector.facts(scope=ansible_module.params['facts'], regex_filter=ansible_module.params['regexp_filter'],
                                     verbose=ansible_module.params['verbose'])
     except CvpClientError as e:
-      ansible_module.fail_json(msg=str(e))
+        ansible_module.fail_json(msg=str(e))
     result = dict(changed=False, data=facts, failed=False)
 
     # Implement logic

--- a/ansible_collections/arista/cvp/plugins/modules/cv_facts_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_facts_v3.py
@@ -186,7 +186,7 @@ def main():
     facts_collector = CvFactsTools(cv_connection=cv_client)
     try:
         facts = facts_collector.facts(scope=ansible_module.params['facts'], regex_filter=ansible_module.params['regexp_filter'],
-                                    verbose=ansible_module.params['verbose'])
+                                      verbose=ansible_module.params['verbose'])
     except CvpClientError as e:
         ansible_module.fail_json(msg=str(e))
     result = dict(changed=False, data=facts, failed=False)


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

Added error raises for cv_facts_v3 to raise a proper error when a user is not authorized

## Related Issue(s)

Fixes #675 

## Component(s) name

`arista.cvp.cv_facts_v3`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Generate a service account token that has No Access to inventory or other features:

```---
- name: Test CV Facts
  hosts: CVP #cv_server
  connection: local
  tasks:
  - name: gather cvp facts
    arista.cvp.cv_facts_v3:
      facts:
      - devices
      #- tasks
      #- images
      #- containers
      - configlets
      #verbose: short
    register: facts
  - name: print facts
    debug:
      msg: "{{facts}}"
```

should result in

```shell
ansible-playbook get_cv_facts.yaml -i ../inventory.yaml

PLAY [Test CV Facts] **********************************************************************************************************

TASK [gather cvp facts] *******************************************************************************************************
fatal: [cv_server]: FAILED! => changed=false
  msg: |-
    GET: https://10.83.12.79:443/web/inventory/devices?provisioned=True : Request Error: Forbidden - 403 Forbidden

PLAY RECAP ********************************************************************************************************************
cv_server                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```

another test is to create a service account token that expires in a few seconds, and then run the playbook with it, the result will be something like:

```shell
TASK [gather cvp facts] *******************************************************************************************************************************************************************************************************************************************************
fatal: [cv_server]: FAILED! => changed=false
  msg: |2-

    10.83.12.79: Authenticate: https://10.83.12.79:443/api/v1/rest: Request Error: Unauthorized
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code has been rebased from devel before I start
- [ x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
