### PR TITLE
Fix(cv_tag_v3): Long workspace name to avoid conflict

### DIFF
--- a/ansible_collections/arista/cvp/molecule/cv_tag_v3/test_cv_tag_v3_device.yml
+++ b/ansible_collections/arista/cvp/molecule/cv_tag_v3/test_cv_tag_v3_device.yml
@@ -5,7 +5,6 @@
   gather_facts: no
   vars:
     DEVICE1: s1-leaf3
-
     DEVICE2: s1-leaf4
 
     ASSIGN_DELETE_TAGS_AUTO_CREATE:

--- a/ansible_collections/arista/cvp/molecule/cv_tag_v3/test_cv_tag_v3_interface.yml
+++ b/ansible_collections/arista/cvp/molecule/cv_tag_v3/test_cv_tag_v3_interface.yml
@@ -5,7 +5,6 @@
   gather_facts: no
   vars:
     DEVICE1: s1-leaf3
-
     DEVICE2: s1-leaf4
 
     ASSIGN_DELETE_TAGS_AUTO_CREATE:

--- a/ansible_collections/arista/cvp/plugins/module_utils/tag_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tag_tools.py
@@ -109,7 +109,7 @@ class CvTagTools(object):
         tag_manager = CvManagerResult(builder_name='tags_manager')
 
         # create workspace
-        workspace_name_id = "AW_" + ''.join(random.choices(string.ascii_uppercase + string.digits, k=6))+'{:%Y%m%d_%H%M%S}'.format(datetime.now())
+        workspace_name_id = "AW_" + ''.join(random.choices(string.ascii_uppercase + string.digits, k=6)) + '{:%Y%m%d_%H%M%S}'.format(datetime.now())
         workspace_id = workspace_name_id
 
         workspace_name = workspace_name_id

--- a/ansible_collections/arista/cvp/plugins/module_utils/tag_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tag_tools.py
@@ -23,14 +23,13 @@ import traceback
 import logging
 import random
 import string
+from datetime import datetime
 from ansible.module_utils.basic import AnsibleModule
-import ansible_collections.arista.cvp.plugins.module_utils.logger   # noqa # pylint: disable=unused-import
 from ansible_collections.arista.cvp.plugins.module_utils.response import CvApiResult, CvManagerResult, CvAnsibleResponse
 from ansible_collections.arista.cvp.plugins.module_utils.resources.schemas import v3 as schema
 from ansible_collections.arista.cvp.plugins.module_utils.tools_schema import validate_json_schema
 try:
-    from cvprac.cvp_client import CvpClient  # noqa # pylint: disable=unused-import
-    from cvprac.cvp_client_errors import CvpApiError, CvpRequestError  # noqa # pylint: disable=unused-import
+    from cvprac.cvp_client_errors import CvpRequestError
     HAS_CVPRAC = True
 except ImportError:
     HAS_CVPRAC = False
@@ -110,7 +109,7 @@ class CvTagTools(object):
         tag_manager = CvManagerResult(builder_name='tags_manager')
 
         # create workspace
-        workspace_name_id = "AnsibleWorkspace" + ''.join(random.choices(string.ascii_uppercase + string.digits, k=3))
+        workspace_name_id = "AW_" + ''.join(random.choices(string.ascii_uppercase + string.digits, k=6))+'{:%Y%m%d_%H%M%S}'.format(datetime.now())
         workspace_id = workspace_name_id
 
         workspace_name = workspace_name_id

--- a/ansible_collections/arista/cvp/plugins/module_utils/tag_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tag_tools.py
@@ -110,7 +110,7 @@ class CvTagTools(object):
 
         # create workspace
         my_date = datetime.now()
-        datetime_string = str(my_date.year)+str(my_date.month)+str(my_date.day)+'_'+str(my_date.hour)+str(my_date.minute)+str(my_date.second)
+        datetime_string = my_date.strftime('%Y%m%d_%H%M%S')
         workspace_name_id = "AW_" + ''.join(random.choices(string.ascii_uppercase + string.digits, k=6)) + datetime_string
         workspace_id = workspace_name_id
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/tag_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tag_tools.py
@@ -109,7 +109,9 @@ class CvTagTools(object):
         tag_manager = CvManagerResult(builder_name='tags_manager')
 
         # create workspace
-        workspace_name_id = "AW_" + ''.join(random.choices(string.ascii_uppercase + string.digits, k=6)) + '{:%Y%m%d_%H%M%S}'.format(datetime.now())
+        my_date = datetime.now()
+        datetime_string = str(my_date.year)+str(my_date.month)+str(my_date.day)+'_'+str(my_date.hour)+str(my_date.minute)+str(my_date.second)
+        workspace_name_id = "AW_" + ''.join(random.choices(string.ascii_uppercase + string.digits, k=6)) + datetime_string
         workspace_id = workspace_name_id
 
         workspace_name = workspace_name_id


### PR DESCRIPTION
## Change Summary

The cv_tag_v3 module creates workspaces in CloudVision under which to make the tag changes. Sometimes these workspaces are created with the same name as previously created instances, resulting in error.
The error was observed in CVP with 700+ workspaces. 
Previously the WS name used 3 random alpha numberic string(42840 combinations). 
The new WS name uses 6 random alpha numberic string + current datetime 

## Related Issue(s)

Fixes #672 

## Component(s) name

`arista.cvp.cv_tag_v3`

## Proposed changes
WS name to use 6 random alpha numberic string + current datetime 

## How to test
`molecule converge -s cv_tag_v3`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
