### PR TITLE
CI: Add readthedocs.yaml configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation with mkdocs
+mkdocs:
+  configuration: mkdocs.yml
+  fail_on_warning: false
+
+python:
+  install:
+    - requirements: ansible_collections/arista/cvp/docs/requirements.txt

--- a/ansible_collections/arista/cvp/docs/requirements.txt
+++ b/ansible_collections/arista/cvp/docs/requirements.txt
@@ -1,11 +1,8 @@
 mkdocs
+mkdocs-bootswatch
 mkdocs-material==9.0.15
 mkdocs-material-extensions
 pymdown-extensions
 mdx_truly_sane_lists
-mike
 mkdocs-git-revision-date-localized-plugin
 mkdocs-git-revision-date-plugin
-mkdocs-exclude
-mkdocs-include-dir-to-nav
-mkdocstrings[python]

--- a/ansible_collections/arista/cvp/docs/requirements.txt
+++ b/ansible_collections/arista/cvp/docs/requirements.txt
@@ -1,9 +1,11 @@
 mkdocs
-mkdocs-bootswatch
-mkdocs-material==8.5.7
+mkdocs-material==9.0.15
 mkdocs-material-extensions
-fontawesome-markdown
 pymdown-extensions
 mdx_truly_sane_lists
+mike
 mkdocs-git-revision-date-localized-plugin
 mkdocs-git-revision-date-plugin
+mkdocs-exclude
+mkdocs-include-dir-to-nav
+mkdocstrings[python]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,7 +74,6 @@ plugins:
 markdown_extensions:
   - admonition
   - attr_list
-  # - fontawesome_markdown
   - mdx_truly_sane_lists
   - smarty
   - pymdownx.arithmatex

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,7 +74,7 @@ plugins:
 markdown_extensions:
   - admonition
   - attr_list
-  - fontawesome_markdown
+  # - fontawesome_markdown
   - mdx_truly_sane_lists
   - smarty
   - pymdownx.arithmatex


### PR DESCRIPTION
Readthedocs are deprecating build configuration in the portal. Instead, they require a configuration file in the repo.

Disable fontawesome-markdown