### PR TITLE
Feat: Adding Support For Environment Variables

### DIFF
--- a/ansible_collections/arista/cvp/README.md
+++ b/ansible_collections/arista/cvp/README.md
@@ -187,6 +187,19 @@ ansible_httpapi_port=443
 
 As modules of this collection are based on [`HTTPAPI` connection plugin](https://docs.ansible.com/ansible/latest/plugins/httpapi.html), authentication elements shall be declared using this plugin mechanism and are automatically shared with `arista.cvp.cv_*` modules.
 
+Alternatively, on a play where you are leveraging a plugin you can omit CVP from inventory, set the play to target "localhost" and set the connection requirements using the following environment variables:
+
+CVP_HOST (Example: mycvpserver.prod.example.com)
+CVP_PORT (Example: 443)
+CVP_USER (Example: myserviceaccount) *
+CVP_PASS (Example: mystrongpassword)
+CVP_TOKEN (Example: mycvpapitoken)
+CVP_CERT_VALIDATE (Example: False)
+CVP_CMD_TIMEOUT (Example: 30)
+CVP_CON_TIMEOUT (Example: 90)
+
+* Review the CVP Authentication documentation for local service accounts.
+
 ## License
 
 The project is published under [Apache License](LICENSE).

--- a/ansible_collections/arista/cvp/docs/how-to/cvp-authentication.md
+++ b/ansible_collections/arista/cvp/docs/how-to/cvp-authentication.md
@@ -63,16 +63,31 @@ ansible_password: "{{ lookup('file', '/path/to/onprem.token')}}"
 
 ### Example reading from an environment variable
 
+The following environment variables are supported for cvp authentication:
+
+CVP_HOST (Example: mycvpserver.prod.example.com)
+CVP_PORT (Example: 443)
+CVP_USER (Example: myserviceaccount) *
+CVP_PASS (Example: mystrongpassword)
+CVP_TOKEN (Example: mycvpapitoken)
+CVP_CERT_VALIDATE (Example: False)
+CVP_CMD_TIMEOUT (Example: 30)
+CVP_CON_TIMEOUT (Example: 90)
+
 ```shell
-export ONPREM_TOKEN=`cat /path/to/onprem.token`
+export CVP_USER=svc_account
 ```
+
+While it is possible to reference an environment variable in host or group vars like so:
 
 ```yaml
 ansible_user: svc_account
-ansible_password: "{{ lookup('env', 'ONPREM_TOKEN')}}"
+ansible_password: "{{ lookup('env', 'CVP_TOKEN')}}"
 ```
 
-> NOTE Both `ansible_ssh_pass` and `ansible_password` can be used to specify the password or the token.
+for Ansible Tower (AAPv2) it is not supported to reference templated variables in a sourced inventory. Providing values as environment variables via Custom Credential Types and associating the credentials with an inventory source or template allows you to store values such as the FQDN or Token within Ansible Tower and pass them to plugins.
+
+> NOTE Remove CVP from your inventory and replace any references to it with localhost in plays / tasks that reference it for targeting or delegation if you want to leverage the environment variables.
 
 ### Example using vault
 
@@ -113,6 +128,7 @@ all:
 provide the password with any other methods as described in the [ansible vault documentation](https://docs.ansible.com/ansible/latest/user_guide/vault.html#using-encrypted-variables-and-files).
 
 > NOTE Encrypting individual variables using vault may not be supported - cf notes at the end of ## On-premise CloudVision authentication section
+> NOTE This is not supported in Ansible Tower (AAPv2)
 
 ## CloudVision as a Service authentication
 
@@ -146,19 +162,38 @@ ansible_password: "{{ lookup('file', '/path/to/cvaas.token')}}"
 
 ### Example reading from an environment variable
 
-export CVAAS_TOKEN=`cat /path/to/cvaas.token`
+The following environment variables are supported for cvp authentication:
 
-```yaml
-ansible_user: cvaas
-ansible_password: "{{ lookup('env', 'CVAAS_TOKEN')}}"
+CVP_HOST (Example: mycvpserver.prod.example.com)
+CVP_PORT (Example: 443)
+CVP_USER (Example: myserviceaccount) *
+CVP_PASS (Example: mystrongpassword)
+CVP_TOKEN (Example: mycvpapitoken)
+CVP_CERT_VALIDATE (Example: False)
+CVP_CMD_TIMEOUT (Example: 30)
+CVP_CON_TIMEOUT (Example: 90)
+
+```shell
+export CVP_USER=svc_account
 ```
 
-> NOTE Both `ansible_ssh_pass` and `ansible_password` can be used to specify the token.
+While it is possible to reference an environment variable in host or group vars like so:
+
+```yaml
+ansible_user: svc_account
+ansible_password: "{{ lookup('env', 'CVP_TOKEN')}}"
+```
+
+for Ansible Tower (AAPv2) it is not supported to reference templated variables in a sourced inventory. Providing values as environment variables via Custom Credential Types and associating the credentials with an inventory source or template allows you to store values such as the FQDN or Token within Ansible Tower and pass them to plugins.
+
+> NOTE Remove CVP from your inventory and replace any references to it with localhost in plays / tasks that reference it for targeting or delegation if you want to leverage the environment variables.
 
 ### Example using vault
 
 1. Save the token generated from the CV/CVaaS UI and encrypt it using `ansible-vault encrypt cvaas.token`
 2. Run the playbook with `ansible-playbook example.yaml --ask-vault-pass`
+
+> NOTE This is not supported in Ansible Tower (AAPv2), refer to previous section.
 
 ## How to validate SSL certificate
 

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
@@ -65,13 +65,9 @@ def cv_connect(module):
         cvp_user = connection.get_option("remote_user")
         cvp_pass = connection.get_option("password")
         host = connection.get_option("host")
-        port = int(connection.get_option("port"))
+        port = connection.get_option("port")
         cert_validation = connection.get_option("validate_certs")
-        if cert_validation == "True":
-            cert_validation = True
-        elif cert_validation == "False":
-            cert_validation = False
-        api_token = (cvp_pass if connection.get_option("remote_user") in svc_accounts else None)
+        api_token = cvp_pass if cvp_user in svc_accounts else None
         ansible_command_timeout = connection.get_option(
         "persistent_command_timeout")
         ansible_connect_timeout = connection.get_option(

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
@@ -63,7 +63,7 @@ def cv_connect(module):
     cert_validation = connection.get_option("validate_certs") or os.getenv("CVP_CERT_VALIDATE")
     is_cvaas = True if cvp_user == 'cvaas' else False
     # Deliberately checking against remote_user to see if ansible_user was set in inventory
-    api_token = ((cvp_pass if connection.get_option("remote_user") in svc_accounts) or os.getenv("CVP_TOKEN")) or None
+    api_token = (cvp_pass if connection.get_option("remote_user") in svc_accounts else None) or os.getenv("CVP_TOKEN")
     user = cvp_user if is_cvaas == False else ''
     user_authentication = cvp_pass if is_cvaas == False else ''
     ansible_command_timeout = connection.get_option(


### PR DESCRIPTION
## Change Summary

Currently the tools_cv.py does not accept environment variables when calling the connect method of the CvpClient class from cvprac.cvp_client. In AAPv2 (Ansible Tower) it is not possible to vault values in a sourced inventory. While you can move the token to host or group vars, this leaves the FQDN hardcoded into the inventory.

This change allows support for setting the host target or host delegation to localhost instead of to a CVP host, such that CVP and any associated vars can be removed from the inventory. A custom credential type in Ansible Tower can be created and the injector config can contain all of the environment variables required which can then be associated with a template.

The custom credential can be associated with a sourced inventory as well, however, the environment variables will be ignored by tools_cv.py if the CVP server is provided in inventory and referenced in the playbook.  

README and CVP_Authentication were also updated to reflect this change.

## Related Issue(s)

N/A

## Component(s) name

affect all plugins

## Proposed changes
The following environment variables will be accepted by tools_cv.py if CVP is omitted from inventory and is replaced with localhost in the playbook:

CVP_HOST
CVP_PORT
CVP_USER
CVP_PASS
CVP_TOKEN
CVP_CERT_VALIDATE (True / False)
CVP_CMD_TIMEOUT
CVP_CON_TIMEOUT

## How to test
Keep CVP in inventory as is in your project and add all of the environment variables with their appropriate values above and you will see that the values in the inventory are still used.

Remove CVP from inventory and change reference to it in the playbook in question to localhost, environment variables will now be required instead.

CVP in inventory and playbook, and no environment variables.

All 3 cases tested successfully on multiple modules.

## Checklist

### User Checklist

1) Delete CVP from inventory
2) Update playbooks to reference locahost instead of cvp in host targeting and delegation
3) Set environment variables on executing system (or leverage custom credential types and inject them into a template via credential association)
4) Run the project

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
