### PR TITLE
Fix: cv_validate_v3 broken with cvprac 1.4.0 due to argument keyword change

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
           - '<!--|  ~|  -->'
 
   - repo: https://github.com/pycqa/pylint
-    rev: "v2.16.1"
+    rev: "v3.1.1"
     hooks:
       - id: pylint # Use pylintrc file in repository
         name: Check for Linting errors on Python files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
           - '<!--|  ~|  -->'
 
   - repo: https://github.com/pycqa/pylint
-    rev: "v3.1.1"
+    rev: "v2.16.1"
     hooks:
       - id: pylint # Use pylintrc file in repository
         name: Check for Linting errors on Python files

--- a/ansible_collections/arista/cvp/plugins/module_utils/validate_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/validate_tools.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023 Arista Networks, Inc.
+# Copyright (c) 2023-2024 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-
@@ -191,9 +191,7 @@ class CvValidationTools(object):
                     MODULE_LOGGER.debug(
                         "queryParams are deviceMac: %s and configuration: %s", str(
                             system_mac), str(config))
-                    resp = self.__cv_client.api.validate_config_for_device(
-                        device_mac=system_mac,
-                        config=config)
+                    resp = self.__cv_client.api.validate_config_for_device(system_mac, config)
                     result_data.add_entry(
                         configlet_name + "_validated_against_" + device_info['device_name']
                     )


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

cvprac updated the keyword arguments for `validate_config_for_device()` from `device_mac` to `dev_mac` in https://github.com/aristanetworks/cvprac/commit/69fd313b18fdd386d2b3e8cf087d5b27d78cb923#diff-ff77c7a073e87f20dd555db78c0b2ee12ed8924d0cc12645fb2e33034ec523aaL1359 and playbooks are failing with:

```
    Traceback (most recent call last):
      File "/home/pprad133/.ansible/tmp/ansible-local-175841olddsl1/ansible-tmp-1716569183.2255661-17610-80870313378101/AnsiballZ_cv_validate_v3.py", line 107, in <module>
        _ansiballz_main()
      File "/home/pprad133/.ansible/tmp/ansible-local-175841olddsl1/ansible-tmp-1716569183.2255661-17610-80870313378101/AnsiballZ_cv_validate_v3.py", line 99, in _ansiballz_main
        invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
      File "/home/pprad133/.ansible/tmp/ansible-local-175841olddsl1/ansible-tmp-1716569183.2255661-17610-80870313378101/AnsiballZ_cv_validate_v3.py", line 47, in invoke_module
        runpy.run_module(mod_name='ansible_collections.arista.cvp.plugins.modules.cv_validate_v3', init_globals=dict(_module_fqn='ansible_collections.arista.cvp.plugins.modules.cv_validate_v3', _modlib_path=modlib_path),
      File "/usr/lib/python3.10/runpy.py", line 224, in run_module
        return _run_module_code(code, init_globals, run_name, mod_spec)
      File "/usr/lib/python3.10/runpy.py", line 96, in _run_module_code
        _run_code(code, mod_globals, init_globals,
      File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
        exec(code, run_globals)
      File "/tmp/ansible_arista.cvp.cv_validate_v3_payload_igauvor3/ansible_arista.cvp.cv_validate_v3_payload.zip/ansible_collections/arista/cvp/plugins/modules/cv_validate_v3.py", line 163, in <module>
      File "/tmp/ansible_arista.cvp.cv_validate_v3_payload_igauvor3/ansible_arista.cvp.cv_validate_v3_payload.zip/ansible_collections/arista/cvp/plugins/modules/cv_validate_v3.py", line 153, in main
      File "/tmp/ansible_arista.cvp.cv_validate_v3_payload_igauvor3/ansible_arista.cvp.cv_validate_v3_payload.zip/ansible_collections/arista/cvp/plugins/module_utils/validate_tools.py", line 194, in manager
    TypeError: CvpApi.validate_config_for_device() got an unexpected keyword argument 'device_mac'
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: 1
```

Thanks for @pmprado for reporting

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.cvp.cv_validate_v3`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

removed the keyword argument name and just passing the vars

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
