### PR TITLE
CI: Update and fix dev requirements

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -142,7 +142,7 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
       - name: Install requirements
-        # forcing a specific version of ansible-lint to install requirement-dev in Python 3.9.
+        # Removing ansible-lint in requirement-dev-3.9 to allow requirements installation for Python 3.9.
         run: |
           pip install -r ansible_collections/arista/cvp/requirements-dev-3.9.txt
           pip install -r ansible_collections/arista/cvp/requirements.txt

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Install requirements
         run: |
           pip install -r ansible_collections/arista/cvp/requirements-dev.txt --upgrade
@@ -130,7 +130,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python_version: ['3.9','3.10','3.11']
+        python_version: ['3.10','3.11','3.12']
     steps:
       - name: 'set environment variables'
         run: |
@@ -265,7 +265,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python_version: ['3.9']
+        python_version: ['3.10']
     steps:
       - name: 'set environment variables'
         run: |

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -130,7 +130,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python_version: ['3.10','3.11','3.12']
+        python_version: ['3.9','3.10','3.11','3.12']
     steps:
       - name: 'set environment variables'
         run: |
@@ -142,8 +142,9 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
       - name: Install requirements
+        # forcing a specific version of ansible-lint to install requirement-dev in Python 3.9.
         run: |
-          pip install -r ansible_collections/arista/cvp/requirements-dev.txt
+          pip install -r ansible_collections/arista/cvp/requirements-dev-3.9.txt
           pip install -r ansible_collections/arista/cvp/requirements.txt
       - name: 'Execute pytest validation'
         run: |

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Install requirements
         # Removing ansible-lint in requirement-dev-3.9 to allow requirements installation for Python 3.9.
         run: |
-          pip install -r ansible_collections/arista/cvp/requirements-dev-3.9.txt
+          pip install -r ansible_collections/arista/cvp/requirements-dev-pytest.txt
           pip install -r ansible_collections/arista/cvp/requirements.txt
       - name: 'Execute pytest validation'
         run: |

--- a/ansible_collections/arista/cvp/index.md
+++ b/ansible_collections/arista/cvp/index.md
@@ -45,7 +45,7 @@ Please check the minimum version supported by your ansible installation on the [
 
 **Ansible version:**
 
-- ansible-core>=2.14.0,<2.17.0
+- ansible-core>=2.15.0,<2.18.0
 
 **3rd party Python libraries:**
 

--- a/ansible_collections/arista/cvp/meta/runtime.yml
+++ b/ansible_collections/arista/cvp/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.14.0,<2.17.0'
+requires_ansible: '>=2.15.0,<2.18.0'
 plugin_routing:
   modules:
     cv_facts:

--- a/ansible_collections/arista/cvp/requirements-dev-3.9.txt
+++ b/ansible_collections/arista/cvp/requirements-dev-3.9.txt
@@ -1,6 +1,6 @@
+# Temp requirements  for python 3.9 (removed ansible-lint)
 ansible-core>=2.15.0,<2.18.0
 ansible-builder
-ansible-lint>=24.7.0
 galaxy-importer>=0.3.1
 pycodestyle
 flake8

--- a/ansible_collections/arista/cvp/requirements-dev-pytest.txt
+++ b/ansible_collections/arista/cvp/requirements-dev-pytest.txt
@@ -1,4 +1,4 @@
-# Temp requirements  for python 3.9 (removed ansible-lint)
+# Temp requirements  for pytest testing. Required ansible-lint version as it's not compatible with Python 3.9, so it is removed.
 ansible-core>=2.15.0,<2.18.0
 ansible-builder
 galaxy-importer>=0.3.1

--- a/ansible_collections/arista/cvp/requirements-dev.txt
+++ b/ansible_collections/arista/cvp/requirements-dev.txt
@@ -1,6 +1,6 @@
 ansible-core>=2.15.0,<2.17.0
 ansible-builder
-ansible-lint<24.7.0
+ansible-lint>24.7.0
 galaxy-importer>=0.3.1
 pycodestyle
 flake8

--- a/ansible_collections/arista/cvp/requirements-dev.txt
+++ b/ansible_collections/arista/cvp/requirements-dev.txt
@@ -1,6 +1,6 @@
 ansible-core>=2.15.0,<2.17.0
 ansible-builder
-ansible-lint>24.7.0
+ansible-lint>=24.7.0
 galaxy-importer>=0.3.1
 pycodestyle
 flake8

--- a/ansible_collections/arista/cvp/requirements-dev.txt
+++ b/ansible_collections/arista/cvp/requirements-dev.txt
@@ -1,6 +1,6 @@
 ansible-core>=2.15.0,<2.17.0
 ansible-builder
-ansible-lint==6.22.2
+ansible-lint<24.7.0
 galaxy-importer>=0.3.1
 pycodestyle
 flake8


### PR DESCRIPTION
## Change Summary

- Fix: ansible-core version in runtime and index.md.
- Bump: ansible-lint>=24.7.0 requirements-dev.txt
- Add Python pytest 3.12 in test matrix.
- Created specific pytest requirements, since ansible-lint is not compatible with Python 3.9
