### PR TITLE
Refactor: Update links, actions version, license date

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -68,7 +68,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://avd.arista.com/stable/docs/contribution/overview.html)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://avd.arista.com/devel/docs/contribution/overview.html)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -68,7 +68,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://avd.sh/en/latest/docs/contribution/overview.html)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://avd.arista.com/stable/docs/contribution/overview.html)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -69,7 +69,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://avd.sh/en/latest/docs/contribution/overview.html)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://avd.arista.com/stable/docs/contribution/overview.html)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -69,7 +69,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://avd.arista.com/stable/docs/contribution/overview.html)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://avd.arista.com/devel/docs/contribution/overview.html)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,6 +30,6 @@ Fixes #<ISSUE ID>
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] My code has been rebased from devel before I start
-- [ ] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
+- [ ] I have read the [**CONTRIBUTING**](https://avd.arista.com/devel/docs/contribution/overview.html) document.
 - [ ] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
 - [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,6 +30,6 @@ Fixes #<ISSUE ID>
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] My code has been rebased from devel before I start
-- [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
+- [ ] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
 - [ ] My change requires a change to the documentation and documentation have been updated accordingly. (check the box if not applicable)
 - [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -253,6 +253,10 @@ jobs:
             --exclude "www.docker.com" \
             --exclude "hub.docker.com" \
             --exclude "tech-library.arista.com" \
+            --exclude "cvp.avd.sh" \
+            --exclude "treelib.readthedocs.io" \
+            --exclude "www.paramiko.org" \
+            --exclude "requests.readthedocs.io" \
             --max-connections-per-host 30 \
             --max-redirections 3 \
             --rate-limit 1 \

--- a/.github/workflows/tag-management.yml
+++ b/.github/workflows/tag-management.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build project # This would actually build your project, using zip for an example artifact
         run: |
@@ -21,7 +21,7 @@ jobs:
           make collection-build
 
       - name: Upload Collection Package to GH Action
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ansible-collection-package
           path: |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/README.md
+++ b/ansible_collections/arista/cvp/README.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/build-md/doc.py
+++ b/ansible_collections/arista/cvp/docs/build-md/doc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 import os

--- a/ansible_collections/arista/cvp/docs/build-md/templates/md.j2
+++ b/ansible_collections/arista/cvp/docs/build-md/templates/md.j2
@@ -1,5 +1,5 @@
 {#
- Copyright (c) 2023-2024 Arista Networks, Inc.
+ Copyright (c) 2023-2025 Arista Networks, Inc.
  Use of this source code is governed by the Apache License 2.0
  that can be found in the LICENSE file.
 #}

--- a/ansible_collections/arista/cvp/docs/contributing.md
+++ b/ansible_collections/arista/cvp/docs/contributing.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/faq/errors.md
+++ b/ansible_collections/arista/cvp/docs/faq/errors.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/getting-started.md
+++ b/ansible_collections/arista/cvp/docs/getting-started.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/how-to/cvp-authentication.md
+++ b/ansible_collections/arista/cvp/docs/how-to/cvp-authentication.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/how-to/debug.md
+++ b/ansible_collections/arista/cvp/docs/how-to/debug.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/installation/collection-installation.md
+++ b/ansible_collections/arista/cvp/docs/installation/collection-installation.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/installation/collection-installation.md
+++ b/ansible_collections/arista/cvp/docs/installation/collection-installation.md
@@ -6,7 +6,7 @@
 
 # Collection installation
 
-These instructions are for regular users to install via Ansible Galaxy. To setup a development environment use [these](https://www.avd.sh/en/devel/docs/contribution/overview.html) instructions.
+These instructions are for regular users to install via Ansible Galaxy. To setup a development environment use [these](https://avd.arista.com/devel/docs/contribution/overview.html) instructions.
 
 **arista.cvp** can also be consumed using the ["AVD All-in-one" container](https://github.com/arista-netdevops-community/avd-all-in-one-container).
 

--- a/ansible_collections/arista/cvp/docs/installation/requirements.md
+++ b/ansible_collections/arista/cvp/docs/installation/requirements.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/modules/cv_change_control_v3.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_change_control_v3.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/modules/cv_configlet.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_configlet.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/modules/cv_configlet_v3.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_configlet_v3.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/modules/cv_container.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_container.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/modules/cv_container_v3.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_container_v3.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/modules/cv_device.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_device.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/modules/cv_device_v3.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_device_v3.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/modules/cv_facts.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_facts.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/modules/cv_facts_v3.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_facts_v3.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/modules/cv_image_v3.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_image_v3.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/modules/cv_tag_v3.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_tag_v3.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/modules/cv_task.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_task.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/modules/cv_task_v3.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_task_v3.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/modules/cv_validate_v3.md
+++ b/ansible_collections/arista/cvp/docs/modules/cv_validate_v3.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/release-notes/v1.x.md
+++ b/ansible_collections/arista/cvp/docs/release-notes/v1.x.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/release-notes/v2.x.md
+++ b/ansible_collections/arista/cvp/docs/release-notes/v2.x.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/release-notes/v3.x.md
+++ b/ansible_collections/arista/cvp/docs/release-notes/v3.x.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/release-notes/v3.x.md
+++ b/ansible_collections/arista/cvp/docs/release-notes/v3.x.md
@@ -232,12 +232,12 @@ Full release note available on [github](https://github.com/aristanetworks/ansibl
 
 ### Enhancements
 
-- [cv_device_v3] Add serialNumber support to manage devices. ([#374](https://github.com/aristanetworks/ansible-avd/issues/374))
+- [cv_device_v3] Add serialNumber support to manage devices. ([#374](https://github.com/aristanetworks/ansible-cvp/issues/374))
 
 ### Bug fixes
 
-- [cv_device_v3] Correct format ID in str raising an error ([#399](https://github.com/aristanetworks/ansible-avd/issues/399))
-- [cv_device_v3] Update format string ([#396](https://github.com/aristanetworks/ansible-avd/issues/396))
+- [cv_device_v3] Correct format ID in str raising an error ([#399](https://github.com/aristanetworks/ansible-cvp/issues/399))
+- [cv_device_v3] Update format string ([#396](https://github.com/aristanetworks/ansible-cvp/issues/396))
 
 ## Release 3.1.2
 

--- a/ansible_collections/arista/cvp/docs/schema/cv_change_control_v3.md
+++ b/ansible_collections/arista/cvp/docs/schema/cv_change_control_v3.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/schema/cv_container_v3.md
+++ b/ansible_collections/arista/cvp/docs/schema/cv_container_v3.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/schema/cv_device_v3.md
+++ b/ansible_collections/arista/cvp/docs/schema/cv_device_v3.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/schema/cv_tag_v3.md
+++ b/ansible_collections/arista/cvp/docs/schema/cv_tag_v3.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/docs/schema/cv_validate_v3.md
+++ b/ansible_collections/arista/cvp/docs/schema/cv_validate_v3.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/index.md
+++ b/ansible_collections/arista/cvp/index.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/index.md
+++ b/ansible_collections/arista/cvp/index.md
@@ -201,4 +201,4 @@ Contributing pull requests are gladly welcomed for this repository. If you are p
 
 You can also open an [issue](https://github.com/aristanetworks/ansible-cvp/issues) to report any problem or to submit enhancement.
 
-A more complete [guide for contribution](https://avd.arista.com/stable/docs/contribution/overview.html) is available in the repository
+A more complete [guide for contribution](https://avd.arista.com/devel/docs/contribution/overview.html) is available in the repository

--- a/ansible_collections/arista/cvp/index.md
+++ b/ansible_collections/arista/cvp/index.md
@@ -201,4 +201,4 @@ Contributing pull requests are gladly welcomed for this repository. If you are p
 
 You can also open an [issue](https://github.com/aristanetworks/ansible-cvp/issues) to report any problem or to submit enhancement.
 
-A more complete [guide for contribution](https://avd.sh/en/latest/docs/contribution/overview.html) is available in the repository
+A more complete [guide for contribution](https://avd.arista.com/stable/docs/contribution/overview.html) is available in the repository

--- a/ansible_collections/arista/cvp/molecule/cv_device_v3/reconcile.py
+++ b/ansible_collections/arista/cvp/molecule/cv_device_v3/reconcile.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 from cvprac.cvp_client import CvpClient

--- a/ansible_collections/arista/cvp/plugins/README.md
+++ b/ansible_collections/arista/cvp/plugins/README.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/change_tools.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/module_utils/configlet_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/configlet_tools.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/container_tools.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/device_tools.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/facts_tools.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/module_utils/generic_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/generic_tools.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/module_utils/image_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/image_tools.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/module_utils/logger.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/logger.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/module_utils/resources/api/fields.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/resources/api/fields.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/module_utils/resources/exceptions.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/resources/exceptions.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/module_utils/resources/modules/fields.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/resources/modules/fields.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/module_utils/resources/schemas/v1.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/resources/schemas/v1.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/module_utils/resources/schemas/v3.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/resources/schemas/v3.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/module_utils/response.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/response.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/module_utils/schema_v1.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/schema_v1.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/module_utils/tag_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tag_tools.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/module_utils/task_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/task_tools.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools_cv.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools_inventory.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools_inventory.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools_schema.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools_schema.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/module_utils/tools_tree.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/tools_tree.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/module_utils/validate_tools.py
+++ b/ansible_collections/arista/cvp/plugins/module_utils/validate_tools.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_change_control_v3.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_configlet.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/modules/cv_configlet_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_configlet_v3.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/modules/cv_container.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_container.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/modules/cv_container_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_container_v3.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/modules/cv_device.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_device.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/modules/cv_device_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_device_v3.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_facts.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # pylint: skip-file

--- a/ansible_collections/arista/cvp/plugins/modules/cv_facts_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_facts_v3.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/modules/cv_image_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_image_v3.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/modules/cv_tag_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_tag_v3.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/modules/cv_task.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_task.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/modules/cv_task_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_task_v3.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/plugins/modules/cv_validate_v3.py
+++ b/ansible_collections/arista/cvp/plugins/modules/cv_validate_v3.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/ansible_collections/arista/cvp/roles/configlets_sync/README.md
+++ b/ansible_collections/arista/cvp/roles/configlets_sync/README.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/roles/configlets_sync/handlers/main.yml
+++ b/ansible_collections/arista/cvp/roles/configlets_sync/handlers/main.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 ---

--- a/ansible_collections/arista/cvp/roles/configlets_sync/tasks/init.yml
+++ b/ansible_collections/arista/cvp/roles/configlets_sync/tasks/init.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 ---

--- a/ansible_collections/arista/cvp/roles/configlets_sync/tasks/main.yml
+++ b/ansible_collections/arista/cvp/roles/configlets_sync/tasks/main.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 ---

--- a/ansible_collections/arista/cvp/roles/configlets_sync/tasks/pull.yml
+++ b/ansible_collections/arista/cvp/roles/configlets_sync/tasks/pull.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 ---

--- a/ansible_collections/arista/cvp/roles/configlets_sync/tasks/push.yml
+++ b/ansible_collections/arista/cvp/roles/configlets_sync/tasks/push.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 ---

--- a/ansible_collections/arista/cvp/roles/configlets_sync/tasks/sync.yml
+++ b/ansible_collections/arista/cvp/roles/configlets_sync/tasks/sync.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # Run everything if user set action=sync

--- a/ansible_collections/arista/cvp/roles/configlets_sync/templates/template.compare_configlets.j2
+++ b/ansible_collections/arista/cvp/roles/configlets_sync/templates/template.compare_configlets.j2
@@ -1,5 +1,5 @@
 {#
- Copyright (c) 2023-2024 Arista Networks, Inc.
+ Copyright (c) 2023-2025 Arista Networks, Inc.
  Use of this source code is governed by the Apache License 2.0
  that can be found in the LICENSE file.
 #}

--- a/ansible_collections/arista/cvp/roles/configlets_sync/templates/template.cvp.shared_configlets.j2
+++ b/ansible_collections/arista/cvp/roles/configlets_sync/templates/template.cvp.shared_configlets.j2
@@ -1,5 +1,5 @@
 {#
- Copyright (c) 2023-2024 Arista Networks, Inc.
+ Copyright (c) 2023-2025 Arista Networks, Inc.
  Use of this source code is governed by the Apache License 2.0
  that can be found in the LICENSE file.
 #}

--- a/ansible_collections/arista/cvp/roles/configlets_sync/templates/template.device_configlets.j2
+++ b/ansible_collections/arista/cvp/roles/configlets_sync/templates/template.device_configlets.j2
@@ -1,5 +1,5 @@
 {#
- Copyright (c) 2023-2024 Arista Networks, Inc.
+ Copyright (c) 2023-2025 Arista Networks, Inc.
  Use of this source code is governed by the Apache License 2.0
  that can be found in the LICENSE file.
 #}

--- a/ansible_collections/arista/cvp/roles/configlets_sync/templates/template.shared_configlets.j2
+++ b/ansible_collections/arista/cvp/roles/configlets_sync/templates/template.shared_configlets.j2
@@ -1,5 +1,5 @@
 {#
- Copyright (c) 2023-2024 Arista Networks, Inc.
+ Copyright (c) 2023-2025 Arista Networks, Inc.
  Use of this source code is governed by the Apache License 2.0
  that can be found in the LICENSE file.
 #}

--- a/ansible_collections/arista/cvp/roles/dhcp_configuration/README.md
+++ b/ansible_collections/arista/cvp/roles/dhcp_configuration/README.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/ansible_collections/arista/cvp/roles/dhcp_configuration/handlers/main.yml
+++ b/ansible_collections/arista/cvp/roles/dhcp_configuration/handlers/main.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 ---

--- a/ansible_collections/arista/cvp/roles/dhcp_configuration/tasks/fix-debian.yml
+++ b/ansible_collections/arista/cvp/roles/dhcp_configuration/tasks/fix-debian.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 ---

--- a/ansible_collections/arista/cvp/roles/dhcp_configuration/tasks/main.yml
+++ b/ansible_collections/arista/cvp/roles/dhcp_configuration/tasks/main.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 ---

--- a/ansible_collections/arista/cvp/roles/dhcp_configuration/tasks/offline.yml
+++ b/ansible_collections/arista/cvp/roles/dhcp_configuration/tasks/offline.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 ---

--- a/ansible_collections/arista/cvp/roles/dhcp_configuration/tasks/online.yml
+++ b/ansible_collections/arista/cvp/roles/dhcp_configuration/tasks/online.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 ---

--- a/ansible_collections/arista/cvp/roles/dhcp_configuration/templates/dhcpd.conf.j2
+++ b/ansible_collections/arista/cvp/roles/dhcp_configuration/templates/dhcpd.conf.j2
@@ -1,6 +1,6 @@
 
 {#
- Copyright (c) 2023-2024 Arista Networks, Inc.
+ Copyright (c) 2023-2025 Arista Networks, Inc.
  Use of this source code is governed by the Apache License 2.0
  that can be found in the LICENSE file.
 #}

--- a/contributing.md
+++ b/contributing.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/development/README.md
+++ b/development/README.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -165,5 +165,5 @@ nav:
     - Versions 3.x: docs/release-notes/v3.x.md
   - About:
     - Ansible Galaxy page: https://galaxy.ansible.com/arista/cvp
-    - Arista Validated Design Collection: https://www.avd.sh
+    - Arista AVD Ansible Collection: https://avd.arista.com
     - Arista Automation Examples: https://aristanetworks.github.io/netdevops-examples/

--- a/tests/PR_testing/README.md
+++ b/tests/PR_testing/README.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/tests/Unittest-README.md
+++ b/tests/Unittest-README.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023-2024 Arista Networks, Inc.
+  ~ Copyright (c) 2023-2025 Arista Networks, Inc.
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->

--- a/tests/data/container_tools_unit.py
+++ b/tests/data/container_tools_unit.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/data/device_tools_unit.py
+++ b/tests/data/device_tools_unit.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # mock data from CVP version 2022.1.1

--- a/tests/data/facts_system_cvaas.py
+++ b/tests/data/facts_system_cvaas.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/data/facts_unit.py
+++ b/tests/data/facts_unit.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/data/image_unit.py
+++ b/tests/data/image_unit.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/data/validate_tools_unit.py
+++ b/tests/data/validate_tools_unit.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # error configlet

--- a/tests/lib/config.py
+++ b/tests/lib/config.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/lib/cvaas_configlet.py
+++ b/tests/lib/cvaas_configlet.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/lib/helpers.py
+++ b/tests/lib/helpers.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/lib/json_data.py
+++ b/tests/lib/json_data.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/lib/mock.py
+++ b/tests/lib/mock.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/lib/mockMagic.py
+++ b/tests/lib/mockMagic.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # pylint: disable=unknown-option-value

--- a/tests/lib/mock_ansible.py
+++ b/tests/lib/mock_ansible.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/lib/parametrize.py
+++ b/tests/lib/parametrize.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/lib/provisioner.py
+++ b/tests/lib/provisioner.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/lib/static_content.py
+++ b/tests/lib/static_content.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/lib/utils.py
+++ b/tests/lib/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 """

--- a/tests/system/constants_data.py
+++ b/tests/system/constants_data.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 """

--- a/tests/system/test_cv_configlet.py
+++ b/tests/system/test_cv_configlet.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/system/test_cv_container_tools.py
+++ b/tests/system/test_cv_container_tools.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/system/test_cv_device_tools.py
+++ b/tests/system/test_cv_device_tools.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/system/test_cv_device_tools_fqdn.py
+++ b/tests/system/test_cv_device_tools_fqdn.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/system/test_cv_device_tools_generic.py
+++ b/tests/system/test_cv_device_tools_generic.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/system/test_cv_device_tools_serial.py
+++ b/tests/system/test_cv_device_tools_serial.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/system/test_cv_facts_tools.py
+++ b/tests/system/test_cv_facts_tools.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 from unittest.mock import create_autospec

--- a/tests/unit/module_utils/test_validate_tools.py
+++ b/tests/unit/module_utils/test_validate_tools.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 from unittest.mock import call

--- a/tests/unit/test_configlet_input.py
+++ b/tests/unit/test_configlet_input.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/unit/test_container_inputs.py
+++ b/tests/unit/test_container_inputs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/unit/test_cv_container_tools.py
+++ b/tests/unit/test_cv_container_tools.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/unit/test_cv_device_tools.py
+++ b/tests/unit/test_cv_device_tools.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 from unittest.mock import call

--- a/tests/unit/test_cv_facts_tools.py
+++ b/tests/unit/test_cv_facts_tools.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/unit/test_cv_image_tools.py
+++ b/tests/unit/test_cv_image_tools.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/unit/test_cv_response.py
+++ b/tests/unit/test_cv_response.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/unit/test_device_element.py
+++ b/tests/unit/test_device_element.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/unit/test_device_inventory.py
+++ b/tests/unit/test_device_inventory.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/unit/test_json_schema.py
+++ b/tests/unit/test_json_schema.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-

--- a/tests/unit/test_tools_cv.py
+++ b/tests/unit/test_tools_cv.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # coding: utf-8 -*-


### PR DESCRIPTION
## Change Summary

- [x] Update link for arista.avd ansible collection.
- [x] Bump GitHub actions to supported versions.
- [x] Update license heading to 2023-2025
- [x] Fix incorrect links
- [x] Ignore links failing due to 403 error in check-links workflow
