### PR TITLE
Bump: Restore support for ansible-core 2.15

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -164,7 +164,7 @@ jobs:
       fail-fast: true
       matrix:
         ansible_version:
-          - 'ansible-core>=2.16.0,<2.19.0 --upgrade'
+          - 'ansible-core>=2.15.0,<2.19.0 --upgrade'
         cvp_scenario:
           - cv_configlet_loose
           - cv_configlet_strict
@@ -199,7 +199,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ansible_version: ['ansible-core==2.16.0', 'ansible-core<2.19.0']
+        ansible_version: ['ansible-core==2.15.0', 'ansible-core<2.19.0']
         cvp_scenario:
           - dhcp_management_mac
           - dhcp_management_offline

--- a/ansible_collections/arista/cvp/README.md
+++ b/ansible_collections/arista/cvp/README.md
@@ -43,7 +43,7 @@ Please check the minimum version supported by your ansible installation on the [
 
 **Ansible version:**
 
-- ansible-core>=2.16.0,<2.19.0
+- ansible-core>=2.15.0,<2.19.0
 
 **3rd party Python libraries:**
 

--- a/ansible_collections/arista/cvp/docs/installation/requirements.md
+++ b/ansible_collections/arista/cvp/docs/installation/requirements.md
@@ -30,7 +30,7 @@
 
 ## Supported Ansible Versions
 
-- ansible-core from **2.16.0** to **2.18.x**
+- ansible-core from **2.15.0** to **2.18.x**
 
 ## Additional Python Libraries required
 

--- a/ansible_collections/arista/cvp/docs/release-notes/v3.x.md
+++ b/ansible_collections/arista/cvp/docs/release-notes/v3.x.md
@@ -21,7 +21,6 @@
 - Ansible-cvp now requires Python **3.10** or later
 - Ansible-cvp now requires a newer minimum version of the Python package `ansible-core>=2.15.0,<2.19.0`. Support for ansible-core 2.15 has been restored because this version remains supported within Ansible Automation Platform 2.4.
 
-
 ## Release 3.13.0
 
 ### Requirements

--- a/ansible_collections/arista/cvp/docs/release-notes/v3.x.md
+++ b/ansible_collections/arista/cvp/docs/release-notes/v3.x.md
@@ -19,6 +19,14 @@
 ### Requirements
 
 - Ansible-cvp now requires Python **3.10** or later
+- Ansible-cvp now requires a newer minimum version of the Python package `ansible-core>=2.15.0,<2.19.0`. Support for ansible-core 2.15 has been restored because this version remains supported within Ansible Automation Platform 2.4.
+
+
+## Release 3.13.0
+
+### Requirements
+
+- Ansible-cvp now requires Python **3.10** or later
 - Ansible-cvp now requires a newer minimum version of the Python package `ansible-core>=2.16.0,<2.19.0`
   The latest version can be installed with `pip install "ansible-core>=2.16.0,<2.19.0" --upgrade`
 

--- a/ansible_collections/arista/cvp/index.md
+++ b/ansible_collections/arista/cvp/index.md
@@ -45,7 +45,7 @@ Please check the minimum version supported by your ansible installation on the [
 
 **Ansible version:**
 
-- ansible-core>=2.16.0,<2.19.0
+- ansible-core>=2.15.0,<2.19.0
 
 **3rd party Python libraries:**
 

--- a/ansible_collections/arista/cvp/meta/runtime.yml
+++ b/ansible_collections/arista/cvp/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.16.0,<2.19.0'
+requires_ansible: '>=2.15.0,<2.19.0'
 plugin_routing:
   modules:
     cv_facts:

--- a/ansible_collections/arista/cvp/requirements-dev.txt
+++ b/ansible_collections/arista/cvp/requirements-dev.txt
@@ -1,4 +1,4 @@
-ansible-core>=2.16.0,<2.19.0
+ansible-core>=2.15.0,<2.19.0
 ansible-builder
 ansible-lint>=24.7.0
 galaxy-importer>=0.3.1


### PR DESCRIPTION
## Change Summary

Restore support for ansible-core 2.15 because this version remains supported within Ansible Automation Platform 2.4.
