### PR TITLE
Doc: Update documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <img src='ansible_collections/arista/cvp/medias/ansible-cloudvision.png' alt='Arista CloudVision and Ansible'/>
 </p>
 
-More documentation is available in [project's website](https://cvp.avd.sh/)
+More documentation is available in [project's website](https://aristanetworks.github.io/ansible-cvp/)
 
 ## List of CVP versions supported
 
@@ -37,25 +37,25 @@ This repository provides content for Ansible's collection **arista.cvp** with fo
 
 **Version 3:**
 
-- [**arista.cvp.cv_configlet_v3**](https://cvp.avd.sh/en/latest/docs/modules/cv_configlet_v3.md) -  Manage configlet configured on CVP.
-- [**arista.cvp.cv_container_v3**](https://cvp.avd.sh/en/latest/docs/modules/cv_container_v3.md) -  Manage container topology and attach configlet and devices to containers.
-- [**arista.cvp.cv_device_v3**](https://cvp.avd.sh/en/latest/docs/modules/cv_device_v3.md) - Manage devices configured on CVP
-- [**arista.cvp.cv_task_v3**](https://cvp.avd.sh/en/latest/docs/modules/cv_task_v3.md) - Run tasks created on CVP.
-- [**arista.cvp.cv_facts_v3**](https://cvp.avd.sh/en/latest/docs/modules/cv_facts_v3.md) - Collect information from CloudVision.
-- [**arista.cvp.cv_image_v3**](https://cvp.avd.sh/en/latest/docs/modules/cv_image_v3.md) - Create EOS images and bundles on CloudVision.
+- [**arista.cvp.cv_configlet_v3**](https://aristanetworks.github.io/ansible-cvp/docs/modules/cv_configlet_v3/) -  Manage configlet configured on CVP.
+- [**arista.cvp.cv_container_v3**](https://aristanetworks.github.io/ansible-cvp/docs/modules/cv_container_v3/) -  Manage container topology and attach configlet and devices to containers.
+- [**arista.cvp.cv_device_v3**](https://aristanetworks.github.io/ansible-cvp/docs/modules/cv_device_v3/) - Manage devices configured on CVP
+- [**arista.cvp.cv_task_v3**](https://aristanetworks.github.io/ansible-cvp/docs/modules/cv_task_v3/) - Run tasks created on CVP.
+- [**arista.cvp.cv_facts_v3**](https://aristanetworks.github.io/ansible-cvp/docs/modules/cv_facts_v3/) - Collect information from CloudVision.
+- [**arista.cvp.cv_image_v3**](https://aristanetworks.github.io/ansible-cvp/docs/modules/cv_image_v3/) - Create EOS images and bundles on CloudVision.
 
 ### List of available roles
 
-- [**arista.cvp.dhcp_configuration**](https://cvp.avd.sh/en/latest/roles/dhcp_configuration/) - Configure DHCPD service on a CloudVision server or any dhcpd service.
-- [**arista.cvp.configlet_sync**](https://cvp.avd.sh/en/latest/roles/configlets_sync/) - Synchronize configlets between multiple CloudVision servers.
+- [**arista.cvp.dhcp_configuration**](https://aristanetworks.github.io/ansible-cvp/roles/dhcp_configuration/) - Configure DHCPD service on a CloudVision server or any dhcpd service.
+- [**arista.cvp.configlet_sync**](https://aristanetworks.github.io/ansible-cvp/roles/configlets_sync/) - Synchronize configlets between multiple CloudVision servers.
 
 ## Deprecated modules
 
-- [**arista.cvp.cv_facts**](https://cvp.avd.sh/en/latest/docs/modules/cv_facts.md) - Collect CVP facts from server like list of containers, devices, configlet and tasks.
-- [**arista.cvp.cv_configlet**](https://cvp.avd.sh/en/latest/docs/modules/cv_configlet.md) -  Manage configlet configured on CVP.
-- [**arista.cvp.cv_container**](https://cvp.avd.sh/en/latest/docs/modules/cv_container.md) -  Manage container topology and attach configlet and devices to containers.
-- [**arista.cvp.cv_device**](https://cvp.avd.sh/en/latest/docs/modules/cv_device.md) - Manage devices configured on CVP
-- [**arista.cvp.cv_task**](https://cvp.avd.sh/en/latest/docs/modules/cv_task.md) - Run tasks created on CVP.
+- [**arista.cvp.cv_facts**](https://aristanetworks.github.io/ansible-cvp/docs/modules/cv_facts/) - Collect CVP facts from server like list of containers, devices, configlet and tasks.
+- [**arista.cvp.cv_configlet**](https://aristanetworks.github.io/ansible-cvp/docs/modules/cv_configlet/) -  Manage configlet configured on CVP.
+- [**arista.cvp.cv_container**](https://aristanetworks.github.io/ansible-cvp/docs/modules/cv_container/) -  Manage container topology and attach configlet and devices to containers.
+- [**arista.cvp.cv_device**](https://aristanetworks.github.io/ansible-cvp/docs/modules/cv_device/) - Manage devices configured on CVP
+- [**arista.cvp.cv_task**](https://aristanetworks.github.io/ansible-cvp/docs/modules/cv_task/) - Run tasks created on CVP.
 
 ## Example
 
@@ -139,11 +139,11 @@ As modules of this collection are based on [`HTTPAPI` connection plugin](https:/
 
 ## Installation
 
-Complete installation process is available on [repository website](https://cvp.avd.sh/)
+Complete installation process is available on [repository website](https://aristanetworks.github.io/ansible-cvp/)
 
 ### Requirements
 
-To install requirements please follow [this](https://cvp.avd.sh/en/stable/docs/installation/requirements/) guide.
+To install requirements please follow [this](https://aristanetworks.github.io/ansible-cvp/en/stable/docs/installation/requirements/) guide.
 
 ### Installation from ansible-galaxy
 

--- a/ansible_collections/arista/cvp/README.md
+++ b/ansible_collections/arista/cvp/README.md
@@ -21,7 +21,7 @@ The CVP collection has the following requirements:
 - Install the arista.cvp collection
 - [Additional Python packages](#additional-python-dependencies)
 
-For a full breakdown of the requirements, please see the official `arista.cvp` [documentation](https://cvp.avd.sh/en/stable/docs/installation/requirements/).
+For a full breakdown of the requirements, please see the official `arista.cvp` [documentation](https://aristanetworks.github.io/ansible-cvp/docs/installation/requirements/).
 
 ## Installations
 

--- a/ansible_collections/arista/cvp/docs/release-notes/v1.x.md
+++ b/ansible_collections/arista/cvp/docs/release-notes/v1.x.md
@@ -22,7 +22,7 @@
 - Report better error message when device not reachable (#205)
 - Add role to support configlets synchronisation between cloudvision servers (#196)
 - Allow `dhcp_configuration` role to only generate `dhcpd.conf` file (#206)
-- Publish collection documentation on [github.io](https://cvp.avd.sh/)
+- Publish collection documentation on [github.io](https://aristanetworks.github.io/ansible-cvp/)
 
 ### Fixed issues
 

--- a/ansible_collections/arista/cvp/docs/release-notes/v2.x.md
+++ b/ansible_collections/arista/cvp/docs/release-notes/v2.x.md
@@ -7,11 +7,11 @@
 # Release Notes For Ansible CVP 2.x
 
 !!! info
-    Documentation for 2.1.x branch [available here](https://cvp.avd.sh/en/releases-v2.1.x/)
+    Documentation for 2.1.x branch [available here](https://github.com/aristanetworks/ansible-cvp/tree/releases/v2.1.x/ansible_collections/arista/cvp/docs)
 
 ## Release 2.1.2
 
-Documentation for 2.1.x branch [available here](https://cvp.avd.sh/en/releases-v2.1.x/)
+Documentation for 2.1.x branch [available here](https://github.com/aristanetworks/ansible-cvp/tree/releases/v2.1.x/ansible_collections/arista/cvp/docs)
 
 ### Supported CloudVision version
 
@@ -31,7 +31,7 @@ Documentation for 2.1.x branch [available here](https://cvp.avd.sh/en/releases-v
 
 ## Release 2.1.1
 
-Documentation for 2.1.x branch [available here](https://cvp.avd.sh/en/releases-v2.1.x/)
+Documentation for 2.1.x branch [available here](https://github.com/aristanetworks/ansible-cvp/tree/releases/v2.1.x/ansible_collections/arista/cvp/docs)
 
 ### Supported CloudVision version
 
@@ -67,7 +67,7 @@ Documentation for 2.1.x branch [available here](https://cvp.avd.sh/en/releases-v
 
 ## Release 2.1.0
 
-Documentation for 2.1.x branch [available here](https://cvp.avd.sh/en/releases-v2.1.x/)
+Documentation for 2.1.x branch [available here](https://github.com/aristanetworks/ansible-cvp/tree/releases/v2.1.x/ansible_collections/arista/cvp/docs)
 
 ### Supported CloudVision version
 
@@ -96,7 +96,7 @@ N/A
 
 ## Release 2.0.0
 
-Documentation for 2.0.x branch [available here](https://cvp.avd.sh/en/releases-v2.0.x/)
+Documentation for 2.0.x branch [available here](https://github.com/aristanetworks/ansible-cvp/tree/releases/v2.0.x/ansible_collections/arista/cvp/docs)
 
 ### Supported CloudVision version
 

--- a/ansible_collections/arista/cvp/docs/release-notes/v3.x.md
+++ b/ansible_collections/arista/cvp/docs/release-notes/v3.x.md
@@ -7,7 +7,7 @@
 # Release Notes For Ansible CVP 3.x
 
 !!! info
-    Documentation for 3.x.x branch [available here](https://cvp.avd.sh/en/latest/)
+    Documentation for 3.x.x branch [available here](https://aristanetworks.github.io/ansible-cvp/)
 
 ## Supported CloudVision version
 

--- a/ansible_collections/arista/cvp/galaxy.yml
+++ b/ansible_collections/arista/cvp/galaxy.yml
@@ -44,10 +44,10 @@ dependencies: {}
 repository: https://github.com/aristanetworks/ansible-cvp
 
 # The URL to any online docs
-documentation: https://cvp.avd.sh/
+documentation: https://aristanetworks.github.io/ansible-cvp/
 
 # The URL to the homepage of the collection/project
-homepage: https://cvp.avd.sh/
+homepage: https://aristanetworks.github.io/ansible-cvp/
 
 # The URL to the collection issue tracker
 issues: https://github.com/aristanetworks/ansible-cvp/issues


### PR DESCRIPTION
## Change Summary

Update documentation links to https://aristanetworks.github.io/ansible-cvp/

Note: We no longer maintain older versions of 2.x documentation, so I opted to just redirect to the GitHub branch.
